### PR TITLE
fix: Use the correct HTTP method for updating ledgers

### DIFF
--- a/entities/ledgers.go
+++ b/entities/ledgers.go
@@ -317,7 +317,7 @@ func (e *ledgersEntity) UpdateLedger(
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}


### PR DESCRIPTION
Problem: When updating ledgers, the SDK would make a PUT request to Midaz, when the expected method is a PATCH - hence, the request for updating the ledger failed with a 405 Method Not Allowed.

Solution: replace the PUT with a PATCH method.