### PR TITLE
fix: use the correct HTTP method to update entities that were using PUT

### DIFF
--- a/entities/accounts.go
+++ b/entities/accounts.go
@@ -382,7 +382,7 @@ func (e *accountsEntity) UpdateAccount(ctx context.Context, organizationID, ledg
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}

--- a/entities/assets.go
+++ b/entities/assets.go
@@ -349,7 +349,7 @@ func (e *assetsEntity) UpdateAsset(
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}

--- a/entities/operations.go
+++ b/entities/operations.go
@@ -408,7 +408,7 @@ func (e *operationsEntity) UpdateOperation(ctx context.Context, orgID, ledgerID,
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)

--- a/entities/portfolios.go
+++ b/entities/portfolios.go
@@ -288,7 +288,7 @@ func (e *portfoliosEntity) UpdatePortfolio(ctx context.Context, organizationID, 
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}

--- a/entities/segments.go
+++ b/entities/segments.go
@@ -292,7 +292,7 @@ func (e *segmentsEntity) UpdateSegment(
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
 
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)


### PR DESCRIPTION
These entities were using the wrong HTTP method for updating: accounts, assets, operations, portfolios and segments.

This change updates the method from PUT to PATCH, making them compatible with Midaz API.