### PR TITLE
feat: multi-tenancy support, dependency updates, and CI improvements

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -18,7 +18,7 @@ jobs:
   check-branch:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -38,7 +38,7 @@ jobs:
           lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
           go_version: "1.26.0" # Versão do Go, se necessário alterar
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_version: "v2.10.1" # Versão do GolangCI-Lint, se necessário mude para a versão desejada
+          golangci_lint_version: "v2.11.4" # Versão do GolangCI-Lint, se necessário mude para a versão desejada
 
   GoSec:
     name: Run GoSec to SDK
@@ -46,13 +46,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-go@v6.3.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.0"
           cache: false
 
       - name: Gosec Scanner
-        uses: securego/gosec@bb17e422fc34bf4c0a2e5cab9d07dc45a68c040c # v2.24.7
+        uses: securego/gosec@5e5517beec77b8228ba43ec8d7cc22d82ed31924 # v2.25.0
         with:
           args: ./...
 
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.0"
           cache: true
@@ -76,7 +76,7 @@ jobs:
         run: make coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: artifacts/coverage.html
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.0"
           cache: true
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.0"
           cache: true
@@ -115,7 +115,7 @@ jobs:
         run: make godoc-static
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: godoc
           path: docs/godoc/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           git clean -fd
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           version: latest
           args: release --clean
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Generate app installation token
         id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
           private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,7 @@ endif
 
 ci:
 	$(call print_header,"Running SDK CI pipeline")
-	@$(MAKE) tidy
-	@$(MAKE) fmt
-	@$(MAKE) lint
-	@$(MAKE) gosec
-	@$(MAKE) test
-	@$(MAKE) coverage
-	@$(MAKE) verify-sdk
+	@$(MAKE) tidy fmt lint gosec test coverage verify-sdk
 	@echo "$(GREEN)[ok]$(NC) SDK CI pipeline completed successfully$(GREEN) ✔️$(NC)"
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,26 @@ endif
 # Core Commands
 #-------------------------------------------------------
 
-.PHONY: help
+.PHONY: help ci
+
+ci:
+	$(call print_header,"Running SDK CI pipeline")
+	@$(MAKE) tidy
+	@$(MAKE) fmt
+	@$(MAKE) lint
+	@$(MAKE) gosec
+	@$(MAKE) test
+	@$(MAKE) coverage
+	@$(MAKE) verify-sdk
+	@echo "$(GREEN)[ok]$(NC) SDK CI pipeline completed successfully$(GREEN) ✔️$(NC)"
+
 help:
 	@echo ""
 	@echo "$(SERVICE_NAME) Commands"
 	@echo ""
 	@echo "Core Commands:"
 	@echo "  make help                        - Display this help message"
+	@echo "  make ci                          - Run the SDK CI pipeline locally"
 	@echo "  make set-env                     - Create .env file from .env.example if it doesn't exist"
 	@echo "  make test                        - Run all tests"
 	@echo "  make test-fast                   - Run tests with -short flag"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endef
 GO := go
 GOFMT := gofmt
 GOLINT := golangci-lint
-GOSEC_VERSION := v2.24.7
+GOSEC_VERSION := v2.25.0
 GOSEC := $(GO) run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
 GOMOD := $(GO) mod
 GOBUILD := $(GO) build

--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,8 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -139,10 +139,10 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
-google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 h1:zUWMZsvo/IJcD1t6MNCPO/azZTwz0TvwCBqr5aifoVY=
+google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529/go.mod h1:a5OGAgyRr4lqco7AG9hQM9Fwh0N2ZV4grR0eXFEsXQg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:XF8+t6QQiS0o9ArVan/HW8Q7cycNPGsJf6GA2nXxYAg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
## Summary

- **Multi-tenancy support**: Adds `X-Tenant-ID` header propagation via context, enabling tenant-scoped API requests across all SDK operations. Includes `WithTenantID` client option, `entities.WithTenantID(ctx, id)` for per-request overrides, and automatic header injection in both standard and raw HTTP request paths.
- **Midaz bump v3.5.3 → v3.6.3**: Fixes breaking `DoingBusinessAs` pointer-type change in `UpdateOrganizationInput`; also pulls 24 transitive upgrades (OTel 1.43, gRPC 1.80, grpc-gateway 2.29, etc.).
- **CI & tooling**: GitHub Actions bumps across `check-branch`, `go-combined-analysis`, and `release` workflows; `make ci` target added so the full CI suite can run locally; golangci tweak to exclude a gosec G705 false positive on stderr debug output.

## Scope

| Area | What changed |
|------|--------------|
| `client.go`, `entities/` | New `WithTenantID` option, tenant context key, `HeaderTenantID` constant, HTTP-layer tenant propagation (context override > client default) |
| `models/organization.go` | `DoingBusinessAs` updated to `*string` (Midaz v3.6.x breaking change) |
| `entities/http_tenant_test.go` | 454-line tenant test suite covering precedence, empty overrides, concurrent safety |
| `client_test.go`, `pkg/config/config_test.go` | Expanded coverage for `WithTenantID` wiring and env-var fallback |
| `go.mod` / `go.sum` | Midaz v3.5.3 → v3.6.3 + transitive upgrades |
| `.github/workflows/*` | Action version bumps |
| `Makefile` | `make ci` target |
| `.golangci.yml` | gosec G705 exclusion for intentional stderr debug output |

## Key Design Notes

- **Precedence**: per-request `entities.WithTenantID(ctx, id)` > client-level `WithTenantID(...)` option > `MIDAZ_TENANT_ID` env/config default.
- **Explicit-empty override**: client option uses an internal `tenantIDSet` flag so passing `""` cleanly clears a config/env default (instead of being ignored).
- **Concurrency**: `HTTPClient.SetTenantID` mirrors `http.Client` semantics — configure at setup, do not mutate mid-flight.

## How to Test

```bash
make fmt lint test verify-sdk
go test -race ./entities/...
```

Manual: set `MIDAZ_TENANT_ID=...` or pass `client.WithTenantID("...")` and verify `X-Tenant-ID` header appears on outbound requests (debug mode logs headers).

## Linked

- Supersedes/rolls up #188 (merged into develop, not yet in main).