### PR TITLE
feat(sdk): add CRM services and transaction enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,9 @@ MIDAZ_USER_AGENT=Midaz-Go-SDK/1.0.0  # User agent string for API requests
 # API URLs (defaults based on environment if not specified)
 # The SDK resolves MIDAZ_BASE_URL to the unified Ledger API base under /v1.
 MIDAZ_BASE_URL=http://localhost:3002
+MIDAZ_CRM_URL=http://localhost:4003/v1
 MIDAZ_ONBOARDING_URL=http://localhost:3002/v1
 MIDAZ_TRANSACTION_URL=http://localhost:3002/v1
-MIDAZ_CRM_URL=http://localhost:4003/v1
 
 # HTTP configuration
 MIDAZ_TIMEOUT=30                  # Timeout in seconds for API requests (default: 60)
@@ -49,4 +49,4 @@ MIDAZ_CLIENT_SECRET=
 
 # Example-specific configuration
 CONCURRENT_CUSTOMER_TO_MERCHANT_TXS=1000 # Number of customer-to-merchant (concurrent) transactions to run
-CONCURRENT_MERCHANT_TO_CUSTOMER_TXS=1000 # Number of merchant-to-customer (batch) transactions to run
+CONCURRENT_MERCHANT_TO_CUSTOMER_TXS="1000" # Number of merchant-to-customer (batch) transactions to run

--- a/.env.example
+++ b/.env.example
@@ -8,14 +8,14 @@ MIDAZ_AUTH_TOKEN=<set-your-token>
 MIDAZ_ENVIRONMENT=local
 
 # SDK configuration
-MIDAZ_USER_AGENT=Midaz-Go-SDK/1.0.0  # User agent string for API requests
+MIDAZ_USER_AGENT="Midaz-Go-SDK/1.0.0"  # User agent string for API requests
 
 # API URLs (defaults based on environment if not specified)
 # The SDK resolves MIDAZ_BASE_URL to the unified Ledger API base under /v1.
-MIDAZ_BASE_URL=http://localhost:3002
-MIDAZ_CRM_URL=http://localhost:4003/v1
-MIDAZ_ONBOARDING_URL=http://localhost:3002/v1
-MIDAZ_TRANSACTION_URL=http://localhost:3002/v1
+MIDAZ_BASE_URL="http://localhost:3002"
+MIDAZ_CRM_URL="http://localhost:4003/v1"
+MIDAZ_ONBOARDING_URL="http://localhost:3002/v1"
+MIDAZ_TRANSACTION_URL="http://localhost:3002/v1"
 
 # HTTP configuration
 MIDAZ_TIMEOUT=30                  # Timeout in seconds for API requests (default: 60)

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Midaz Go SDK Environment Variables
 
 # Authentication token for the Midaz API (required)
-MIDAZ_AUTH_TOKEN=midaz-auth-token-123456
+MIDAZ_AUTH_TOKEN=<set-your-token>
 
 # Environment configuration (local, development, production)
 # Defaults to "local" if not specified
@@ -11,9 +11,11 @@ MIDAZ_ENVIRONMENT=local
 MIDAZ_USER_AGENT=Midaz-Go-SDK/1.0.0  # User agent string for API requests
 
 # API URLs (defaults based on environment if not specified)
-MIDAZ_BASE_URL=http://localhost
-MIDAZ_ONBOARDING_URL=http://localhost:3000/v1
-MIDAZ_TRANSACTION_URL=http://localhost:3001/v1
+# The SDK resolves MIDAZ_BASE_URL to the unified Ledger API base under /v1.
+MIDAZ_BASE_URL=http://localhost:3002
+MIDAZ_ONBOARDING_URL=http://localhost:3002/v1
+MIDAZ_TRANSACTION_URL=http://localhost:3002/v1
+MIDAZ_CRM_URL=http://localhost:4003/v1
 
 # HTTP configuration
 MIDAZ_TIMEOUT=30                  # Timeout in seconds for API requests (default: 60)

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Midaz Go SDK Environment Variables
 
 # Authentication token for the Midaz API (required)
-MIDAZ_AUTH_TOKEN=<set-your-token>
+MIDAZ_AUTH_TOKEN="set-your-token"
 
 # Environment configuration (local, development, production)
 # Defaults to "local" if not specified

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -36,7 +36,7 @@ jobs:
           lerian_ci_cd_user_gpg_key_password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
           lerian_ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          go_version: "1.26.0" # Versão do Go, se necessário alterar
+          go_version: "1.26.2" # Versão do Go, se necessário alterar
           github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_version: "v2.11.4" # Versão do GolangCI-Lint, se necessário mude para a versão desejada
 
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.2"
           cache: false
 
       - name: Gosec Scanner
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.2"
           cache: true
 
       - name: Run tests
@@ -91,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.2"
           cache: true
 
       - name: Verify SDK
@@ -108,7 +108,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.0"
+          go-version: "1.26.2"
           cache: true
 
       - name: Generate static documentation

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -18,6 +18,9 @@ permissions:
   actions: read
   security-events: write
 
+env:
+  GO_VERSION: "1.26.2"
+
 jobs:
   GolangCI-Lint:
     name: Run GolangCI-Lint to SDK
@@ -36,7 +39,7 @@ jobs:
           lerian_ci_cd_user_gpg_key_password: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
           lerian_ci_cd_user_name: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
           lerian_ci_cd_user_email: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          go_version: "1.26.2" # Versão do Go, se necessário alterar
+          go_version: ${{ env.GO_VERSION }} # Versão do Go, se necessário alterar
           github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_version: "v2.11.4" # Versão do GolangCI-Lint, se necessário mude para a versão desejada
 
@@ -48,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: false
 
       - name: Gosec Scanner
@@ -66,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Run tests
@@ -91,7 +94,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Verify SDK
@@ -108,7 +111,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.2"
+          go-version: ${{ env.GO_VERSION }}
           cache: true
 
       - name: Generate static documentation

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -295,6 +295,8 @@ linters:
             - fmt.Printf
             - fmt.Println
             - fmt.Fprintf
+            - strings.Builder.WriteByte
+            - strings.Builder.WriteString
         - name: cognitive-complexity
           severity: warning
           arguments: [20]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,67 +1,74 @@
-# Repository Guidelines
+# Repository guidelines
 
-## Project Structure & Module Organization
+## Project structure and module organization
 
-- `entities/` — HTTP clients and service accessors.
-- `models/` — Public API types (request/response payloads).
-- `pkg/` — SDK utilities (config, validation, observability, retry, performance, generator, integrity).
-- `examples/` — Runnable examples. Start with `examples/mass-demo-generator`.
-- `docs/` — Generated docs and guides; `scripts/` — automation helpers.
-- Root files: `Makefile`, `go.mod`, `.env.example`, `PLAN.md`.
+- `client.go` - Root SDK entry point (`github.com/LerianStudio/midaz-sdk-golang/v2`, package name `client`).
+- `entities/` - Entity service interfaces, HTTP transport, request helpers, and service accessors.
+- `models/` - Public API types, request builders, response wrappers, pagination options, and Midaz model aliases.
+- `pkg/` - SDK utilities including access manager, concurrency, config, errors, formatting, observability, pagination, performance, retry, security, transaction helpers, validation, and versioning.
+- `examples/` - Runnable examples. Start with `examples/mass-demo-generator` for end-to-end demo data.
+- `docs/` - Generated Go docs and hand-written guides; `docs/mapping/` contains public and internal API maps.
+- `scripts/` - Automation helpers for docs and repository maintenance.
+- Root files: `Makefile`, `go.mod`, `.env.example`, `CONTRIBUTING.md`, `README.md`.
 
-## Build, Test, and Development Commands
+## Build, test, and development commands
 
-- `make set-env` — Create `.env` from `.env.example`.
-- `make test` / `make test-fast` — Run all/short tests.
-- `make coverage` — Produce HTML coverage report in `artifacts/`.
-- `make lint` / `make fmt` / `make tidy` — Lint, format, and tidy deps.
-- `make verify-sdk` — Quick API build/compat checks.
-- `go build ./...` — Build all packages.
-- `go test -v ./path/to/file_test.go` — Test single file.
-- `go test -v ./path/to/package -run TestName` — Run specific test.
-- `make docs` — Generate static documentation.
-- Example (interactive off):
-  - `make demo-data`
-  - or `cd examples/mass-demo-generator && DEMO_NON_INTERACTIVE=1 go run main.go --org-locale=br --patterns=false`
-- Docs server: `make godoc` (http://localhost:6060).
+- `make set-env` - Create `.env` from `.env.example`.
+- `make tidy` / `make fmt` / `make lint` - Tidy dependencies, format code, and run `golangci-lint`.
+- `make gosec` - Run security scanning.
+- `make test` / `make test-fast` - Run all tests or short tests.
+- `make coverage` - Produce an HTML coverage report in `artifacts/`.
+- `make verify-sdk` - Run quick API build and compatibility checks.
+- `make ci` - Preferred full local pipeline: tidy, fmt, lint, gosec, test, coverage, and SDK verification.
+- `go build ./...` - Build all packages.
+- `go test -v ./path/to/package -run TestName` - Run a targeted test.
+- `make docs` - Generate static documentation.
+- `make godoc` - Start an interactive docs server at http://localhost:6060.
+- `make demo-data` - Run the mass demo generator in non-interactive mode.
+- `cd examples/mass-demo-generator && DEMO_NON_INTERACTIVE=1 go run . --org-locale=br` - Run the generator directly.
 
-## Coding Style & Naming Conventions
+## Coding style and naming conventions
 
-- Go 1.24.x. Run `make fmt` before committing.
+- Go 1.26.x. Run `make fmt` before committing.
 - Follow standard Go style and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
-- Package names: lowercase, single-word.
+- Package names: lowercase, single-word when possible.
 - Exported names: CamelCase with first letter capitalized.
 - Unexported names: camelCase with first letter lowercase.
 - Import order: standard library, external packages, internal packages.
-- Keep functions small, context-aware (`context.Context` first param), and return rich errors.
-- Use functional options pattern for configuration.
-- Use interfaces for external dependencies (especially lib-commons).
+- Keep functions small, context-aware (`context.Context` first parameter), and return rich errors.
+- Use functional options for configuration and fluent builders for model input helpers.
+- Use interfaces for external dependencies and service boundaries.
 - Document all exported functions, types, and variables.
-- Lint with `golangci-lint` (`make lint`). No panics in library code.
+- No panics in library code. Return errors instead.
 
-## Testing Guidelines
+## Testing guidelines
 
-- Use Go's `testing` with `testify` for assertions and `gomock` where mocking helps.
-- Name tests `*_test.go`; functions `TestXxx` and table-driven where appropriate.
-- Write unit tests for all new code (minimum 80% coverage).
-- Run `make test` locally; target >80% coverage for new critical logic; generate report with `make coverage`.
+- Use Go's `testing` package with `testify` for assertions and `gomock` where mocking helps.
+- Name test files `*_test.go` and test functions `TestXxx`.
+- Prefer table-driven tests for validation, mapping, transport, and retry behavior.
+- Write unit tests for all new code; target at least 80% coverage for new critical logic.
+- Run `make ci` before opening a PR, or run targeted checks plus `make test` when iterating quickly.
 
-## Commit & Pull Request Guidelines
+## Commit and pull request guidelines
 
-- Conventional Commits: `<type>(<scope>): <description>`
-  - Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
-  - Examples: `feat(accounts): add balance caching`, `fix(retry): handle timeout errors`
-- PRs must include: purpose, scope, key changes, how-to-test, and linked issues.
-- Run `make fmt lint test verify-sdk` before opening a PR. Include example commands for demos when applicable.
+- Use Conventional Commits: `<type>(<scope>): <description>`.
+- Supported types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`.
+- Examples: `feat(accounts): add balance caching`, `fix(retry): handle timeout errors`.
+- PRs must include purpose, scope, key changes, how to test, and linked issues.
+- Prefer `make ci` before opening a PR. Include example commands for demo or generator changes.
 
-## Security & Configuration Tips
+## Security and configuration tips
 
-- Never commit secrets. Configure via `.env` (copy from `.env.example`).
-- Typical vars: auth token and service URLs for onboarding/transaction APIs.
-- Ensure idempotent requests by setting `X-Idempotency` header via context when needed.
+- Never commit secrets. Configure local runs via `.env` copied from `.env.example`.
+- Service URL variables: `MIDAZ_BASE_URL`, `MIDAZ_ONBOARDING_URL`, `MIDAZ_TRANSACTION_URL`, `MIDAZ_CRM_URL`.
+- Access Manager variables: `PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_ADDRESS`, `MIDAZ_CLIENT_ID`, `MIDAZ_CLIENT_SECRET`.
+- Other common variables: `MIDAZ_ENVIRONMENT`, `MIDAZ_USER_AGENT`, `MIDAZ_TIMEOUT`, `MIDAZ_DEBUG`, `MIDAZ_MAX_RETRIES`, `MIDAZ_IDEMPOTENCY`.
+- Environment loading is explicit: use `config.NewConfig(config.FromEnvironment())`.
+- Ensure idempotent unsafe requests by setting `X-Idempotency` via `entities.WithIdempotencyKey(ctx, key)` when needed.
 
-## Agent-Specific Instructions
+## Agent-specific instructions
 
-- Keep changes minimal and scoped; update `PLAN.md` when you finish milestones or add flags/patterns.
-- Touch only relevant packages; follow existing folder conventions.
-- After generator or example changes, verify with `make demo-data` and document new flags in `docs/`.
+- Keep changes minimal and scoped.
+- Touch only relevant packages and docs; follow existing folder conventions.
+- After generator or example changes, verify with `make demo-data` or a targeted `go run` command and update `docs/examples.md`.
+- After public API changes, update `README.md`, `docs/README.md`, and `docs/mapping/`.

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ GO := go
 GOFMT := gofmt
 GOLINT := golangci-lint
 GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT_VERSION_NUMBER := $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))
 GOSEC_VERSION := v2.25.0
 GOSEC := $(GO) run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
 GOMOD := $(GO) mod
@@ -180,7 +181,7 @@ coverage:
 lint:
 	$(call print_header,"Running linters")
 	@if find . -name "*.go" -type f | grep -q .; then \
-		if ! command -v $(GOLINT) > /dev/null; then \
+		if ! command -v $(GOLINT) > /dev/null || ! $(GOLINT) --version | grep -q "version $(GOLANGCI_LINT_VERSION_NUMBER)"; then \
 			echo "$(YELLOW)Installing golangci-lint $(GOLANGCI_LINT_VERSION)...$(NC)"; \
 			go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ endef
 GO := go
 GOFMT := gofmt
 GOLINT := golangci-lint
+GOLANGCI_LINT_VERSION := v2.11.4
 GOSEC_VERSION := v2.25.0
 GOSEC := $(GO) run github.com/securego/gosec/v2/cmd/gosec@$(GOSEC_VERSION)
 GOMOD := $(GO) mod
@@ -180,8 +181,8 @@ lint:
 	$(call print_header,"Running linters")
 	@if find . -name "*.go" -type f | grep -q .; then \
 		if ! command -v $(GOLINT) > /dev/null; then \
-			echo "$(YELLOW)Installing golangci-lint...$(NC)"; \
-			go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+			echo "$(YELLOW)Installing golangci-lint $(GOLANGCI_LINT_VERSION)...$(NC)"; \
+			go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 		fi; \
 		$(GOLINT) run; \
 		echo "$(GREEN)[ok]$(NC) Linting completed successfully$(GREEN) ✔️$(NC)"; \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![Latest Release](https://img.shields.io/github/v/release/LerianStudio/midaz-sdk-golang?include_prereleases)](https://github.com/LerianStudio/midaz-sdk-golang/v2/releases)
+[![Latest Release](https://img.shields.io/github/v/release/LerianStudio/midaz-sdk-golang?include_prereleases)](https://github.com/LerianStudio/midaz-sdk-golang/releases)
 [![Go Report](https://goreportcard.com/badge/github.com/lerianstudio/midaz-sdk-golang)](https://goreportcard.com/report/github.com/lerianstudio/midaz-sdk-golang)
 [![Discord](https://img.shields.io/badge/Discord-Lerian%20Studio-%237289da.svg?logo=discord)](https://discord.gg/DnhqKwkGv3)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/LerianStudio/midaz-sdk-golang)](https://golang.org/)
@@ -12,24 +12,19 @@
 
 # Midaz Go SDK
 
-A comprehensive Go client for the Midaz financial ledger API. This SDK provides a powerful and flexible way to interact with the Midaz platform, enabling developers to build robust financial applications with ease.
+The Midaz Go SDK is an idiomatic Go client for the Midaz financial ledger APIs. It exposes entity services for Ledger resources, CRM holders and aliases, structured errors, explicit configuration, retries, pagination helpers, concurrency utilities, and OpenTelemetry observability.
 
 ## Features
 
-- **Comprehensive API Coverage**: Complete support for all Midaz API endpoints, including organizations, ledgers, accounts, transactions, portfolios, segments, and assets.
-- **Functional Options Pattern**: Flexible configuration with type-safe, chainable options.
-- **Plugin-based Authentication**: Secure authentication through the Access Manager for seamless integration with identity providers.
-- **Robust Error Handling**: Detailed error information with field-level validation errors and helpful suggestions.
-- **Concurrency Support**: Built-in utilities for parallel processing, batching, and rate limiting.
-- **Observability**: Integrated tracing, metrics, and logging capabilities.
-- **Pagination**: Generic pagination utilities that support both offset and cursor-based pagination.
-- **Retry Mechanism**: Configurable retry mechanism with exponential backoff for resilient API interactions.
-- **Environment Support**: Seamless swclient.**WithAccessManager**(**"**your-auth-token**"**),itching between local, development, and production environments.
-- **Idiomatic Go Design**: Follows Go best practices for a natural fit in your Go applications.
-
-## Documentation
-
-For comprehensive documentation including API references, usage guides, and examples, see the [SDK Documentation](docs/README.md).
+- **Current Midaz API coverage**: Ledger resources plus CRM holders and aliases.
+- **Entity service API**: Access services through `c.Entity.<Service>` with explicit methods such as `CreateOrganization`, `ListAccounts`, and `CreateTransactionWithDSL`.
+- **Functional options**: Configure clients with `client.WithConfig`, `client.WithBaseURL`, `client.WithRetries`, `client.WithObservabilityProvider`, and related options.
+- **Access Manager authentication**: Configure plugin authentication with `auth.AccessManager` and `config.WithAccessManager` or environment variables.
+- **Structured errors**: Use `pkg/errors` categories, codes, helper checkers, status accessors, and request/resource context.
+- **Retries and idempotency**: Built-in retry behavior for transient failures, with idempotency-aware retries for unsafe requests.
+- **Pagination**: `models.ListOptions`, `models.ListResponse[T]`, and pagination metadata helpers.
+- **Observability**: OpenTelemetry tracing propagation, metrics, logging, and middleware helpers.
+- **Concurrency utilities**: Worker pools, batching, and rate limiting in `pkg/concurrent`.
 
 ## Installation
 
@@ -37,580 +32,329 @@ For comprehensive documentation including API references, usage guides, and exam
 go get github.com/LerianStudio/midaz-sdk-golang/v2
 ```
 
-## Quick Start
+## Quick start
 
 ```go
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
+    "context"
+    "fmt"
+    "log"
 
-	client "github.com/LerianStudio/midaz-sdk-golang/v2"
-	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
-	auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
-	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
-)
-
-func main() {
-	// Configure plugin access manager
-	AccessManager := auth.AccessManager{
-		Enabled:      true,
-		Address:      "https://your-auth-service.com",
-		ClientID:     "your-client-id",
-		ClientSecret: "your-client-secret",
-	}
-
-	// Create a configuration with plugin access manager
-	cfg, err := config.NewConfig(
-		config.WithAccessManager(AccessManager),
-	)
-	if err != nil {
-		log.Fatalf("Failed to create config: %v", err)
-	}
-
-	// Create a client
-	c, err := client.New(
-		client.WithConfig(cfg),
-		client.WithEnvironment(config.EnvironmentProduction),
-		client.UseAllAPIs(),
-	)
-	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
-	}
-
-	// Create an organization
-	ctx := context.Background()
-	org, err := c.Entity.Organizations.CreateOrganization(
-		ctx,
-		&models.CreateOrganizationInput{
-			LegalName:       "Example Corporation",
-			LegalDocument:   "123456789",
-			DoingBusinessAs: "Example Inc.",
-			Address: models.Address{
-				Line1:   "123 Main St",
-				City:    "New York",
-				State:   "NY",
-				ZipCode: "10001",
-				Country: "US",
-			},
-		},
-	)
-	if err != nil {
-		log.Fatalf("Failed to create organization: %v", err)
-	}
-
-	fmt.Printf("Organization created: %s\n", org.ID)
-}
-```
-
-## Client Configuration
-
-The SDK uses the functional options pattern for flexible configuration:
-
-```go
-// Basic configuration with plugin auth
-pluginAuth := auth.PluginAuth{
-	Enabled:      true,
-	Address:      "https://your-auth-service.com",
-	ClientID:     "your-client-id",
-	ClientSecret: "your-client-secret",
-}
-
-cfg, err := config.NewConfig(
-	config.WithPluginAuth(pluginAuth),
-)
-if err != nil {
-	log.Fatalf("Failed to create config: %v", err)
-}
-
-client, err := client.New(
-	client.WithConfig(cfg),
-	client.UseAllAPIs(),
-)
-
-// Environment-specific configuration
-pluginAuth := auth.PluginAuth{
-	Enabled:      true,
-	Address:      "https://your-auth-service.com",
-	ClientID:     "your-client-id",
-	ClientSecret: "your-client-secret",
-}
-
-cfg, err := config.NewConfig(
-	config.WithPluginAuth(pluginAuth),
-)
-if err != nil {
-	log.Fatalf("Failed to create config: %v", err)
-}
-
-client, err := client.New(
-	client.WithConfig(cfg),
-	client.WithEnvironment(config.EnvironmentProduction),
-	client.UseAllAPIs(),
-)
-
-// Advanced configuration
-pluginAuth := auth.PluginAuth{
-	Enabled:      true,
-	Address:      "https://your-auth-service.com",
-	ClientID:     "your-client-id",
-	ClientSecret: "your-client-secret",
-}
-
-cfg, err := config.NewConfig(
-	config.WithPluginAuth(pluginAuth),
-)
-if err != nil {
-	log.Fatalf("Failed to create config: %v", err)
-}
-
-client, err := client.New(
-	client.WithConfig(cfg),
-	client.WithTimeout(30 * time.Second),
-	client.WithRetries(3, 100*time.Millisecond, 1*time.Second),
-	client.WithObservability(true, true, true), // Enable tracing, metrics, and logging
-	client.UseAllAPIs(),
-)
-
-// Plugin-based authentication configuration
-AccessManager := auth.AccessManager{
-	Enabled:      true,
-	Address:      "https://your-auth-service.com",
-	ClientID:     "your-client-id",
-	ClientSecret: "your-client-secret",
-}
-
-cfg, err := config.NewConfig(
-	config.WithPluginAuth(pluginAuth),
-)
-if err != nil {
-	log.Fatalf("Failed to create config: %v", err)
-}
-
-client, err := client.New(
-	client.WithConfig(cfg),
-	client.UseAllAPIs(),
-)
-```
-
-## SDK Architecture
-
-The Midaz Go SDK is organized into three main components:
-
-- **Client**: The top-level entry point that provides access to all API services.
-- **Entities**: Service interfaces for interacting with Midaz resources.
-- **Models**: Data structures representing Midaz resources.
-- **Utility Packages**: Helper packages for configuration, concurrency, observability, access management, etc.
-
-### Models
-
-The `models` package defines the data structures used by the SDK:
-
-- **Account**: Represents an account for tracking assets and balances.
-- **Asset**: Represents a type of value that can be tracked and transferred.
-- **Balance**: Represents the current state of an account's holdings.
-- **Ledger**: Represents a collection of accounts and transactions.
-- **Organization**: Represents a business entity that owns ledgers and accounts.
-- **Portfolio**: Represents a collection of accounts for grouping and management.
-- **Segment**: Represents a categorization unit for more granular organization.
-- **Transaction**: Represents a financial event with operations (debits and credits).
-- **Operation**: Represents an individual accounting entry within a transaction.
-
-## Working with Entities
-
-The SDK provides high-level access to all Midaz entities through the `entities` package. This package implements service interfaces for interacting with Midaz resources and operations, providing a clean, entity-based API:
-
-- **Entity**: A centralized access point to all entity types, acting as a factory for the service interfaces.
-- **AccountsService**: Methods for managing accounts and their balances.
-- **AssetsService**: Methods for managing asset definitions.
-- **BalancesService**: Methods for retrieving and managing account balances.
-- **LedgersService**: Methods for creating and managing ledgers within organizations.
-- **OperationsService**: Methods for working with transaction operations.
-- **OrganizationsService**: Methods for creating and managing organizations.
-- **PortfoliosService**: Methods for managing portfolios for account grouping.
-- **SegmentsService**: Methods for managing segments for account categorization.
-- **TransactionsService**: Methods for creating and managing financial transactions.
-
-### Organizations
-
-```go
-// Create an organization
-org, err := client.Entity.Organizations.CreateOrganization(ctx, &models.CreateOrganizationInput{
-	LegalName:       "Example Organization",
-	LegalDocument:   "123456789",
-	DoingBusinessAs: "Example",
-})
-
-// Get an organization
-org, err := client.Entity.Organizations.GetOrganization(ctx, "org-id")
-
-// List organizations
-orgs, err := client.Entity.Organizations.ListOrganizations(ctx, nil)
-```
-
-### Ledgers
-
-```go
-// Create a ledger
-ledger, err := client.Entity.Ledgers.CreateLedger(ctx, "org-id", &models.CreateLedgerInput{
-	Name: "Main Ledger",
-	Metadata: map[string]any{
-		"description": "Primary ledger for tracking all accounts",
-	},
-})
-
-// List ledgers
-ledgers, err := client.Entity.Ledgers.ListLedgers(ctx, "org-id", nil)
-```
-
-### Accounts
-
-```go
-// Create an account
-account, err := client.Entity.Accounts.CreateAccount(ctx, "org-id", "ledger-id", &models.CreateAccountInput{
-	Name:      "Customer Account",
-	AssetCode: "USD",
-	Type:      "customer",
-})
-
-// Get account balance
-balance, err := client.Entity.Accounts.GetBalance(ctx, "org-id", "ledger-id", "account-id")
-```
-
-## Access Manager
-
-The Access Manager provides a plugin-based authentication mechanism that allows you to integrate with external identity providers. This feature eliminates the need to hardcode authentication tokens in your application, enhancing security and flexibility.
-
-### Configuration
-
-To use the Access Manager, you need to configure it with the address of your authentication service and your client credentials:
-
-```go
-// Import the access manager package
-import (
-    auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
+    client "github.com/LerianStudio/midaz-sdk-golang/v2"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/models"
     "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
 )
 
-// Configure plugin auth
-AccessManager := auth.AccessManager{
+func main() {
+    cfg, err := config.NewConfig(config.FromEnvironment())
+    if err != nil {
+        log.Fatalf("failed to create config: %v", err)
+    }
+
+    c, err := client.New(
+        client.WithConfig(cfg),
+        client.UseAllAPIs(),
+    )
+    if err != nil {
+        log.Fatalf("failed to create client: %v", err)
+    }
+    defer c.Shutdown(context.Background())
+
+    ctx := context.Background()
+    orgInput := models.NewCreateOrganizationInput("Example Corporation", "123456789").
+        WithDoingBusinessAs("Example Inc.").
+        WithAddress(models.Address{
+            Line1:   "123 Main St",
+            City:    "New York",
+            State:   "NY",
+            ZipCode: "10001",
+            Country: "US",
+        })
+
+    org, err := c.Entity.Organizations.CreateOrganization(ctx, orgInput)
+    if err != nil {
+        log.Fatalf("failed to create organization: %v", err)
+    }
+
+    fmt.Printf("organization created: %s\n", org.ID)
+}
+```
+
+`config.FromEnvironment()` is explicit. Environment variables are not loaded unless you pass that option to `config.NewConfig`.
+
+## Client configuration
+
+### Environment-based configuration
+
+```go
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
+
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.UseAllAPIs(),
+)
+```
+
+### Access Manager configuration
+
+```go
+import auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
+
+accessManager := auth.AccessManager{
     Enabled:      true,
     Address:      "https://your-auth-service.com",
     ClientID:     "your-client-id",
     ClientSecret: "your-client-secret",
 }
 
-// Create a configuration with plugin auth
 cfg, err := config.NewConfig(
-    config.WithAccessManager(AccessManager),
+    config.WithAccessManager(accessManager),
 )
 if err != nil {
-    log.Fatalf("Failed to create config: %v", err)
+    return err
 }
 
-// Create a client with the configuration
-client, err := client.New(
+c, err := client.New(
     client.WithConfig(cfg),
     client.UseAllAPIs(),
 )
 ```
 
-### Environment Variables
+Equivalent environment variables:
 
-You can also configure the Access Manager using environment variables:
-
-```
+```bash
 PLUGIN_AUTH_ENABLED=true
 PLUGIN_AUTH_ADDRESS=https://your-auth-service.com
 MIDAZ_CLIENT_ID=your-client-id
 MIDAZ_CLIENT_SECRET=your-client-secret
 ```
 
-Then load them in your application:
+### Direct URL configuration
 
 ```go
-AccessManagerEnabled := os.Getenv("PLUGIN_AUTH_ENABLED") == "true"
-AccessManagerAddress := os.Getenv("PLUGIN_AUTH_ADDRESS")
-clientID := os.Getenv("MIDAZ_CLIENT_ID")
-clientSecret := os.Getenv("MIDAZ_CLIENT_SECRET")
+c, err := client.New(
+    client.WithBaseURL("http://localhost:3000"),
+    client.WithTimeout(30*time.Second),
+    client.WithRetries(3, 100*time.Millisecond, 10*time.Second),
+    client.UseAllAPIs(),
+)
+```
 
-AccessManager := auth.AccessManager{
-    Enabled:      AccessManagerEnabled,
-    Address:      AccessManagerAddress,
-    ClientID:     clientID,
-    ClientSecret: clientSecret,
+## Entity services
+
+Enable entity services with `client.UseAllAPIs()` or `client.UseEntityAPI()`. The current service surface is:
+
+- `Accounts`
+- `AccountTypes`
+- `Assets`
+- `AssetRates`
+- `Balances`
+- `Holders`
+- `Aliases`
+- `Ledgers`
+- `MetadataIndexes`
+- `Operations`
+- `OperationRoutes`
+- `Organizations`
+- `Portfolios`
+- `Segments`
+- `Transactions`
+- `TransactionRoutes`
+
+Example calls:
+
+```go
+orgs, err := c.Entity.Organizations.ListOrganizations(ctx, models.NewListOptions().WithLimit(20))
+ledger, err := c.Entity.Ledgers.CreateLedger(ctx, orgID, models.NewCreateLedgerInput("Main Ledger"))
+account, err := c.Entity.Accounts.GetAccount(ctx, orgID, ledgerID, accountID)
+balance, err := c.Entity.Accounts.GetBalance(ctx, orgID, ledgerID, accountID)
+holders, err := c.Entity.Holders.ListHolders(ctx, orgID, models.NewListOptions().WithLimit(20))
+```
+
+## Transactions
+
+The current transaction contract uses a send-based payload:
+
+```go
+txInput := models.NewCreateTransactionInput("USD", "100.00").
+    WithDescription("Payment from customer to merchant").
+    WithSend(&models.SendInput{
+        Asset: "USD",
+        Value: "100.00",
+        Source: &models.SourceInput{
+            From: []models.FromToInput{
+                {Account: customerAlias, Amount: models.AmountInput{Asset: "USD", Value: "100.00"}},
+            },
+        },
+        Distribute: &models.DistributeInput{
+            To: []models.FromToInput{
+                {Account: merchantAlias, Amount: models.AmountInput{Asset: "USD", Value: "100.00"}},
+            },
+        },
+    })
+
+tx, err := c.Entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, txInput)
+```
+
+DSL-style structured transactions are available with `CreateTransactionWithDSL`, and raw DSL file content can be sent with `CreateTransactionWithDSLFile`.
+
+## Pagination
+
+```go
+options := models.NewListOptions().
+    WithLimit(50).
+    WithFilter("status", "ACTIVE")
+
+for {
+    page, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
+    if err != nil {
+        return err
+    }
+
+    for _, account := range page.Items {
+        process(account)
+    }
+
+    if !page.Pagination.HasNextPage() {
+        break
+    }
+
+    options = page.Pagination.NextPageOptions()
 }
 ```
 
-### How It Works
+See [pagination](docs/pagination.md) for page, cursor, and sorting details.
 
-When plugin-based authentication is enabled, the SDK will:
-
-1. Make a request to your authentication service using the provided client credentials
-2. Retrieve an authentication token
-3. Use this token for all subsequent API calls to the Midaz platform
-4. Handle token refresh automatically when needed
-
-This approach provides several benefits:
-
-- **Security**: No hardcoded tokens in your application code
-- **Flexibility**: Easily switch between different authentication providers
-- **Centralized Management**: Manage all your authentication settings in one place
-- **Automatic Token Refresh**: Tokens are automatically refreshed when they expire
-
-### Transactions
+## Error handling
 
 ```go
-// Create a transaction using DSL
-tx, err := client.Entity.Transactions.CreateTransactionWithDSL(ctx, "org-id", "ledger-id", &models.TransactionDSLInput{
-	Description: "Payment from customer to merchant",
-	Send: &models.DSLSend{
-		Asset: "USD",
-		Value: 10000, // $100.00
-		Scale: 2,
-		Source: &models.DSLSource{
-			From: []models.DSLFromTo{
-				{
-					Account: "customer-account-id",
-					Amount: &models.DSLAmount{
-						Asset: "USD",
-						Value: 10000,
-						Scale: 2,
-					},
-				},
-			},
-		},
-		Distribute: &models.DSLDistribute{
-			To: []models.DSLFromTo{
-				{
-					Account: "merchant-account-id",
-					Amount: &models.DSLAmount{
-						Asset: "USD",
-						Value: 10000,
-						Scale: 2,
-					},
-				},
-			},
-		},
-	},
-})
-```
-
-## Utility Packages
-
-The SDK includes several utility packages in the `pkg` directory that provide powerful functionality for working with the Midaz API:
-
-- **config**: Configuration management for the SDK, including environment-based configuration and service URL mapping.
-- **concurrent**: Utilities for concurrent operations, including worker pools, batching, and rate limiting.
-- **observability**: Tracing, metrics, and logging capabilities for monitoring and debugging SDK operations.
-- **pagination**: Generic pagination utilities for working with paginated API responses.
-- **validation**: Validation utilities for ensuring data integrity and providing helpful error messages.
-- **errors**: Structured error handling with field-level validation errors and error classification.
-- **format**: Formatting utilities for dates, times, and other data types.
-- **retry**: Configurable retry mechanism with exponential backoff for resilient API interactions.
-- **performance**: Performance optimization utilities for batch operations and other high-performance scenarios.
-
-## Advanced Features
-
-### Pagination
-
-The SDK provides powerful pagination utilities:
-
-```go
-// Create a paginator for accounts
-paginator := client.Entity.Accounts.GetAccountPaginator(ctx, "org-id", "ledger-id", &models.ListOptions{
-	Limit: 10,
-})
-
-// Iterate through all pages
-for paginator.HasNext() {
-	accounts, err := paginator.Next()
-	if err != nil {
-		// Handle error
-	}
-
-	for _, account := range accounts.Items {
-		// Process each account
-	}
+account, err := c.Entity.Accounts.GetAccount(ctx, orgID, ledgerID, accountID)
+if err != nil {
+    switch {
+    case sdkerrors.IsNotFoundError(err):
+        return fmt.Errorf("account not found: %w", err)
+    case sdkerrors.IsAuthenticationError(err):
+        return fmt.Errorf("authentication failed: %w", err)
+    case sdkerrors.IsRateLimitError(err):
+        return fmt.Errorf("rate limited: %w", err)
+    default:
+        return fmt.Errorf("failed to get account: %w", err)
+    }
 }
 ```
 
-### Concurrency Utilities
-
-Process items in parallel with concurrency utilities:
+Import the error package as:
 
 ```go
-// Process accounts in parallel
-results := concurrent.WorkerPool(
-	ctx,
-	accountIDs,
-	func(ctx context.Context, accountID string) (*models.Account, error) {
-		// Fetch account details
-		return client.Entity.Accounts.GetAccount(ctx, "org-id", "ledger-id", accountID)
-	},
-	concurrent.WithWorkers(5), // Use 5 workers
-)
+import sdkerrors "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+```
 
-// Process items in batches
-batchResults := concurrent.Batch(
-	ctx,
-	transactionIDs,
-	10, // Process 10 items per batch
-	func(ctx context.Context, batch []string) ([]string, error) {
-		// Process the batch and return results
-		return processedIDs, nil
-	},
-	concurrent.WithWorkers(3), // Process 3 batches concurrently
+See [error handling](docs/errors.md) for categories, status accessors, retry boundaries, and validation details.
+
+## Observability
+
+```go
+provider, err := observability.New(context.Background(),
+    observability.WithServiceName("my-service"),
+    observability.WithComponentEnabled(true, true, true),
+    observability.WithCollectorEndpoint("localhost:4317"),
+)
+if err != nil {
+    return err
+}
+defer provider.Shutdown(context.Background())
+
+c, err := client.New(
+    client.WithObservabilityProvider(provider),
+    client.UseAllAPIs(),
 )
 ```
 
-### Observability
+See [tracing](docs/tracing.md) for OpenTelemetry propagation and server-side extraction examples.
 
-Enable detailed observability for monitoring and debugging:
+## Environment variables
 
-```go
-// Create a client with observability enabled
-client, err := client.New(
-	client.WithObservability(true, true, true), // Enable tracing, metrics, and logging
-	client.UseAllAPIs(),
-)
+The SDK reads these variables when `config.FromEnvironment()` is used:
 
-// Trace an operation
-err = client.Trace("create-organization", func(ctx context.Context) error {
-	_, err := client.Entity.Organizations.CreateOrganization(ctx, input)
-	return err
-})
-```
-
-## Environment Variables
-
-The SDK can be configured using environment variables:
-
-- `MIDAZ_AUTH_TOKEN`: Authentication token
-- `MIDAZ_ENVIRONMENT`: Environment (local, development, production)
-- `MIDAZ_ONBOARDING_URL`: Override for the onboarding service URL
-- `MIDAZ_TRANSACTION_URL`: Override for the transaction service URL
-- `MIDAZ_DEBUG`: Enable debug mode (true/false)
-- `MIDAZ_MAX_RETRIES`: Maximum number of retry attempts
+- `MIDAZ_ENVIRONMENT`
+- `MIDAZ_BASE_URL`
+- `MIDAZ_ONBOARDING_URL`
+- `MIDAZ_TRANSACTION_URL`
+- `MIDAZ_CRM_URL`
+- `MIDAZ_USER_AGENT`
+- `MIDAZ_TIMEOUT`
+- `MIDAZ_DEBUG`
+- `MIDAZ_MAX_RETRIES`
+- `MIDAZ_IDEMPOTENCY`
+- `PLUGIN_AUTH_ENABLED`
+- `PLUGIN_AUTH_ADDRESS`
+- `MIDAZ_CLIENT_ID`
+- `MIDAZ_CLIENT_SECRET`
 
 ## Documentation
 
-Detailed documentation is available:
+- [SDK documentation](docs/README.md)
+- [Examples](docs/examples.md)
+- [External API mapping](docs/mapping/external_apis.md)
+- [Internal API mapping](docs/mapping/internal_apis.md)
+- [Generated Go package documentation](docs/godoc/index.txt)
 
-- [API Reference](docs/README.md): Complete API documentation
-- [Examples](docs/examples.md): Usage examples for common operations
-- [Package Overview](docs/godoc/index.txt): Go package documentation
-
-To generate documentation:
+Generate docs with:
 
 ```bash
-# Start an interactive documentation server
-make godoc
-
-# Generate static documentation
 make docs
+```
+
+Start an interactive docs server with:
+
+```bash
+make godoc
 ```
 
 ## Examples
 
-For more detailed examples, see the [examples directory](examples/):
+- [Configuration examples](examples/configuration-examples/main.go)
+- [Context example](examples/context-example/main.go)
+- [Concurrency example](examples/concurrency-example/main.go)
+- [Retry example](examples/retry-example/main.go)
+- [Observability demo](examples/observability-demo/observability-demo.go)
+- [Tracing example](examples/tracing-example/main.go)
+- [Tracing server example](examples/tracing-server-example/main.go)
+- [Complete workflow](examples/workflow-with-entities/main.go)
+- [Mass demo generator](examples/mass-demo-generator)
 
-- [Configuration Examples](examples/configuration-examples/main.go): Various ways to configure the client
-- [Context Example](examples/context-example/main.go): Using context for timeouts and cancellation
-- [Concurrency Example](examples/concurrency-example/main.go): Parallel processing and batching
-- [Retry Example](examples/retry-example/main.go): Custom retry configurations
-- [Observability Example](examples/observability-example/main.go): Tracing, metrics, and logging
-- [Complete Workflow](examples/workflow-with-entities/main.go): End-to-end workflow example
+Run the mass demo generator:
+
+```bash
+cd examples/mass-demo-generator
+DEMO_NON_INTERACTIVE=1 go run . --org-locale=br
+```
 
 ## Testing
 
-Run the test suite:
-
 ```bash
 make test
+make coverage
+make verify-sdk
 ```
 
-Generate test coverage report:
+For the full local pipeline, run:
 
 ```bash
-make coverage
-```
-
-## Best Practices
-
-### Error Handling
-
-The SDK provides rich error information. Always check errors and use the error helpers to extract details:
-
-```go
-// Create an account
-account, err := client.Entity.Accounts.CreateAccount(ctx, "org-id", "ledger-id", input)
-if err != nil {
-    // Check error type
-    switch {
-    case errors.IsValidationError(err):
-        // Handle validation error
-        fmt.Println("Validation error:", err)
-    
-        // Get field-level errors
-        if fieldErrs := errors.GetFieldErrors(err); len(fieldErrs) > 0 {
-            for _, fieldErr := range fieldErrs {
-                fmt.Printf("Field %s: %s\n", fieldErr.Field, fieldErr.Message)
-            }
-        }
-    case errors.IsNotFoundError(err):
-        // Handle not found error
-        fmt.Println("Resource not found:", err)
-    case errors.IsAuthenticationError(err):
-        // Handle authentication error
-        fmt.Println("Authentication error:", err)
-    case errors.IsNetworkError(err):
-        // Handle network error
-        fmt.Println("Network error:", err)
-    default:
-        // Handle other errors
-        fmt.Println("Error:", err)
-    }
-    return
-}
-```
-
-### Context Usage
-
-Always use contexts for cancellation and timeouts:
-
-```go
-// Create a context with timeout
-ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-defer cancel()
-
-// Use the context for API calls
-account, err := client.Entity.Accounts.GetAccount(ctx, "org-id", "ledger-id", "account-id")
-```
-
-### Resource Management
-
-Always clean up resources when you're done:
-
-```go
-// Create a client
-client, err := client.New(/* options */)
-if err != nil {
-    log.Fatal(err)
-}
-defer client.Shutdown(context.Background())
-
-// Use the client...
+make ci
 ```
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-This project is licensed under the Apache License, Version 2.0 - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the Apache License, Version 2.0. See [LICENSE.md](LICENSE.md) for details.
 
 Copyright 2025 Lerian Studio

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Midaz Go SDK is an idiomatic Go client for the Midaz financial ledger APIs. 
 
 ## Features
 
-- **Current Midaz API coverage**: Ledger resources plus CRM holders and aliases.
+- **Current Midaz API coverage**: Ledger resources plus CRM holders, aliases, and MetadataIndexes.
 - **Entity service API**: Access services through `c.Entity.<Service>` with explicit methods such as `CreateOrganization`, `ListAccounts`, and `CreateTransactionWithDSL`.
 - **Functional options**: Configure clients with `client.WithConfig`, `client.WithBaseURL`, `client.WithRetries`, `client.WithObservabilityProvider`, and related options.
 - **Access Manager authentication**: Configure plugin authentication with `auth.AccessManager` and `config.WithAccessManager` or environment variables.

--- a/client.go
+++ b/client.go
@@ -38,14 +38,17 @@ type Client struct {
 
 	// tenantID is the default tenant identifier sent as X-Tenant-ID on every request.
 	// Per-request overrides via entities.WithTenantID(ctx, id) take precedence.
+	// This remains an optional compatibility header; authenticated claims are the
+	// primary tenant source of truth in the reference Midaz path.
 	tenantID string
 	// tenantIDSet tracks whether WithTenantID was explicitly called, allowing
 	// an empty value to override the config/env default.
 	tenantIDSet bool
 
 	// Observability provider
-	observability observability.Provider
-	metrics       *observability.MetricsCollector
+	observability     observability.Provider
+	metrics           *observability.MetricsCollector
+	customRetryPolicy func(*http.Response, error) bool
 }
 
 // New creates a new Midaz client with the provided options.
@@ -103,28 +106,12 @@ func (c *Client) setupEntity() error {
 		return errors.New("missing transaction URL in config")
 	}
 
-	// Custom retry policy if enabled
-	var retryOptions *retry.Options
-	if c.config.EnableRetries {
-		retryOptions = retry.DefaultOptions()
-
-		if err := retry.WithMaxRetries(c.config.MaxRetries)(retryOptions); err != nil {
-			return fmt.Errorf("failed to set max retries: %w", err)
-		}
-
-		if err := retry.WithInitialDelay(c.config.RetryWaitMin)(retryOptions); err != nil {
-			return fmt.Errorf("failed to set initial delay: %w", err)
-		}
-
-		if err := retry.WithMaxDelay(c.config.RetryWaitMax)(retryOptions); err != nil {
-			return fmt.Errorf("failed to set max delay: %w", err)
-		}
+	if err := config.WithObservabilityProvider(c.observability)(c.config); err != nil {
+		return fmt.Errorf("failed to configure observability provider: %w", err)
 	}
 
 	// Create the entity API with service-specific URLs
-	options := []entities.Option{
-		entities.WithObservability(c.observability),
-	}
+	options := []entities.Option{entities.WithObservability(c.observability)}
 
 	// Propagate tenant ID to the entity layer if configured.
 	// Client-level tenantID takes precedence over config-level TenantID.
@@ -141,16 +128,33 @@ func (c *Client) setupEntity() error {
 		options = append(options, entities.WithDefaultTenantID(tenantID))
 	}
 
-	// Add plugin auth if enabled
-	pluginAuth := c.config.GetPluginAuth()
-	if pluginAuth.Enabled {
-		options = append(options, entities.WithPluginAuth(pluginAuth))
-	}
+	options = append(options,
+		entities.WithDebug(c.config.Debug),
+		entities.WithUserAgent(c.config.UserAgent),
+	)
 
-	entity, err := entities.NewWithServiceURLs(serviceURLs, options...)
+	entity, err := entities.NewEntityWithConfig(c.config, options...)
 	if err != nil {
 		return err
 	}
+
+	httpClient := entity.GetEntityHTTPClient()
+	httpClient.SetEnableIdempotency(c.config.EnableIdempotency)
+	httpClient.WithRetryOptions(
+		retry.WithMaxRetries(c.config.MaxRetries),
+		retry.WithInitialDelay(c.config.RetryWaitMin),
+		retry.WithMaxDelay(c.config.RetryWaitMax),
+	)
+
+	if !c.config.EnableRetries {
+		httpClient.WithRetryOption(retry.WithMaxRetries(0))
+	}
+
+	if c.customRetryPolicy != nil {
+		httpClient.SetCustomRetryPolicy(c.customRetryPolicy)
+	}
+
+	entity.InitServices()
 
 	c.Entity = entity
 
@@ -227,18 +231,14 @@ func WithRetries(maxRetries int, minBackoff, maxBackoff time.Duration) Option {
 //
 // Returns:
 //   - Option: A function that sets the retry policy on the Client
-func WithCustomRetryPolicy(_ func(*http.Response, error) bool) Option {
+func WithCustomRetryPolicy(shouldRetry func(*http.Response, error) bool) Option {
 	return func(c *Client) error {
-		// Custom retry policy will be applied when creating entities
+		c.customRetryPolicy = shouldRetry
+
 		if c.Entity != nil {
 			httpClient := c.Entity.GetEntityHTTPClient()
 			if httpClient != nil {
-				httpClient.WithRetryOption(retry.WithMaxRetries(c.config.MaxRetries))
-				httpClient.WithRetryOption(retry.WithInitialDelay(c.config.RetryWaitMin))
-				httpClient.WithRetryOption(retry.WithMaxDelay(c.config.RetryWaitMax))
-				httpClient.WithRetryOption(retry.WithBackoffFactor(2.0))
-				httpClient.WithRetryOption(retry.WithRetryableHTTPCodes(retry.DefaultRetryableHTTPCodes))
-				httpClient.WithRetryOption(retry.WithRetryableErrors(retry.DefaultRetryableErrors))
+				httpClient.SetCustomRetryPolicy(shouldRetry)
 			}
 		}
 
@@ -550,6 +550,14 @@ func WithTransactionURL(transactionURL string) Option {
 	}
 }
 
+// WithCRMURL sets the URL for the CRM API.
+// This overrides any URL derived from the Environment setting.
+func WithCRMURL(crmURL string) Option {
+	return func(c *Client) error {
+		return config.WithCRMURL(crmURL)(c.config)
+	}
+}
+
 // WithDebug enables or disables debug mode.
 // In debug mode, the SDK logs detailed information about requests and responses.
 //
@@ -567,7 +575,9 @@ func WithDebug(enable bool) Option {
 // WithTenantID sets the default tenant ID for all API requests made through this client.
 // The tenant ID is sent as the X-Tenant-ID header on every request.
 // Per-request overrides via entities.WithTenantID(ctx, tenantID) take precedence
-// over this client-level default.
+// over this client-level default. This is an optional compatibility signal for
+// deployments that honor the header, not a replacement for tenant resolution from
+// authenticated claims.
 //
 // Parameters:
 //   - tenantID: The tenant identifier to use

--- a/client_test.go
+++ b/client_test.go
@@ -55,8 +55,9 @@ func TestNewClient(t *testing.T) {
 	client, err = New(
 		WithConfig(testCfg),
 		WithHTTPClient(customHTTPClient),
-		WithOnboardingURL("http://test.example.com/onboarding"),
-		WithTransactionURL("http://test.example.com/transaction"),
+		WithOnboardingURL("https://test.example.com/onboarding"),
+		WithTransactionURL("https://test.example.com/transaction"),
+		WithCRMURL("https://test.example.com/crm"),
 		WithTimeout(30*time.Second),
 		WithDebug(true),
 		WithEnvironment(config.EnvironmentDevelopment),
@@ -81,6 +82,14 @@ func TestNewClient(t *testing.T) {
 
 	if !client.config.Debug {
 		t.Error("Expected debug to be true")
+	}
+
+	if got := client.config.ServiceURLs[config.ServiceCRM]; got != "https://test.example.com/crm" {
+		t.Errorf("Expected CRM URL to be applied, got %q", got)
+	}
+
+	if client.Entity.Holders == nil || client.Entity.Aliases == nil || client.Entity.MetadataIndexes == nil {
+		t.Fatal("Expected new Entity services to be initialized")
 	}
 
 	if !client.useEntity {

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
+	"github.com/stretchr/testify/require"
 )
 
 // createTestConfig creates a test config with sensible defaults.
@@ -88,9 +89,10 @@ func TestNewClient(t *testing.T) {
 		t.Errorf("Expected CRM URL to be applied, got %q", got)
 	}
 
-	if client.Entity.Holders == nil || client.Entity.Aliases == nil || client.Entity.MetadataIndexes == nil {
-		t.Fatal("Expected new Entity services to be initialized")
-	}
+	require.NotNil(t, client.Entity)
+	require.NotNil(t, client.Entity.Holders)
+	require.NotNil(t, client.Entity.Aliases)
+	require.NotNil(t, client.Entity.MetadataIndexes)
 
 	if !client.useEntity {
 		t.Error("Expected useEntity to be true")

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,154 +1,101 @@
-# Midaz Go SDK Documentation
+# Midaz Go SDK documentation
 
-This documentation provides comprehensive information about the Midaz Go SDK, including API references, usage guides, and examples.
+This directory contains hand-written guides and generated package documentation for the Midaz Go SDK.
 
-## Key Documentation
+## Start here
 
-- [Development GODOC Documentation](./docs/godoc/github.com/LerianStudio/midaz-sdk-golang/v2/index.md) - Static documentation for development
+- [Environment variables](./environment.md) - Runtime configuration and `.env` usage.
+- [Error handling](./errors.md) - SDK error categories, helpers, and retry boundaries.
+- [Architecture](./architecture.md) - SDK structure and implementation overview.
+- [Examples](./examples.md) - Runnable examples and common workflows.
+- [Pagination](./pagination.md) - List options, page metadata, and cursor behavior.
+- [Tracing](./tracing.md) - OpenTelemetry setup and trace propagation.
 
-- [Environment Variables](./environment.md) - Complete guide to environment variable configuration
-- [Error Handling](./errors.md) - Comprehensive guide to error handling in the SDK
-- [Architecture](./architecture.md) - Overview of the SDK architecture
-- [Examples](./examples.md) - Detailed explanation of the example applications
-- [Pagination](./pagination.md) - Guide to using the pagination features
+## API mapping
 
-## API Reference Documentation
+- [External API mapping](./mapping/external_apis.md) - Public SDK constructors, options, services, and model helpers.
+- [Internal API mapping](./mapping/internal_apis.md) - Maintainer-facing map of internal transport and service implementation patterns.
 
-- [External API Mapping](./mapping/external_apis.md) - Mapping between SDK interfaces and external APIs
-- [Internal API Mapping](./mapping/internal_apis.md) - Mapping between SDK interfaces and internal APIs
+## Generated package documentation
 
-## Package Structure
+Generate or refresh static package docs with:
 
-The Midaz Go SDK is organized into the following main packages:
+```bash
+make docs
+```
 
-- **Root Package**: Main entry point for the SDK, provides the Client type and configuration options
-- **Entities**: High-level entity-based API for working with Midaz resources
-- **Models**: Data models representing Midaz resources
-- **Pkg**: Utility packages for various SDK functionalities
+Run an interactive Go documentation server with:
 
-## API Documentation
+```bash
+make godoc
+```
 
-The SDK provides detailed API documentation for all packages. You can browse this documentation in two ways:
+Then open http://localhost:6060/pkg/github.com/LerianStudio/midaz-sdk-golang/v2/.
 
-1. **Interactive Documentation** (requires godoc):
+Generated docs currently include:
 
-   ```bash
-   make godoc
-   ```
+- [Root package](./godoc/index.txt)
+- [Entities package](./godoc/entities/index.txt)
+- [Models package](./godoc/models/index.txt)
+- [Config package](./godoc/pkg/config/index.txt)
+- [Errors package](./godoc/pkg/errors/index.txt)
+- [Observability package](./godoc/pkg/observability/index.txt)
+- [Validation package](./godoc/pkg/validation/index.txt)
+- [Concurrent package](./godoc/pkg/concurrent/index.txt)
+- [Retry package](./godoc/pkg/retry/index.txt)
+- [Performance package](./godoc/pkg/performance/index.txt)
+- [Pagination package](./godoc/pkg/pagination/index.txt)
+- [Format package](./godoc/pkg/format/index.txt)
 
-   Then visit http://localhost:6060/pkg/github.com/LerianStudio/midaz-sdk-golang/v2/
+## Package structure
 
-2. **Static Documentation**:
-   The static documentation is generated in the `docs/godoc` directory as Markdown files. You can browse this documentation directly.
+- `github.com/LerianStudio/midaz-sdk-golang/v2` - Root package. Exposes `Client`, `New`, and client functional options.
+- `entities` - Entity service interfaces and HTTP implementations for Ledger and CRM API resources.
+- `models` - Public SDK request/response types, fluent builders, aliases, pagination helpers, and common constants.
+- `pkg/access-manager` - Plugin-based authentication using Access Manager credentials.
+- `pkg/config` - Environment-aware configuration and service URL resolution.
+- `pkg/errors` - Structured SDK error type, categories, codes, constructors, and checking helpers.
+- `pkg/observability` - OpenTelemetry tracing, metrics, logging, propagation, and middleware helpers.
+- `pkg/retry` - Retry policies, backoff, jitter, and HTTP retry helpers.
+- `pkg/pagination` - Generic paginator utilities separate from `models.ListOptions`.
+- `pkg/concurrent` - Worker pool, batch, and rate-limit helpers.
+- `pkg/security`, `pkg/validation`, `pkg/format`, `pkg/transaction`, `pkg/version` - Supporting utility packages.
 
-   ```bash
-   make godoc-static
-   ```
+## Entity services
 
-   Generated API documentation files:
+The root client exposes entity services through `c.Entity` when created with `client.UseAllAPIs()` or `client.UseEntityAPI()`:
 
-   - [Main Package](./godoc/index.txt)
-   - [Entities Package](./godoc/entities/index.txt)
-   - [Models Package](./godoc/models/index.txt)
+- `Accounts`
+- `AccountTypes`
+- `Assets`
+- `AssetRates`
+- `Balances`
+- `Holders`
+- `Aliases`
+- `Ledgers`
+- `MetadataIndexes`
+- `Operations`
+- `OperationRoutes`
+- `Organizations`
+- `Portfolios`
+- `Segments`
+- `Transactions`
+- `TransactionRoutes`
 
-   **Core Packages:**
+## Configuration baseline
 
-   - [Config Package](./godoc/pkg/config/index.txt)
-   - [Errors Package](./godoc/pkg/errors/index.txt)
-   - [Observability Package](./godoc/pkg/observability/index.txt)
-   - [Validation Package](./godoc/pkg/validation/index.txt)
-   - [Validation Core Package](./godoc/pkg/validation/core/index.txt)
+Environment variables are not loaded implicitly. Use:
 
-   **Performance & Concurrency:**
+```go
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
 
-   - [Concurrent Package](./godoc/pkg/concurrent/index.txt)
-   - [Retry Package](./godoc/pkg/retry/index.txt)
-   - [Performance Package](./godoc/pkg/performance/index.txt)
-   - [Pagination Package](./godoc/pkg/pagination/index.txt)
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.UseAllAPIs(),
+)
+```
 
-   **Data Generation & Testing:**
-
-   - [Generator Package](./godoc/pkg/generator/index.txt)
-   - [Data Package](./godoc/pkg/data/index.txt)
-   - [Integrity Package](./godoc/pkg/integrity/index.txt)
-   - [Stats Package](./godoc/pkg/stats/index.txt)
-
-   **Additional Utilities:**
-
-   - [Access Manager Package](./godoc/pkg/access-manager/index.txt)
-   - [Format Package](./godoc/pkg/format/index.txt)
-   - [Conversion Package](./godoc/pkg/conversion/index.txt)
-   - [Transaction Package](./godoc/pkg/transaction/index.txt)
-   - [Utils Package](./godoc/pkg/utils/index.txt)
-   - [Accounts Package](./godoc/pkg/accounts/index.txt)
-
-## Key Packages
-
-### Root Package
-
-The root package provides the main entry point for the SDK. The key types are:
-
-- **Client**: The main client for interacting with the Midaz API
-- **Option**: Functional options for configuring the client
-
-### Entities Package
-
-The entities package provides high-level entity-based APIs for working with Midaz resources:
-
-- **Organizations**: Methods for managing organizations
-- **Ledgers**: Methods for managing ledgers
-- **Accounts**: Methods for managing accounts
-- **Transactions**: Methods for creating and managing transactions
-- **Assets**: Methods for managing assets
-- **Portfolios**: Methods for managing portfolios
-- **Segments**: Methods for managing segments
-
-### Models Package
-
-The models package provides data models representing Midaz resources:
-
-- **Organization**: Represents an organization in the Midaz system
-- **Ledger**: Represents a ledger in the Midaz system
-- **Account**: Represents an account in the Midaz system
-- **Transaction**: Represents a transaction in the Midaz system
-- **Asset**: Represents an asset in the Midaz system
-- **Portfolio**: Represents a portfolio in the Midaz system
-- **Segment**: Represents a segment in the Midaz system
-
-### Utility Packages
-
-The SDK includes several utility packages in the `pkg` directory:
-
-#### Core Utilities
-
-- **config**: Configuration utilities for the SDK
-- **errors**: Error handling utilities with structured error types
-- **observability**: Observability tools for tracing, metrics, and logging
-- **validation**: Validation utilities for SDK models
-
-#### Performance & Concurrency
-
-- **concurrent**: Utilities for concurrent operations with worker pools and circuit breakers
-- **retry**: Retry mechanisms with exponential backoff for API requests
-- **performance**: Performance optimization utilities including batch processing
-- **pagination**: Utilities for paginated API requests with cursor and offset support
-
-#### Data Generation & Testing
-
-- **generator**: Comprehensive data generation utilities for creating realistic demo data
-- **data**: Templates and patterns for generating organizations, accounts, assets, and transactions
-- **integrity**: Balance verification and double-entry accounting validation
-- **stats**: Statistics collection and performance monitoring utilities
-
-#### Additional Utilities
-
-- **access-manager**: Plugin-based authentication for integrating with external identity providers
-- **format**: Date/time formatting and standardization utilities
-- **conversion**: Type conversion utilities between SDK and backend models
-- **transaction**: Transaction processing helpers and batch operations
-- **utils**: General utility functions for UUID generation and validation
-- **accounts**: Account management utilities (separate from entities layer)
-
-## Examples
-
-For detailed examples of how to use the SDK, refer to the `examples` directory in the SDK repository.
+See [Environment variables](./environment.md) for the full list of supported variables.

--- a/docs/comprehensive-architecture.md
+++ b/docs/comprehensive-architecture.md
@@ -1,1402 +1,817 @@
-# Midaz Go SDK - Comprehensive Architecture Documentation
+# Midaz Go SDK architecture
 
-## Table of Contents
+This document explains how the current Midaz Go SDK is organized, how requests move through the SDK, and which extension points are available. It focuses on the implemented codebase, not planned architecture.
 
-- [Executive Summary](#executive-summary)
-- [System Component Overview](#system-component-overview)
-- [Architectural Diagrams](#architectural-diagrams)
-- [Core Components](#core-components)
-- [Data Models](#data-models)
-- [Service Interfaces](#service-interfaces)
-- [Utility Packages](#utility-packages)
-- [Design Patterns](#design-patterns)
-- [API Surface Documentation](#api-surface-documentation)
-- [Data Flow Analysis](#data-flow-analysis)
-- [Authentication & Security](#authentication--security)
-- [Observability & Monitoring](#observability--monitoring)
-- [Configuration Management](#configuration-management)
-- [Error Handling Strategy](#error-handling-strategy)
-- [Performance & Concurrency](#performance--concurrency)
-- [Extension Points](#extension-points)
-- [Deployment & Environment Support](#deployment--environment-support)
+The SDK is an idiomatic Go client for Midaz Ledger and CRM APIs. The root module is `github.com/LerianStudio/midaz-sdk-golang/v2`, and the root package name is `client` in `client.go`.
 
-## Executive Summary
+## Architecture at a glance
 
-The Midaz Go SDK is a comprehensive, production-ready client library for interacting with the Midaz financial ledger platform. Built using modern Go practices, it implements a clean, layered architecture with strong abstractions, comprehensive error handling, and robust observability features.
+The SDK uses a layered request path:
 
-### Key Architectural Principles
-
-- **Layered Architecture**: Clear separation between client, entities, models, and utility layers
-- **Functional Options Pattern**: Type-safe, extensible configuration throughout
-- **Interface-Driven Design**: Mockable, testable service interfaces
-- **Context-Aware Operations**: Full support for cancellation, timeouts, and tracing
-- **Plugin-Based Authentication**: Flexible authentication via external identity providers
-- **Rich Error Handling**: Structured errors with field-level validation details
-- **Built-in Observability**: OpenTelemetry integration for tracing, metrics, and logging
-
-### Technology Stack
-
-- **Language**: Go 1.24.2
-- **HTTP Client**: Standard library with custom retry/observability middleware
-- **Observability**: OpenTelemetry (OTLP) with gRPC exporters
-- **Testing**: Testify framework with comprehensive mocks
-- **Dependencies**: Minimal external dependencies, primarily LerianStudio ecosystem
-
-## System Component Overview
-
-```mermaid
-graph TB
-    subgraph "Client Application"
-        APP[Application Code]
-    end
-
-    subgraph "Midaz Go SDK"
-        CLIENT[Client Layer]
-        ENTITIES[Entities Layer]
-        MODELS[Models Layer]
-        UTILS[Utility Packages]
-
-        CLIENT --> ENTITIES
-        ENTITIES --> MODELS
-        ENTITIES --> UTILS
-        CLIENT --> UTILS
-    end
-
-    subgraph "Midaz Platform Services"
-        ONBOARDING[Onboarding Service]
-        TRANSACTION[Transaction Service]
-        AUTH[Access Manager]
-    end
-
-    subgraph "Observability Stack"
-        OTEL[OpenTelemetry Collector]
-        METRICS[Metrics Store]
-        TRACES[Tracing Backend]
-        LOGS[Logging System]
-    end
-
-    APP --> CLIENT
-    ENTITIES --> ONBOARDING
-    ENTITIES --> TRANSACTION
-    CLIENT --> AUTH
-    UTILS --> OTEL
-    OTEL --> METRICS
-    OTEL --> TRACES
-    OTEL --> LOGS
+```text
+Application code
+  -> client.Client
+  -> config.Config
+  -> entities.Entity
+  -> private entity implementations
+  -> entities.HTTPClient
+  -> Midaz Ledger API / Midaz CRM API
 ```
 
-## Architectural Diagrams
-
-### High-Level System Architecture
-
 ```mermaid
-graph LR
-    subgraph "SDK Client"
-        CLIENT[Client<br/>Entry Point]
-        CONFIG[Configuration<br/>Management]
-        OBSERVABILITY[Observability<br/>Provider]
-    end
+flowchart LR
+    App[Application code] --> Client[client.Client]
+    Client --> Config[config.Config]
+    Client --> Entity[entities.Entity]
 
-    subgraph "Entity Services"
-        ACCOUNTS[AccountsService]
-        TRANSACTIONS[TransactionsService]
-        ORGANIZATIONS[OrganizationsService]
-        LEDGERS[LedgersService]
-        ASSETS[AssetsService]
-        BALANCES[BalancesService]
-        PORTFOLIOS[PortfoliosService]
-        SEGMENTS[SegmentsService]
-        OPERATIONS[OperationsService]
-        ASSETRATES[AssetRatesService]
-    end
+    Config --> Entity
+    Entity --> Services[Entity service interfaces]
+    Services --> Impl[Private entity implementations]
+    Impl --> HTTP[entities.HTTPClient]
 
-    subgraph "Infrastructure"
-        HTTP[HTTP Client<br/>with Middleware]
-        RETRY[Retry Logic]
-        VALIDATION[Input Validation]
-        PAGINATION[Pagination<br/>Support]
-        CONCURRENT[Concurrency<br/>Utilities]
-    end
+    HTTP --> Ledger[Midaz Ledger API]
+    HTTP --> CRM[Midaz CRM API]
+    HTTP --> Access[Access Manager token endpoint]
 
-    CLIENT --> ACCOUNTS
-    CLIENT --> TRANSACTIONS
-    CLIENT --> ORGANIZATIONS
-    CLIENT --> LEDGERS
-    CLIENT --> ASSETS
-    CLIENT --> BALANCES
-    CLIENT --> PORTFOLIOS
-    CLIENT --> SEGMENTS
-    CLIENT --> OPERATIONS
-    CLIENT --> ASSETRATES
-
-    ACCOUNTS --> HTTP
-    TRANSACTIONS --> HTTP
-    ORGANIZATIONS --> HTTP
-    LEDGERS --> HTTP
-    ASSETS --> HTTP
-    BALANCES --> HTTP
-    PORTFOLIOS --> HTTP
-    SEGMENTS --> HTTP
-    OPERATIONS --> HTTP
-    ASSETRATES --> HTTP
-
-    HTTP --> RETRY
-    HTTP --> VALIDATION
-    HTTP --> PAGINATION
-    HTTP --> CONCURRENT
-    HTTP --> OBSERVABILITY
-
-    CONFIG --> CLIENT
-    OBSERVABILITY --> CLIENT
+    Client --> Obs[observability.Provider]
+    HTTP --> Obs
 ```
 
-### Data Flow Architecture
+The major layers are:
+
+- **Root client layer**: Owns top-level configuration, context, observability, retry settings, tenant defaults, and enabled API groups.
+- **Config layer**: Resolves URLs, HTTP client settings, retry settings, Access Manager settings, idempotency, and environment-based options.
+- **Entity layer**: Exposes the 16 service interfaces through `c.Entity`.
+- **Private entity implementations**: Build resource-specific URLs, validate required inputs, call the HTTP layer, and map responses into SDK models.
+- **HTTP layer**: Handles JSON encoding, request construction, headers, authorization, retries, idempotency, response decoding, error mapping, and trace propagation.
+- **Model layer**: Provides public request and response types, fluent builders, list options, list responses, aliases, and validation helpers.
+- **Utility packages**: Provide configuration, structured errors, observability, retry, pagination, validation, security, formatting, concurrency, generation, and transaction helpers.
+
+## Project structure
+
+```text
+.
+├── client.go
+├── entities/
+├── models/
+├── pkg/
+├── examples/
+├── docs/
+├── scripts/
+├── Makefile
+├── go.mod
+└── .env.example
+```
+
+| Path | Purpose |
+| --- | --- |
+| `client.go` | Root SDK entry point. Defines package `client`, `Client`, `New`, client options, API enabling, observability access, shutdown, and small model constructors. |
+| `entities/` | Entity service interfaces, private HTTP-backed implementations, entity factory, request context helpers, URL builders, and transport helpers. |
+| `models/` | Public SDK types, request inputs, fluent builders, list responses, pagination options, CRM models, transaction models, and Midaz model aliases. |
+| `pkg/config/` | SDK configuration, service URL resolution, environment reading, HTTP client setup, Access Manager config, retry defaults, and idempotency flags. |
+| `pkg/access-manager/` | Access Manager client-credentials token request support. |
+| `pkg/errors/` | Structured SDK error type, categories, codes, constructors, and helper checkers. |
+| `pkg/observability/` | OpenTelemetry provider abstraction, tracing, metrics, logging, context propagation, and HTTP helpers. |
+| `pkg/retry/` | Retry options, retry engine, HTTP retry helpers, exponential backoff, jitter, and retryable status/error matching. |
+| `pkg/pagination/` | Generic pagination helpers separate from `models.ListOptions`. |
+| `pkg/security/` | Outbound request validation and related safety checks. |
+| `pkg/validation/` | Validation helpers and field-level validation structures. |
+| `pkg/concurrent/` | Worker pool, batching, and rate-limit utilities. |
+| `pkg/transaction/` | Transaction batching and transaction helper workflows. |
+| `pkg/generator/`, `pkg/data/`, `pkg/integrity/`, `pkg/stats/` | Demo data, transaction generation, integrity checks, and statistics helpers used by examples and tooling. |
+| `examples/` | Runnable examples for configuration, Access Manager, tracing, retries, validation, concurrency, and end-to-end workflows. |
+| `docs/` | Hand-written guides and generated Go documentation. |
+
+The module currently declares Go `1.26.0` in `go.mod`.
+
+## Client lifecycle
+
+You create a client with `client.New(...)`. The constructor starts with default settings, applies options in order, then initializes enabled API groups.
+
+```go
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
+
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.UseAllAPIs(),
+)
+if err != nil {
+    return err
+}
+defer c.Shutdown(context.Background())
+```
+
+`client.UseAllAPIs()` and `client.UseEntityAPI()` currently enable the same entity API surface. If you do not pass one of these options, `c.Entity` remains unset.
+
+The initialization path is:
+
+1. `client.New` creates a `Client` with default background context, disabled default observability provider, and `config.DefaultConfig()`.
+2. Client options update the `Client` and its config.
+3. If entity APIs are enabled, `setupEntity()` reads service URLs, attaches observability, propagates debug/user-agent/tenant settings, creates the entity layer, and configures retry and idempotency behavior.
+4. `entities.NewEntityWithConfig(...)` reads Access Manager settings, fetches an Access Manager token if enabled, creates an `entities.HTTPClient`, stores service URLs, applies entity options, and initializes services.
+5. `entities.Entity.initServices()` creates all private service implementations and propagates the parent HTTP client configuration into each service-specific HTTP client.
+
+## Configuration
+
+The SDK has two configuration entry points:
+
+- `config.DefaultConfig()` for internal defaults before client options are applied.
+- `config.NewConfig(...)` for validated application configuration.
+
+Default config values include:
+
+| Setting | Default |
+| --- | --- |
+| Environment | `local` |
+| Timeout | `60s` |
+| User agent | from `pkg/version.UserAgent()` |
+| Max retries | `3` |
+| Retry wait minimum | `1s` at the config layer |
+| Retry wait maximum | `30s` at the config layer |
+| Retries enabled | `true` |
+| Idempotency enabled | `true` |
+| Local Ledger base URL | `http://localhost:3002/v1` |
+| Local CRM base URL | `http://localhost:4003/v1` |
+
+The HTTP retry engine has its own default options in `pkg/retry`:
+
+| Retry option | Default |
+| --- | --- |
+| Max retries | `3` |
+| Initial delay | `100ms` |
+| Max delay | `10s` |
+| Backoff factor | `2.0` |
+| Jitter factor | `0.25` |
+
+When you configure the root client with `client.WithRetries(max, min, maxBackoff)`, `setupEntity()` applies those values to the entity HTTP client.
+
+## Environment variables
+
+The SDK does not load `.env` files by itself.
+
+`config.FromEnvironment()` reads values from the current process environment only. If you want to use a `.env` file, load it before creating the SDK config, or use shell exports, Docker environment variables, or your process manager.
+
+```go
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
+```
+
+Supported environment variables read by `config.FromEnvironment()` are:
+
+| Variable | Behavior |
+| --- | --- |
+| `MIDAZ_ENVIRONMENT` | Sets `local`, `development`, or `production`. |
+| `PLUGIN_AUTH_ENABLED` | Enables Access Manager token fetching when set to `true`. |
+| `PLUGIN_AUTH_ADDRESS` | Sets the Access Manager base address. |
+| `MIDAZ_CLIENT_ID` | Sets the Access Manager client ID. |
+| `MIDAZ_CLIENT_SECRET` | Sets the Access Manager client secret. |
+| `MIDAZ_USER_AGENT` | Overrides the user-agent string. |
+| `MIDAZ_BASE_URL` | Sets a shared base URL. The SDK derives Ledger and CRM service URLs from it. |
+| `MIDAZ_ONBOARDING_URL` | Overrides the onboarding service URL. |
+| `MIDAZ_TRANSACTION_URL` | Overrides the transaction service URL. |
+| `MIDAZ_CRM_URL` | Overrides the CRM service URL. |
+| `MIDAZ_TIMEOUT` | Sets HTTP timeout in seconds. |
+| `MIDAZ_DEBUG` | Enables debug mode when set to `true`. |
+| `MIDAZ_MAX_RETRIES` | Sets maximum retry attempts. |
+| `MIDAZ_IDEMPOTENCY` | Enables or disables automatic idempotency behavior when set. |
+
+The current config reader does not read `MIDAZ_RETRY_WAIT_MIN`, `MIDAZ_RETRY_WAIT_MAX`, `MIDAZ_OTEL_ENDPOINT`, or `MIDAZ_LOG_LEVEL`. Configure retry timing and observability programmatically when you need those settings.
+
+## Service URL resolution
+
+The config package uses three service names internally:
+
+| Service name | Purpose |
+| --- | --- |
+| `onboarding` | Ledger API resources historically grouped under onboarding, such as organizations, ledgers, accounts, assets, portfolios, and segments. |
+| `transaction` | Ledger API transaction-side resources, such as transactions, operations, balances, routes, metadata indexes, and asset rates. |
+| `crm` | CRM resources, currently holders and aliases. |
+
+For local defaults:
+
+- Ledger API uses `http://localhost:3002/v1`
+- CRM API uses `http://localhost:4003/v1`
+
+For development and production defaults, CRM falls back to the Ledger base URL unless you provide `MIDAZ_CRM_URL` or `config.WithCRMURL(...)`.
+
+`client.WithBaseURL(...)` derives service URLs from a shared base:
+
+- Ledger services use port `3002` for localhost without an explicit port.
+- CRM uses port `4003` for localhost without an explicit port.
+- The SDK appends `/v1` when the path does not already end in `/v1`.
+
+## Entity services
+
+The root client exposes entity services through `c.Entity` after you enable the entity API.
+
+```go
+c, err := client.New(
+    client.WithBaseURL("http://localhost"),
+    client.UseAllAPIs(),
+)
+if err != nil {
+    return err
+}
+
+orgs, err := c.Entity.Organizations.ListOrganizations(ctx, models.NewListOptions().WithLimit(20))
+```
+
+The current entity surface has 16 services:
+
+| Service | API area | Backing URL key | Purpose |
+| --- | --- | --- | --- |
+| `Organizations` | Ledger | `onboarding` | Manage organizations. |
+| `Ledgers` | Ledger | `onboarding` | Manage ledgers inside organizations. |
+| `Accounts` | Ledger | mostly `onboarding`, balance helper uses `transaction` | Manage accounts and account-level balance helpers. |
+| `AccountTypes` | Ledger | `onboarding` | Manage account types. |
+| `Assets` | Ledger | `onboarding` | Manage assets. |
+| `AssetRates` | Ledger | `transaction` | Manage asset rate resources. |
+| `Balances` | Ledger | `transaction` | Read and manage balance resources. |
+| `Operations` | Ledger | `transaction` | Read account-based and transaction-based operations. |
+| `OperationRoutes` | Ledger | `transaction` | Manage operation routes. |
+| `Transactions` | Ledger | `transaction` | Create, list, update, commit, cancel, and revert transactions. |
+| `TransactionRoutes` | Ledger | `transaction` | Manage transaction routes. |
+| `MetadataIndexes` | Ledger | `transaction` | Manage metadata indexes. |
+| `Portfolios` | Ledger | `onboarding` | Manage portfolios. |
+| `Segments` | Ledger | `onboarding` | Manage segments. |
+| `Holders` | CRM | `crm` | Manage CRM holders. |
+| `Aliases` | CRM | `crm` | Manage CRM aliases and related parties. |
+
+Each public service field is an interface. Each concrete implementation is private to the `entities` package, such as `accountsEntity`, `transactionsEntity`, `holdersEntity`, and `aliasesEntity`.
+
+## Conceptual resource hierarchy
+
+The SDK does not define a database schema. The following hierarchy is conceptual and describes how SDK methods scope requests.
+
+```mermaid
+flowchart TD
+    Org[Organization] --> Ledger[Ledger]
+    Ledger --> Account[Account]
+    Ledger --> Asset[Asset]
+    Ledger --> Portfolio[Portfolio]
+    Ledger --> Segment[Segment]
+    Ledger --> Transaction[Transaction]
+    Transaction --> Operation[Operation]
+    Ledger --> Balance[Balance]
+    Ledger --> TransactionRoute[Transaction route]
+    Ledger --> OperationRoute[Operation route]
+    Org --> Holder[CRM holder]
+    Holder --> Alias[CRM alias]
+```
+
+Use the model types in `models/` as the source of truth for SDK request and response fields. Avoid treating conceptual diagrams as field-level ER diagrams.
+
+## Request lifecycle
+
+A normal SDK request follows this path:
 
 ```mermaid
 sequenceDiagram
-    participant APP as Application
-    participant CLIENT as Client
-    participant ENTITY as Entity Service
-    participant HTTP as HTTP Client
-    participant MIDDLEWARE as Observability Middleware
+    participant App as Application
+    participant Client as client.Client
+    participant Entity as entities.Entity
+    participant Service as private service implementation
+    participant HTTP as entities.HTTPClient
     participant API as Midaz API
-    participant AUTH as Access Manager
 
-    APP->>CLIENT: New() with options
-    CLIENT->>AUTH: Get authentication token
-    AUTH-->>CLIENT: Return token
-    CLIENT->>ENTITY: Initialize services
+    App->>Client: client.New(options...)
+    Client->>Entity: setupEntity()
+    Entity->>Service: initServices()
 
-    APP->>CLIENT: Entity.Organizations.CreateOrganization()
-    CLIENT->>ENTITY: CreateOrganization()
-    ENTITY->>HTTP: POST request
-    HTTP->>MIDDLEWARE: Wrap with observability
-    MIDDLEWARE->>API: Execute HTTP request
-    API-->>MIDDLEWARE: Response
-    MIDDLEWARE-->>HTTP: Response with metrics/traces
-    HTTP-->>ENTITY: Process response
-    ENTITY->>ENTITY: Convert mmodel to SDK model
-    ENTITY-->>CLIENT: Return Organization
-    CLIENT-->>APP: Return Organization
+    App->>Service: c.Entity.Accounts.GetAccount(ctx, orgID, ledgerID, accountID)
+    Service->>Service: validate required parameters
+    Service->>Service: build resource URL
+    Service->>HTTP: doRequest(ctx, method, url, headers, body, result)
+    HTTP->>HTTP: start span when observability is enabled
+    HTTP->>HTTP: encode JSON body
+    HTTP->>HTTP: add headers
+    HTTP->>HTTP: inject trace context
+    HTTP->>HTTP: execute with retry policy
+    HTTP->>API: HTTP request
+    API-->>HTTP: HTTP response
+    HTTP->>HTTP: map errors or decode JSON
+    HTTP-->>Service: result or error
+    Service-->>App: SDK model or error
 ```
 
-### Component Interaction Workflow
+The HTTP layer adds these standard headers:
 
-```mermaid
-graph TB
-    subgraph "Request Flow"
-        START([Client Request])
-        VALIDATE{Input Validation}
-        AUTH{Authentication}
-        RETRY{Retry Logic}
-        HTTP[HTTP Request]
-        RESPONSE[Process Response]
-        CONVERT[Model Conversion]
-        END([Return Result])
-    end
+| Header | Behavior |
+| --- | --- |
+| `Accept: application/json` | Added to requests. |
+| `Content-Type: application/json` | Added when the request has a body and no custom content type is set. |
+| `User-Agent` | Uses config user agent or version default. |
+| `Authorization: Bearer <token>` | Added only when an Access Manager token is available or an entity has an auth token. |
+| `X-Idempotency` | Added from context or transaction input when present. Some transaction requests can request automatic generation. |
+| `X-Tenant-ID` | Added from request context or client/config default tenant ID when present. |
+| `X-Organization-Id` | Added by CRM holder and alias requests. |
 
-    subgraph "Cross-Cutting Concerns"
-        OBSERVABILITY[Observability<br/>Tracing/Metrics/Logging]
-        ERROR[Error Handling<br/>& Classification]
-        PAGINATION[Pagination<br/>Support]
-        CONCURRENCY[Concurrency<br/>Control]
-    end
+The tenant header is compatibility metadata. The reference Midaz path treats authenticated claims as the primary tenant source of truth.
 
-    START --> VALIDATE
-    VALIDATE -->|Valid| AUTH
-    VALIDATE -->|Invalid| ERROR
-    AUTH -->|Success| RETRY
-    AUTH -->|Failure| ERROR
-    RETRY --> HTTP
-    HTTP --> RESPONSE
-    RESPONSE --> CONVERT
-    CONVERT --> END
+## Access Manager authentication
 
-    OBSERVABILITY -.-> HTTP
-    OBSERVABILITY -.-> RESPONSE
-    ERROR -.-> VALIDATE
-    ERROR -.-> AUTH
-    ERROR -.-> HTTP
-    PAGINATION -.-> RESPONSE
-    CONCURRENCY -.-> HTTP
-```
+Access Manager support lives in `pkg/access-manager`.
 
-## Core Components
-
-### 1. Client Layer (`client.go`)
-
-**Purpose**: Top-level entry point providing unified access to all SDK functionality.
-
-**Key Responsibilities**:
-
-- Configuration management via functional options
-- Service initialization and lifecycle management
-- Observability provider setup and context management
-- Authentication token management
-- Graceful shutdown coordination
-
-**Key Methods**:
-
-- `New(options ...Option) (*Client, error)`: Main constructor with functional options
-- `WithEnvironment(env Environment)`: Environment configuration
-- `WithObservability(tracing, metrics, logging bool)`: Observability setup
-- `UseAllAPIs()`: Enable all service interfaces
-- `Shutdown(ctx context.Context)`: Graceful resource cleanup
-
-**Location**: `/client.go:23-674`
-
-### 2. Entity Layer (`entities/`)
-
-**Purpose**: Service-specific interfaces providing direct API access with proper abstraction.
-
-**Key Components**:
-
-- **Entity Factory** (`entities/entity.go`): Central access point to all services
-- **Service Interfaces**: Strongly-typed interfaces for each domain
-- **HTTP Client** (`entities/http.go`): Configured HTTP client with middleware
-- **Model Conversion**: Bridge between SDK models and backend models
-
-**Service Interfaces**:
-
-- `AccountsService`: Account creation, retrieval, balance management
-- `TransactionsService`: Transaction processing (standard & DSL)
-- `OrganizationsService`: Organization lifecycle management
-- `LedgersService`: Ledger creation and management
-- `AssetsService`: Asset definition and configuration
-- And 5 additional specialized services
-
-**Location**: `/entities/entity.go:32-378`
-
-### 3. Models Layer (`models/`)
-
-**Purpose**: Data structures representing all Midaz platform resources with validation.
-
-**Key Features**:
-
-- **Type Safety**: Strongly-typed structs for all resources
-- **Validation**: Built-in validation using the validation package
-- **Conversion Methods**: Bidirectional conversion with backend models (`mmodel`)
-- **Builder Patterns**: Fluent APIs for model construction
-- **JSON Serialization**: Proper JSON tags and custom marshaling
-
-**Core Models**:
-
-- `Account`: Financial account with balances and metadata
-- `Transaction`: Financial transaction with operations
-- `Organization`: Business entity owning ledgers
-- `Ledger`: Collection of accounts and transactions
-- `Asset`: Financial instrument definitions
-- Plus 5 additional domain models
-
-**Location**: `/models/model.go:1-50`
-
-## Data Models
-
-### Entity Relationship Diagram
-
-```mermaid
-erDiagram
-    Organization {
-        string ID
-        string LegalName
-        string LegalDocument
-        string DoingBusinessAs
-        Address Address
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Ledger {
-        string ID
-        string Name
-        string OrganizationID
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Account {
-        string ID
-        string Name
-        string Alias
-        string Type
-        string AssetCode
-        string OrganizationID
-        string LedgerID
-        string PortfolioID
-        string SegmentID
-        Balance Balance
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Transaction {
-        string ID
-        string Description
-        string ExternalID
-        string OrganizationID
-        string LedgerID
-        Operation[] Operations
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Operation {
-        string ID
-        string TransactionID
-        string AccountID
-        string Type
-        string AssetCode
-        int Amount
-        int Scale
-        map Metadata
-        time CreatedAt
-    }
-
-    Asset {
-        string ID
-        string Name
-        string Type
-        string Code
-        int Scale
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Portfolio {
-        string ID
-        string Name
-        string OrganizationID
-        string LedgerID
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Segment {
-        string ID
-        string Name
-        string OrganizationID
-        string LedgerID
-        map Metadata
-        Status Status
-        time CreatedAt
-        time UpdatedAt
-    }
-
-    Balance {
-        string AccountID
-        string AssetCode
-        int Available
-        int OnHold
-        int Scale
-        time UpdatedAt
-    }
-
-    Organization ||--o{ Ledger : owns
-    Ledger ||--o{ Account : contains
-    Ledger ||--o{ Transaction : contains
-    Ledger ||--o{ Portfolio : contains
-    Ledger ||--o{ Segment : contains
-    Account ||--o{ Balance : has
-    Account ||--o{ Operation : participates_in
-    Transaction ||--o{ Operation : contains
-    Portfolio ||--o{ Account : groups
-    Segment ||--o{ Account : categorizes
-```
-
-### Data Flow Patterns
-
-```mermaid
-graph LR
-    subgraph "Input Models"
-        CREATE_ORG[CreateOrganizationInput]
-        CREATE_LEDGER[CreateLedgerInput]
-        CREATE_ACCOUNT[CreateAccountInput]
-        CREATE_TRANSACTION[CreateTransactionInput]
-        TRANSACTION_DSL[TransactionDSLInput]
-    end
-
-    subgraph "SDK Models"
-        ORG[Organization]
-        LEDGER[Ledger]
-        ACCOUNT[Account]
-        TRANSACTION[Transaction]
-        OPERATION[Operation]
-    end
-
-    subgraph "Backend Models (mmodel)"
-        MORG[mmodel.Organization]
-        MLEDGER[mmodel.Ledger]
-        MACCOUNT[mmodel.Account]
-        MTRANSACTION[mmodel.Transaction]
-        MOPERATION[mmodel.Operation]
-    end
-
-    CREATE_ORG -->|Validation| ORG
-    CREATE_LEDGER -->|Validation| LEDGER
-    CREATE_ACCOUNT -->|Validation| ACCOUNT
-    CREATE_TRANSACTION -->|Validation| TRANSACTION
-    TRANSACTION_DSL -->|DSL Processing| TRANSACTION
-
-    ORG <-->|Conversion| MORG
-    LEDGER <-->|Conversion| MLEDGER
-    ACCOUNT <-->|Conversion| MACCOUNT
-    TRANSACTION <-->|Conversion| MTRANSACTION
-    OPERATION <-->|Conversion| MOPERATION
-```
-
-## Service Interfaces
-
-### Complete API Surface
-
-#### OrganizationsService
+The SDK supports client-credentials token fetching through:
 
 ```go
-type OrganizationsService interface {
-    // CRUD Operations
-    CreateOrganization(ctx context.Context, input *models.CreateOrganizationInput) (*models.Organization, error)
-    GetOrganization(ctx context.Context, id string) (*models.Organization, error)
-    UpdateOrganization(ctx context.Context, id string, input *models.UpdateOrganizationInput) (*models.Organization, error)
-    DeleteOrganization(ctx context.Context, id string) error
-    ListOrganizations(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.Organization], error)
+import auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
+
+cfg, err := config.NewConfig(
+    config.WithAccessManager(auth.AccessManager{
+        Enabled:      true,
+        Address:      "https://access-manager.example.com",
+        ClientID:     "midaz-client",
+        ClientSecret: "secret",
+    }),
+)
+if err != nil {
+    return err
 }
-```
 
-#### LedgersService
-
-```go
-type LedgersService interface {
-    CreateLedger(ctx context.Context, organizationID string, input *models.CreateLedgerInput) (*models.Ledger, error)
-    GetLedger(ctx context.Context, organizationID, id string) (*models.Ledger, error)
-    UpdateLedger(ctx context.Context, organizationID, id string, input *models.UpdateLedgerInput) (*models.Ledger, error)
-    DeleteLedger(ctx context.Context, organizationID, id string) error
-    ListLedgers(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Ledger], error)
-}
-```
-
-#### AccountsService
-
-```go
-type AccountsService interface {
-    CreateAccount(ctx context.Context, organizationID, ledgerID string, input *models.CreateAccountInput) (*models.Account, error)
-    GetAccount(ctx context.Context, organizationID, ledgerID, id string) (*models.Account, error)
-    GetAccountByAlias(ctx context.Context, organizationID, ledgerID, alias string) (*models.Account, error)
-    UpdateAccount(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateAccountInput) (*models.Account, error)
-    DeleteAccount(ctx context.Context, organizationID, ledgerID, id string) error
-    ListAccounts(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Account], error)
-    GetBalance(ctx context.Context, organizationID, ledgerID, accountID string) (*models.Balance, error)
-}
-```
-
-#### TransactionsService
-
-```go
-type TransactionsService interface {
-    // Standard Transaction Processing
-    CreateTransaction(ctx context.Context, orgID, ledgerID string, input *models.CreateTransactionInput) (*models.Transaction, error)
-
-    // DSL Transaction Processing
-    CreateTransactionWithDSL(ctx context.Context, orgID, ledgerID string, input *models.TransactionDSLInput) (*models.Transaction, error)
-    CreateTransactionWithDSLFile(ctx context.Context, orgID, ledgerID string, dslContent []byte) (*models.Transaction, error)
-
-    // Retrieval and Management
-    GetTransaction(ctx context.Context, orgID, ledgerID, transactionID string) (*models.Transaction, error)
-    ListTransactions(ctx context.Context, orgID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Transaction], error)
-    UpdateTransaction(ctx context.Context, orgID, ledgerID, transactionID string, input any) (*models.Transaction, error)
-}
-```
-
-#### Additional Services
-
-- **AssetsService**: Asset definition and management
-- **BalancesService**: Account balance queries and history
-- **PortfoliosService**: Account grouping and portfolio management
-- **SegmentsService**: Account categorization and segment management
-- **OperationsService**: Individual transaction operation management
-- **AssetRatesService**: Currency exchange rate management
-
-## Utility Packages
-
-### Configuration (`pkg/config/`)
-
-**Purpose**: Centralized configuration management with environment support.
-
-**Key Features**:
-
-- Environment-based URL resolution (local, development, production)
-- Functional options pattern for type-safe configuration
-- Environment variable integration
-- Service URL mapping and validation
-- Plugin authentication configuration
-
-**Location**: `/pkg/config/config.go:78-752`
-
-### Observability (`pkg/observability/`)
-
-**Purpose**: OpenTelemetry integration for comprehensive monitoring.
-
-**Capabilities**:
-
-- Distributed tracing with span management
-- Metrics collection (request counts, latencies, errors)
-- Structured logging with context propagation
-- HTTP middleware for automatic instrumentation
-- OTLP exporters for traces and metrics
-- Custom metric collectors for SDK operations
-
-**Location**: `/pkg/observability/observability.go:1-50`
-
-### Concurrency (`pkg/concurrent/`)
-
-**Purpose**: Utilities for high-performance parallel processing with resilience features.
-
-**Features**:
-
-- Worker pools with configurable concurrency levels
-- Circuit breaker pattern for protecting downstream services
-- Rate limiting and backpressure handling
-- Batch processing utilities with HTTP batch adapters
-- Result collection and error aggregation
-- Context-aware cancellation and timeout management
-- Unordered result processing for maximum throughput
-- Failure threshold monitoring and automatic recovery
-
-**Key Components**:
-
-- `WorkerPool`: Configurable parallel processing with worker goroutines
-- `CircuitBreaker`: Automatic failure detection and service protection
-- `HttpBatchAdapter`: Batch HTTP request processing for efficiency
-- `RateLimiter`: Token bucket algorithm for request throttling
-
-**Location**: `/pkg/concurrent/concurrent.go:1-50`
-
-### Retry Logic (`pkg/retry/`)
-
-**Purpose**: Resilient operation execution with intelligent backoff.
-
-**Capabilities**:
-
-- Exponential backoff with configurable parameters
-- Jitter for distributed system stability
-- Context-aware cancellation
-- Configurable retry conditions
-- HTTP-specific retry logic
-- Integration with observability for retry metrics
-
-**Location**: `/pkg/retry/retry.go:1-50`
-
-### Validation (`pkg/validation/`)
-
-**Purpose**: Comprehensive input validation with helpful error messages.
-
-**Features**:
-
-- DSL transaction validation
-- Asset code and type validation
-- Account alias and metadata validation
-- Address validation with regional support
-- Date range validation
-- Configurable validation rules
-- Field-level error reporting with suggestions
-
-**Location**: `/pkg/validation/validation.go:1-50`
-
-### Data Generation Framework (`pkg/generator/`)
-
-**Purpose**: Comprehensive framework for generating realistic demo data and testing scenarios.
-
-**Key Interfaces**:
-
-- `OrganizationGenerator`: Creates organizations with realistic business data
-- `LedgerGenerator`: Generates ledgers with proper configuration and pagination support
-- `AssetGenerator`: Creates assets with scale configuration and rate management
-- `AccountGenerator`: Generates accounts with hierarchy and type relationships
-- `TransactionGenerator`: Creates transactions using DSL patterns and batch processing
-- `TransactionLifecycle`: Manages pending/commit/revert transaction states
-
-**Advanced Features**:
-
-- Concurrent generation with worker pools and circuit breakers
-- Template-based data creation with realistic patterns
-- Account type integration (checking, savings, credit, expense, revenue, liability, equity)
-- Operation route and transaction route creation for validation
-- DSL-based transaction pattern demonstrations
-- Idempotency key support and external ID management
-
-**Location**: `/pkg/generator/interfaces.go:1-73`
-
-### Data Templates (`pkg/data/`)
-
-**Purpose**: Provides templates and patterns for realistic data generation.
-
-**Template Types**:
-
-- `OrgTemplate`: Organizations with legal documents, addresses, and industry metadata
-- `LedgerTemplate`: Basic ledger configurations with metadata
-- `AssetTemplate`: Assets with scale, type, and code specifications
-- `AccountTemplate`: Account creation with type requirements and relationships
-- `TransactionPattern`: DSL-based transaction patterns for complex flows
-
-**Features**:
-
-- Realistic business data with proper formatting
-- Metadata constraints validation (100/2000 character limits)
-- Support for different locales (US EIN vs Brazil CNPJ)
-- Account type relationships and hierarchy support
-- DSL transaction pattern templates
-
-**Location**: `/pkg/data/templates.go:1-63`
-
-### Integrity Verification (`pkg/integrity/`)
-
-**Purpose**: Balance verification and double-entry accounting validation.
-
-**Capabilities**:
-
-- Balance aggregation per asset across all accounts
-- Available and on-hold balance tracking
-- Overdrawn account detection (negative available balances)
-- Double-entry consistency validation
-- Internal net total computation (excluding @external/ accounts)
-- Scale consistency verification for currency amounts
-- Optional account lookup throttling for large ledgers
-
-**Key Types**:
-
-- `BalanceTotals`: Aggregated balance data per asset
-- `Report`: Comprehensive integrity report for ledgers
-- `Checker`: Main integrity verification engine
-
-**Location**: `/pkg/integrity/checker.go:1-219`
-
-### Statistics & Monitoring (`pkg/stats/`)
-
-**Purpose**: Statistics collection, performance monitoring, and metrics aggregation.
-
-**Features**:
-
-- Real-time performance metrics collection
-- API call statistics and timing
-- Transaction volume tracking
-- Entity creation monitoring
-- TPS (Transactions Per Second) calculation
-- Progress monitoring with ETA estimation
-
-**Location**: `/pkg/stats/stats.go:1-50`
-
-### Data Generation & Testing Utilities
-
-- **Generator** (`pkg/generator/`): Comprehensive data generation framework with interfaces for creating realistic demo data
-- **Data** (`pkg/data/`): Templates and patterns for organizations, accounts, assets, and transactions
-- **Integrity** (`pkg/integrity/`): Balance verification, double-entry validation, and data consistency checks
-- **Stats** (`pkg/stats/`): Statistics collection, performance monitoring, and metrics aggregation
-
-### Additional Core Utilities
-
-- **Pagination** (`pkg/pagination/`): Generic pagination support for all list operations with cursor and offset modes
-- **Errors** (`pkg/errors/`): Structured error handling with classification and detailed field-level error reporting
-- **Format** (`pkg/format/`): Date/time formatting and standardization utilities
-- **Performance** (`pkg/performance/`): Batch processing, JSON optimization, and high-throughput operations
-- **Conversion** (`pkg/conversion/`): Type conversion utilities between SDK models and backend models
-- **Transaction** (`pkg/transaction/`): Transaction processing helpers, batch operations, and reporting utilities
-- **Utils** (`pkg/utils/`): General utility functions for UUID generation, validation, and common operations
-- **Accounts** (`pkg/accounts/`): Account management utilities separate from the entities layer
-
-## Design Patterns
-
-### 1. Functional Options Pattern
-
-Used extensively throughout the SDK for type-safe, extensible configuration:
-
-```go
-// Client configuration
-client, err := client.New(
-    client.WithEnvironment(config.EnvironmentProduction),
-    client.WithObservability(true, true, true),
-    client.WithRetries(3, 1*time.Second, 30*time.Second),
+c, err := client.New(
+    client.WithConfig(cfg),
     client.UseAllAPIs(),
 )
+```
 
-// Configuration options
-cfg, err := config.NewConfig(
-    config.WithEnvironment(config.EnvironmentLocal),
-    config.WithAccessManager(accessManager),
-    config.WithTimeout(30 * time.Second),
+When Access Manager is enabled, `entities.NewEntityWithConfig(...)` calls:
+
+```go
+auth.GetTokenFromAccessManager(context.Background(), pluginAuth, config.GetHTTPClient())
+```
+
+The token request is a `POST` to:
+
+```text
+{PLUGIN_AUTH_ADDRESS}/v1/login/oauth/access_token
+```
+
+The request payload is:
+
+```json
+{
+  "grantType": "client_credentials",
+  "clientId": "...",
+  "clientSecret": "..."
+}
+```
+
+The SDK uses the returned `accessToken` as a bearer token on entity HTTP requests.
+
+Important boundaries:
+
+- The SDK fetches the token during entity setup.
+- The SDK does not refresh tokens automatically.
+- The SDK does not use the `refreshToken` field from the Access Manager response.
+- The SDK does not sign individual requests.
+- The SDK does not claim to derive tenant scope from tokens. It only sends optional tenant headers when configured.
+
+## Errors
+
+Most SDK operational errors use `*errors.Error` from `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors`.
+
+The actual error shape is:
+
+```go
+type Error struct {
+    Category   ErrorCategory
+    Code       ErrorCode
+    Message    string
+    Operation  string
+    Resource   string
+    ResourceID string
+    StatusCode int
+    RequestID  string
+    Err        error
+}
+```
+
+`*errors.Error` implements:
+
+- `Error() string`
+- `Unwrap() error`
+- `Is(target error) bool`
+
+Use the helper checkers for common branches:
+
+```go
+import sdkerrors "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+
+account, err := c.Entity.Accounts.GetAccount(ctx, orgID, ledgerID, accountID)
+if err != nil {
+    switch {
+    case sdkerrors.IsNotFoundError(err):
+        return fmt.Errorf("account not found: %w", err)
+    case sdkerrors.IsAuthenticationError(err):
+        return fmt.Errorf("authentication failed: %w", err)
+    case sdkerrors.IsRateLimitError(err):
+        return fmt.Errorf("rate limited: %w", err)
+    default:
+        return fmt.Errorf("get account: %w", err)
+    }
+}
+```
+
+Use `errors.As` from the standard library when you need fields such as operation, resource, status code, or request ID:
+
+```go
+var sdkErr *sdkerrors.Error
+if stderrors.As(err, &sdkErr) {
+    log.Printf(
+        "category=%s code=%s operation=%s status=%d request_id=%s",
+        sdkErr.Category,
+        sdkErr.Code,
+        sdkErr.Operation,
+        sdkErr.StatusCode,
+        sdkErr.RequestID,
+    )
+}
+```
+
+Field-level validation details are not stored on `pkg/errors.Error`. Some validation paths can return `pkg/validation.FieldErrors`.
+
+## Retry behavior
+
+Retry support lives in `pkg/retry` and is applied by `entities.HTTPClient`.
+
+The default retryable HTTP status codes are:
+
+| Status | Meaning |
+| --- | --- |
+| `408` | Request timeout |
+| `429` | Too many requests |
+| `500` | Internal server error |
+| `502` | Bad gateway |
+| `503` | Service unavailable |
+| `504` | Gateway timeout |
+
+Default retryable network error text includes:
+
+- `connection reset by peer`
+- `connection refused`
+- `timeout`
+- `deadline exceeded`
+- `too many requests`
+- `rate limit`
+- `service unavailable`
+
+Configure retries at the client level:
+
+```go
+c, err := client.New(
+    client.WithRetries(3, 100*time.Millisecond, 10*time.Second),
+    client.UseAllAPIs(),
 )
 ```
 
-### 2. Interface Segregation
-
-Each domain has focused interfaces with single responsibilities:
+Disable retries:
 
 ```go
-type AccountsService interface {
-    // Account CRUD
-    CreateAccount(...) (*models.Account, error)
-    GetAccount(...) (*models.Account, error)
-    // ... other account operations
-}
-
-type TransactionsService interface {
-    // Transaction operations only
-    CreateTransaction(...) (*models.Transaction, error)
-    CreateTransactionWithDSL(...) (*models.Transaction, error)
-    // ... other transaction operations
-}
+c, err := client.New(
+    client.DisableRetries(),
+    client.UseAllAPIs(),
+)
 ```
 
-### 3. Factory Pattern
-
-Centralized service creation and configuration:
+You can also provide a custom retry predicate:
 
 ```go
-// Entity factory
-entity := &Entity{
-    Accounts:      NewAccountsEntity(client, token, urls),
-    Transactions:  NewTransactionsEntity(client, token, urls),
-    Organizations: NewOrganizationsEntity(client, token, urls),
-    // ... other services
-}
+c, err := client.New(
+    client.WithCustomRetryPolicy(func(resp *http.Response, err error) bool {
+        if resp != nil && resp.StatusCode == http.StatusConflict {
+            return false
+        }
+
+        return err != nil
+    }),
+    client.UseAllAPIs(),
+)
 ```
 
-### 4. Builder Pattern
+The custom predicate decides whether retry processing continues for a response or error. It does not replace request construction, response decoding, or SDK error mapping.
 
-Fluent APIs for model construction:
+## Idempotency behavior
+
+The SDK is conservative about retries for unsafe HTTP methods.
+
+Unsafe methods are:
+
+- `POST`
+- `PUT`
+- `PATCH`
+- `DELETE`
+
+If an unsafe request has no `X-Idempotency` header, the HTTP layer sets the effective retry count to `0` for that request. This prevents automatic retries from duplicating state-changing operations.
+
+You can attach an idempotency key to any request context:
 
 ```go
-account := models.NewAccount().
-    WithName("Customer Account").
-    WithType("customer").
-    WithAssetCode("USD").
-    WithMetadata(map[string]any{
-        "customer_id": "cust-123",
-        "tier": "premium",
+ctx := entities.WithIdempotencyKey(context.Background(), "payment-2026-04-27-0001")
+
+tx, err := c.Entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, input)
+```
+
+For transaction creation, `models.CreateTransactionInput` also has an idempotency field used by the transaction service:
+
+```go
+input := models.NewCreateTransactionInput("USD", "100.00").
+    WithDescription("Customer payment").
+    WithSend(&models.SendInput{
+        Asset: "USD",
+        Value: "100.00",
+        Source: &models.SourceInput{
+            From: []models.FromToInput{
+                {Account: customerAlias, Amount: models.AmountInput{Asset: "USD", Value: "100.00"}},
+            },
+        },
+        Distribute: &models.DistributeInput{
+            To: []models.FromToInput{
+                {Account: merchantAlias, Amount: models.AmountInput{Asset: "USD", Value: "100.00"}},
+            },
+        },
     })
+
+input.IdempotencyKey = "payment-2026-04-27-0001"
+
+tx, err := c.Entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, input)
 ```
 
-### 5. Middleware Pattern
+Automatic idempotency is intentionally limited. The HTTP layer only auto-generates `X-Idempotency` when:
 
-HTTP request/response processing pipeline:
+1. idempotency is enabled,
+2. the method is unsafe,
+3. no idempotency key is already present, and
+4. the service sets the internal `X-Midaz-Auto-Idempotency: true` marker.
 
-```go
-// Observability middleware
-transport := observability.NewHTTPMiddleware(provider)(http.DefaultTransport)
+The HTTP layer removes the internal marker before the request is sent. It is an SDK implementation detail, not a public API header.
 
-// Retry middleware
-transport = retry.NewHTTPMiddleware(retryOptions)(transport)
+## Observability
 
-// Authentication middleware
-transport = auth.NewHTTPMiddleware(authProvider)(transport)
-```
+Observability lives in `pkg/observability`.
 
-## API Surface Documentation
-
-### External APIs (Client-Facing)
-
-#### Client Construction
-
-```go
-func New(options ...Option) (*Client, error)
-func WithConfig(cfg *config.Config) Option
-func WithEnvironment(env config.Environment) Option
-func WithObservability(tracing, metrics, logging bool) Option
-func UseAllAPIs() Option
-```
-
-#### Service Access
-
-```go
-// Through client
-client.Entity.Organizations.CreateOrganization(...)
-client.Entity.Accounts.CreateAccount(...)
-client.Entity.Transactions.CreateTransaction(...)
-
-// Direct entity creation
-entity, err := entities.NewWithServiceURLs(serviceURLs, options...)
-```
-
-#### Configuration
-
-```go
-cfg, err := config.NewConfig(
-    config.WithEnvironment(config.EnvironmentProduction),
-    config.WithAccessManager(accessManager),
-    config.FromEnvironment(), // Load from env vars
-)
-```
-
-### Internal APIs (Package Interfaces)
-
-#### Model Conversion
-
-```go
-// SDK model to backend model
-mmodelOrg := org.ToMmodelOrganization()
-
-// Backend model to SDK model
-org := models.FromMmodelOrganization(mmodelOrg)
-```
-
-#### HTTP Client Interface
-
-```go
-type HTTPClient interface {
-    Do(req *http.Request) (*http.Response, error)
-    WithRetryOption(option retry.Option)
-    SetAuthToken(token string)
-}
-```
-
-#### Observability Interface
+The public provider interface is:
 
 ```go
 type Provider interface {
-    Tracer(name string) trace.Tracer
-    Meter(name string) metric.Meter
+    Tracer() trace.Tracer
+    Meter() metric.Meter
     Logger() Logger
-    IsEnabled() bool
     Shutdown(ctx context.Context) error
+    IsEnabled() bool
 }
 ```
 
-## Data Flow Analysis
-
-### Complete Transaction Workflow
-
-```mermaid
-sequenceDiagram
-    participant APP as Application
-    participant CLIENT as Client
-    participant CONFIG as Config
-    participant AUTH as Access Manager
-    participant ENTITY as Entity Service
-    participant VALIDATION as Validation
-    participant HTTP as HTTP Client
-    participant RETRY as Retry Logic
-    participant OBS as Observability
-    participant API as Midaz API
-
-    Note over APP,API: Organization Creation Flow
-
-    APP->>CLIENT: New() with functional options
-    CLIENT->>CONFIG: Initialize configuration
-    CONFIG->>AUTH: Setup authentication
-    AUTH-->>CONFIG: Return auth configuration
-    CONFIG-->>CLIENT: Return validated config
-    CLIENT->>ENTITY: Initialize service entities
-    ENTITY-->>CLIENT: Services ready
-
-    APP->>CLIENT: Entity.Organizations.CreateOrganization()
-    CLIENT->>ENTITY: CreateOrganization(input)
-    ENTITY->>VALIDATION: Validate input
-    VALIDATION-->>ENTITY: Validation result
-
-    alt Validation Success
-        ENTITY->>HTTP: Prepare HTTP request
-        HTTP->>OBS: Start span/metrics
-        HTTP->>RETRY: Execute with retry logic
-        RETRY->>API: POST /organizations
-        API-->>RETRY: Response
-        RETRY-->>HTTP: Final response
-        HTTP->>OBS: Record metrics/end span
-        HTTP-->>ENTITY: Response data
-        ENTITY->>ENTITY: Convert mmodel to SDK model
-        ENTITY-->>CLIENT: Return Organization
-        CLIENT-->>APP: Return Organization
-    else Validation Failure
-        VALIDATION-->>ENTITY: Validation errors
-        ENTITY-->>CLIENT: Return validation error
-        CLIENT-->>APP: Return error
-    end
-```
-
-### Account Balance Query Flow
-
-```mermaid
-sequenceDiagram
-    participant APP as Application
-    participant CLIENT as Client
-    participant ACCOUNTS as AccountsService
-    participant CACHE as Balance Cache
-    participant HTTP as HTTP Client
-    participant API as Midaz API
-
-    APP->>CLIENT: Entity.Accounts.GetBalance(orgID, ledgerID, accountID)
-    CLIENT->>ACCOUNTS: GetBalance()
-
-    ACCOUNTS->>CACHE: Check balance cache
-    alt Cache Hit
-        CACHE-->>ACCOUNTS: Return cached balance
-        ACCOUNTS-->>CLIENT: Return Balance
-    else Cache Miss
-        ACCOUNTS->>HTTP: GET /accounts/{id}/balance
-        HTTP->>API: Execute request
-        API-->>HTTP: Balance response
-        HTTP-->>ACCOUNTS: Process response
-        ACCOUNTS->>CACHE: Update cache
-        ACCOUNTS->>ACCOUNTS: Convert to SDK model
-        ACCOUNTS-->>CLIENT: Return Balance
-    end
-    CLIENT-->>APP: Return Balance
-```
-
-## Authentication & Security
-
-### Plugin-Based Authentication Architecture
-
-```mermaid
-graph TB
-    subgraph "Client Application"
-        APP[Application]
-        CONFIG[SDK Configuration]
-    end
-
-    subgraph "Access Manager Plugin"
-        PLUGIN[Access Manager]
-        TOKEN_CACHE[Token Cache]
-        REFRESH[Token Refresh Logic]
-    end
-
-    subgraph "Identity Provider"
-        IDP[Identity Provider<br/>OAuth2/OIDC]
-        TOKEN_ENDPOINT[Token Endpoint]
-    end
-
-    subgraph "Midaz Platform"
-        ONBOARDING[Onboarding API]
-        TRANSACTION[Transaction API]
-        AUTH_MIDDLEWARE[Authentication Middleware]
-    end
-
-    APP --> CONFIG
-    CONFIG --> PLUGIN
-    PLUGIN --> TOKEN_CACHE
-    PLUGIN --> REFRESH
-    REFRESH --> TOKEN_ENDPOINT
-    TOKEN_ENDPOINT --> IDP
-
-    PLUGIN --> AUTH_MIDDLEWARE
-    AUTH_MIDDLEWARE --> ONBOARDING
-    AUTH_MIDDLEWARE --> TRANSACTION
-```
-
-### Security Features
-
-1. **Token Management**:
-
-   - Automatic token refresh
-   - Secure token storage
-   - Token expiration handling
-
-2. **Request Security**:
-
-   - HTTPS enforcement
-   - Request signing (where applicable)
-   - Idempotency key generation
-
-3. **Error Security**:
-   - Sensitive data scrubbing from logs
-   - Error message sanitization
-   - PII protection in traces
-
-**Configuration**:
+The root client creates a disabled provider by default. You can enable or inject observability with:
 
 ```go
-accessManager := auth.AccessManager{
-    Enabled:      true,
-    Address:      "https://auth.example.com",
-    ClientID:     os.Getenv("CLIENT_ID"),
-    ClientSecret: os.Getenv("CLIENT_SECRET"),
-}
-```
-
-## Observability & Monitoring
-
-### OpenTelemetry Integration
-
-```mermaid
-graph LR
-    subgraph "SDK Operations"
-        HTTP[HTTP Requests]
-        VALIDATION[Validation]
-        CONVERSION[Model Conversion]
-        RETRY[Retry Operations]
-    end
-
-    subgraph "OpenTelemetry SDK"
-        TRACER[Tracer]
-        METER[Meter]
-        LOGGER[Logger]
-        PROPAGATOR[Context Propagator]
-    end
-
-    subgraph "Exporters"
-        OTLP[OTLP Exporter]
-        CONSOLE[Console Exporter]
-        PROMETHEUS[Prometheus Exporter]
-    end
-
-    subgraph "Observability Backend"
-        JAEGER[Jaeger<br/>Tracing]
-        PROMETHEUS_SERVER[Prometheus<br/>Metrics]
-        ELK[ELK Stack<br/>Logging]
-    end
-
-    HTTP --> TRACER
-    VALIDATION --> TRACER
-    CONVERSION --> METER
-    RETRY --> METER
-
-    TRACER --> OTLP
-    METER --> OTLP
-    LOGGER --> CONSOLE
-
-    OTLP --> JAEGER
-    OTLP --> PROMETHEUS_SERVER
-    CONSOLE --> ELK
-```
-
-### Metrics Collected
-
-**Request Metrics**:
-
-- `midaz.sdk.request.total`: Total requests by service/operation
-- `midaz.sdk.request.duration`: Request latency percentiles
-- `midaz.sdk.request.error.total`: Error count by type
-
-**Operation Metrics**:
-
-- `midaz.sdk.validation.duration`: Validation time
-- `midaz.sdk.conversion.duration`: Model conversion time
-- `midaz.sdk.retry.attempts`: Retry attempt counts
-
-**Resource Metrics**:
-
-- `midaz.sdk.account.operations`: Account operations
-- `midaz.sdk.transaction.operations`: Transaction operations
-- `midaz.sdk.organization.operations`: Organization operations
-
-## Configuration Management
-
-### Environment-Based Configuration
-
-```mermaid
-graph TB
-    subgraph "Configuration Sources"
-        ENV_VARS[Environment Variables]
-        CONFIG_FILE[.env File]
-        FUNCTIONAL_OPTS[Functional Options]
-        DEFAULTS[Default Values]
-    end
-
-    subgraph "Configuration Resolution"
-        RESOLVER[Config Resolver]
-        VALIDATOR[Config Validator]
-        MAPPER[Service URL Mapper]
-    end
-
-    subgraph "Service Configuration"
-        ONBOARDING_URL[Onboarding Service URL]
-        TRANSACTION_URL[Transaction Service URL]
-        AUTH_CONFIG[Authentication Config]
-        HTTP_CONFIG[HTTP Client Config]
-        OBSERVABILITY_CONFIG[Observability Config]
-    end
-
-    ENV_VARS --> RESOLVER
-    CONFIG_FILE --> RESOLVER
-    FUNCTIONAL_OPTS --> RESOLVER
-    DEFAULTS --> RESOLVER
-
-    RESOLVER --> VALIDATOR
-    VALIDATOR --> MAPPER
-
-    MAPPER --> ONBOARDING_URL
-    MAPPER --> TRANSACTION_URL
-    MAPPER --> AUTH_CONFIG
-    MAPPER --> HTTP_CONFIG
-    MAPPER --> OBSERVABILITY_CONFIG
-```
-
-### Environment Support
-
-**Local Development**:
-
-```
-MIDAZ_ENVIRONMENT=local
-MIDAZ_ONBOARDING_URL=http://localhost:3000/v1
-MIDAZ_TRANSACTION_URL=http://localhost:3001/v1
-```
-
-**Development/Staging**:
-
-```
-MIDAZ_ENVIRONMENT=development
-MIDAZ_BASE_URL=https://api.dev.midaz.io
-```
-
-**Production**:
-
-```
-MIDAZ_ENVIRONMENT=production
-MIDAZ_BASE_URL=https://api.midaz.io
-```
-
-## Error Handling Strategy
-
-### Error Classification
-
-```mermaid
-graph TB
-    subgraph "Error Types"
-        VALIDATION[ValidationError<br/>Input validation failures]
-        AUTH[AuthenticationError<br/>Token/auth issues]
-        AUTHORIZATION[AuthorizationError<br/>Permission denials]
-        NOT_FOUND[NotFoundError<br/>Resource not found]
-        CONFLICT[ConflictError<br/>Resource conflicts]
-        NETWORK[NetworkError<br/>Connection issues]
-        SERVER[ServerError<br/>API server errors]
-        TIMEOUT[TimeoutError<br/>Request timeouts]
-        RATE_LIMIT[RateLimitError<br/>Rate limiting]
-    end
-
-    subgraph "Error Handling"
-        RETRY_LOGIC[Automatic Retry<br/>For transient errors]
-        ERROR_ENRICHMENT[Error Enrichment<br/>Add context/suggestions]
-        STRUCTURED_ERRORS[Structured Errors<br/>Field-level details]
-        ERROR_LOGGING[Error Logging<br/>With correlation IDs]
-    end
-
-    NETWORK --> RETRY_LOGIC
-    TIMEOUT --> RETRY_LOGIC
-    RATE_LIMIT --> RETRY_LOGIC
-    SERVER --> RETRY_LOGIC
-
-    VALIDATION --> ERROR_ENRICHMENT
-    AUTH --> ERROR_ENRICHMENT
-    AUTHORIZATION --> ERROR_ENRICHMENT
-
-    VALIDATION --> STRUCTURED_ERRORS
-
-    ALL --> ERROR_LOGGING
-```
-
-### Error Response Structure
-
-```go
-type SDKError struct {
-    Type        ErrorType         `json:"type"`
-    Message     string           `json:"message"`
-    Code        string           `json:"code,omitempty"`
-    Details     ErrorDetails     `json:"details,omitempty"`
-    FieldErrors []FieldError     `json:"field_errors,omitempty"`
-    Suggestions []string         `json:"suggestions,omitempty"`
-    TraceID     string           `json:"trace_id,omitempty"`
-    Retryable   bool            `json:"retryable"`
-}
-
-type FieldError struct {
-    Field   string `json:"field"`
-    Message string `json:"message"`
-    Code    string `json:"code,omitempty"`
-    Value   any    `json:"value,omitempty"`
-}
-```
-
-## Performance & Concurrency
-
-### Concurrency Patterns
-
-**Worker Pool Pattern**:
-
-```go
-// Process 1000 transactions with 10 workers
-results := concurrent.WorkerPool(ctx, transactions,
-    func(ctx context.Context, tx Transaction) (Result, error) {
-        return processTransaction(ctx, tx)
-    },
-    concurrent.WithWorkers(10),
-    concurrent.WithBufferSize(100),
-    concurrent.WithRateLimit(500), // 500 ops/sec
+provider, err := observability.New(context.Background(),
+    observability.WithServiceName("payments-api"),
+    observability.WithServiceVersion("1.0.0"),
+    observability.WithEnvironment("production"),
+    observability.WithComponentEnabled(true, true, true),
+    observability.WithCollectorEndpoint("localhost:4317"),
 )
-```
-
-**Batch Processing**:
-
-```go
-// Process accounts in batches of 50
-results := concurrent.Batch(ctx, accounts, 50,
-    func(ctx context.Context, batch []Account) ([]Result, error) {
-        return client.BulkUpdateAccounts(ctx, batch)
-    },
-    concurrent.WithWorkers(5),
-)
-```
-
-### Performance Optimizations
-
-1. **Connection Pooling**: Reusable HTTP connections
-2. **Response Streaming**: Large response streaming support
-3. **JSON Optimization**: Custom JSON marshaling for performance
-4. **Memory Management**: Object pooling for frequently used structures
-5. **Caching**: Response caching for read-heavy operations
-
-## Extension Points
-
-### Custom Middleware
-
-```go
-// Custom HTTP middleware
-type CustomMiddleware struct {
-    next http.RoundTripper
+if err != nil {
+    return err
 }
+defer provider.Shutdown(context.Background())
 
-func (m *CustomMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
-    // Custom logic before request
-    resp, err := m.next.RoundTrip(req)
-    // Custom logic after response
-    return resp, err
-}
-```
-
-### Custom Observability Provider
-
-```go
-type CustomObservabilityProvider struct {
-    // Custom implementation
-}
-
-func (p *CustomObservabilityProvider) Tracer(name string) trace.Tracer {
-    // Custom tracer implementation
-}
-
-// Use custom provider
-client, err := client.New(
-    client.WithObservabilityProvider(customProvider),
+c, err := client.New(
+    client.WithObservabilityProvider(provider),
     client.UseAllAPIs(),
 )
 ```
 
-### Custom Validation Rules
+`observability.WithCollectorEndpoint(...)` configures OTLP gRPC exporters. Pass the endpoint as `host:port`, such as:
+
+```text
+localhost:4317
+otel-collector:4317
+```
+
+Do not include `http://` or `https://` in the OTLP gRPC endpoint value.
+
+When the corresponding observability components are enabled, outbound entity requests can:
+
+- create HTTP spans when tracing is enabled,
+- inject W3C trace context and baggage into request headers,
+- record request metrics through `MetricsCollector` when metrics are enabled,
+- use the provider logger for SDK warnings or errors when logging is enabled.
+
+The SDK does not read `MIDAZ_OTEL_ENDPOINT` or `MIDAZ_LOG_LEVEL` in `config.FromEnvironment()`. Configure observability in code.
+
+## Models and validation
+
+The `models` package contains public SDK types. These types are the boundary between application code and entity services.
+
+Common model responsibilities include:
+
+- request input types such as `CreateOrganizationInput`, `CreateAccountInput`, and `CreateTransactionInput`
+- fluent builders such as `models.NewCreateOrganizationInput(...)`
+- response types such as `Organization`, `Ledger`, `Account`, `Transaction`, `Holder`, and `Alias`
+- list options and list responses
+- pagination metadata helpers
+- CRM holder and alias models
+- transaction DSL and send-based transaction inputs
+- validation methods on selected input types
+- conversion helpers between SDK models and Midaz backend model shapes
+
+Validation happens primarily in model `Validate()` methods and service-level required parameter checks. The SDK does not provide a runtime system for custom validation rule registration.
+
+## Pagination
+
+List methods use `models.ListOptions` and `models.ListResponse[T]`.
 
 ```go
-validator, err := validation.NewValidator(
-    validation.WithCustomRule("account_type", func(value any) error {
-        // Custom validation logic
-        return nil
-    }),
-    validation.WithStrictMode(true),
+options := models.NewListOptions().
+    WithLimit(50).
+    WithPage(1).
+    WithFilter("status", "ACTIVE")
+
+accounts, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
+if err != nil {
+    return err
+}
+
+for _, account := range accounts.Items {
+    fmt.Println(account.ID)
+}
+
+if accounts.Pagination.HasNextPage() {
+    nextOptions := accounts.Pagination.NextPageOptions()
+    _ = nextOptions
+}
+```
+
+Cursor support is endpoint-specific. `WithCursor(...)` sets the cursor query parameter, and transaction listing has explicit cursor-aware behavior.
+
+## CRM support
+
+CRM support is implemented through two entity services:
+
+- `Holders`
+- `Aliases`
+
+CRM requests use the `crm` service URL and send the organization context through:
+
+```text
+X-Organization-Id: <organizationID>
+```
+
+Example:
+
+```go
+holders, err := c.Entity.Holders.ListHolders(
+    ctx,
+    orgID,
+    models.NewListOptions().WithLimit(20),
+)
+if err != nil {
+    return err
+}
+
+alias, err := c.Entity.Aliases.CreateAlias(
+    ctx,
+    orgID,
+    holderID,
+    &models.CreateAliasInput{
+        LedgerID:  ledgerID,
+        AccountID: accountID,
+        Metadata: map[string]any{
+            "label": "primary account alias",
+        },
+    },
 )
 ```
 
-## Deployment & Environment Support
+If no CRM URL is configured, the entity layer falls back to the onboarding URL. For local development, prefer setting `MIDAZ_CRM_URL=http://localhost:4003/v1` or using `client.WithCRMURL(...)`.
 
-### Environment Configuration Matrix
+## Security boundaries
 
-| Environment | Onboarding URL                | Transaction URL                | Authentication | Debug        |
-| ----------- | ----------------------------- | ------------------------------ | -------------- | ------------ |
-| Local       | `localhost:3000/v1`           | `localhost:3001/v1`            | Optional       | Enabled      |
-| Development | `api.dev.midaz.io/onboarding` | `api.dev.midaz.io/transaction` | Required       | Configurable |
-| Production  | `api.midaz.io/onboarding`     | `api.midaz.io/transaction`     | Required       | Disabled     |
+The SDK includes outbound request validation in `pkg/security`. The HTTP layer validates parsed request URLs before executing requests.
 
-### Container Deployment
+The SDK also redacts sensitive values in debug logging, including:
+
+- `Authorization`
+- cookies
+- `X-Idempotency`
+- `X-Tenant-ID`
+
+Debug mode logs request and response metadata. Request and response bodies are redacted by length rather than printed directly.
+
+## What the SDK does not provide
+
+The current codebase does not implement these features:
+
+- automatic `.env` loading inside the SDK
+- automatic token refresh
+- request signing
+- custom validation rule registration
+- response streaming APIs
+- SDK-level caching
+- non-existent client middleware constructors
+- field-level ER diagrams as a source of truth
+- automatic observability configuration from environment variables
+
+Use application code or infrastructure around the SDK when you need those capabilities.
+
+## Local development
+
+Create a local `.env` from the example when you want shell-based configuration:
+
+```bash
+make set-env
+```
+
+The SDK still reads only the process environment. If your application uses `.env`, load it before calling `config.NewConfig(config.FromEnvironment())`.
+
+Run the main verification commands:
+
+```bash
+go build ./...
+go test ./...
+make verify-sdk
+```
+
+Use `make ci` for the full local pipeline when you need linting, security scanning, tests, coverage, and SDK compatibility checks.
+
+## Docker guidance for examples and applications
+
+This repository is a Go library, not a single long-running service. A Dockerfile for the repository should either:
+
+1. build all packages to validate the library, or
+2. build a specific runnable example application.
+
+For library validation, use:
 
 ```dockerfile
-FROM golang:1.24-alpine AS builder
-WORKDIR /app
+FROM golang:1.26 AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
-RUN go mod tidy && go build -o app
-
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-COPY --from=builder /app/app /usr/local/bin/app
-CMD ["app"]
+RUN go build ./...
 ```
 
-### Kubernetes Configuration
+For a runnable example, target an example with a `main` package:
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: midaz-sdk-app
-spec:
-  template:
-    spec:
-      containers:
-        - name: app
-          image: midaz-sdk-app:latest
-          env:
-            - name: MIDAZ_ENVIRONMENT
-              value: "production"
-            - name: MIDAZ_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: midaz-credentials
-                  key: client-id
-            - name: PLUGIN_AUTH_ENABLED
-              value: "true"
+```dockerfile
+FROM golang:1.26 AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /out/mass-demo-generator ./examples/mass-demo-generator
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /out/mass-demo-generator /usr/local/bin/mass-demo-generator
+ENTRYPOINT ["/usr/local/bin/mass-demo-generator"]
 ```
 
-## Example Applications & Demonstrations
+Pass SDK configuration through environment variables at runtime:
 
-The SDK includes comprehensive example applications demonstrating various usage patterns and advanced features.
+```bash
+docker run --rm \
+  -e MIDAZ_BASE_URL=https://midaz.example.com \
+  -e MIDAZ_CRM_URL=https://crm.midaz.example.com/v1 \
+  -e PLUGIN_AUTH_ENABLED=false \
+  midaz-mass-demo-generator
+```
 
-### Mass Demo Generator (`examples/mass-demo-generator/`)
+Do not create Docker guidance that assumes the library itself starts a server.
 
-A comprehensive demo data generation application showcasing advanced SDK capabilities:
+## Extension points
 
-**Key Features**:
+Use these supported extension points:
 
-- **Concurrent Processing**: Parallel entity creation with configurable worker pools
-- **Circuit Breaker Integration**: Automatic API protection with failure detection
-- **DSL Transaction Patterns**: Complex transaction flows using domain-specific language
-- **Routing System**: Complete account types, operation routes, and transaction routes
-- **Integrity Verification**: Balance checks and double-entry validation
-- **Comprehensive Reporting**: Detailed HTML and JSON reports with performance metrics
+| Need | Extension point |
+| --- | --- |
+| Custom service URLs | `client.WithBaseURL`, `client.WithOnboardingURL`, `client.WithTransactionURL`, `client.WithCRMURL`, or config equivalents. |
+| Custom HTTP behavior | `client.WithHTTPClient(...)` or `config.WithHTTPClient(...)`. |
+| Retry tuning | `client.WithRetries(...)`, `client.DisableRetries()`, or `client.WithCustomRetryPolicy(...)`. |
+| Access Manager authentication | `config.WithAccessManager(...)` or `config.FromEnvironment()`. |
+| Observability | `client.WithObservabilityProvider(...)`, `client.WithObservabilityOptions(...)`, or `client.WithCollectorEndpoint(...)`. |
+| Tenant compatibility header | `client.WithTenantID(...)`, `config.WithTenantID(...)`, or `entities.WithTenantID(ctx, ...)`. |
+| Per-request idempotency | `entities.WithIdempotencyKey(ctx, ...)` or transaction input idempotency. |
+| Pagination | `models.NewListOptions()` and `models.ListResponse[T]` pagination helpers. |
+| Error branching | `pkg/errors` helper checkers and `errors.As`. |
 
-**Generated Data Structure**:
+## Next steps
 
-1. Organizations with realistic business data and addresses
-2. Ledgers with proper metadata and configuration
-3. Assets including fiat currencies, cryptocurrencies, and loyalty points
-4. Account types (checking, savings, credit, expense, revenue, liability, equity)
-5. Accounts with hierarchical relationships and type associations
-6. Portfolios and segments for account organization
-7. Operation routes and transaction routes for validation
-8. Transactions using both standard operations and DSL patterns
-
-**Performance Characteristics**:
-
-- Configurable concurrency levels (1-50 workers)
-- Circuit breaker protection with failure thresholds
-- Rate limiting and throttling capabilities
-- Real-time progress monitoring with TPS metrics
-- Batch processing optimization for high throughput
-
-### Other Examples
-
-- **`workflow-with-entities/`**: Complete end-to-end workflow implementation
-- **`concurrency-example/`**: Concurrent operations and balance fetching
-- **`observability-demo/`**: Observability and monitoring setup
-- **`configuration-examples/`**: SDK configuration patterns and best practices
-- **`validation-example/`**: Input validation and error handling patterns
-- **`retry-example/`**: Retry mechanisms and error handling
-
----
-
-**Document Version**: 1.1  
-**Last Updated**: 2025-09-28  
-**SDK Version**: 2.0.0  
-**Architecture Review Status**: ✅ Complete
+- Use `README.md` for quick-start usage.
+- Use `docs/environment.md` for environment variable details.
+- Use `docs/errors.md` for error handling patterns.
+- Use `docs/pagination.md` for list and cursor behavior.
+- Use `docs/tracing.md` for OpenTelemetry examples.
+- Use `docs/mapping/external_apis.md` for the public SDK surface.
+- Use generated Go docs from `make docs` or `make godoc` when you need package-level API details.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,205 +1,266 @@
-# Environment Variables in the Midaz Go SDK
+# Environment configuration
 
-The Midaz Go SDK provides comprehensive environment variable support for configuration, allowing you to customize the SDK's behavior without changing code. This document explains all available environment variables and their usage.
+This guide explains which environment variables the Midaz Go SDK reads and how they affect client behavior.
 
-## Table of Contents
+The SDK reads environment variables only from the current process environment. It does **not** load `.env` files by itself. If you keep configuration in a `.env` file, load it before creating the SDK config.
 
-- [Overview](#overview)
-- [Authentication](#authentication)
-- [Environment Configuration](#environment-configuration)
-- [API URLs](#api-urls)
-- [HTTP Configuration](#http-configuration)
-- [Retry Configuration](#retry-configuration)
-- [Feature Flags](#feature-flags)
-- [Observability Configuration](#observability-configuration)
-- [Testing Configuration](#testing-configuration)
-- [Example Configuration](#example-configuration)
+```go
+_ = godotenv.Load()
 
-## Overview
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
 
-Environment variables provide a flexible way to configure the SDK for different environments and use cases. You can set these variables in your operating system environment or in a `.env` file at the root of your project.
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.UseEntityAPI(),
+)
+if err != nil {
+    return err
+}
 
-To use a `.env` file, either:
+_ = c
+```
 
-1. Load it manually using a package like `godotenv`:
-   ```go
-   import "github.com/joho/godotenv"
+## Supported environment variables
 
-   func init() {
-       godotenv.Load() // Loads .env file from the current directory
-   }
-   ```
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `MIDAZ_ENVIRONMENT` | Stores the environment label. Valid values: `local`, `development`, `production`. | `local` |
+| `MIDAZ_BASE_URL` | Base URL used to derive Ledger and CRM service URLs. | Local defaults |
+| `MIDAZ_ONBOARDING_URL` | Explicit Onboarding service URL. | Local Ledger URL |
+| `MIDAZ_TRANSACTION_URL` | Explicit Transaction service URL. | Local Ledger URL |
+| `MIDAZ_CRM_URL` | Explicit CRM service URL. | Local CRM URL |
+| `MIDAZ_TIMEOUT` | HTTP timeout in seconds. | `60` |
+| `MIDAZ_USER_AGENT` | User agent header value. | SDK version user agent |
+| `MIDAZ_DEBUG` | Enables debug logging when set to `true`. | `false` |
+| `MIDAZ_MAX_RETRIES` | Maximum retry attempts. | `3` |
+| `MIDAZ_ENABLE_RETRIES` | Disables retries only for direct `entities.NewHTTPClient` usage when set to `false`. | Enabled |
+| `MIDAZ_IDEMPOTENCY` | Enables or disables SDK idempotency support. | `true` |
+| `PLUGIN_AUTH_ENABLED` | Enables Access Manager authentication when set to `true`. | `false` |
+| `PLUGIN_AUTH_ADDRESS` | Access Manager base address. | Empty |
+| `MIDAZ_CLIENT_ID` | Access Manager client ID. | Empty |
+| `MIDAZ_CLIENT_SECRET` | Access Manager client secret. | Empty |
+| `MIDAZ_SKIP_AUTH_CHECK` | Testing-only bypass for missing Access Manager address validation. | `false` |
 
-2. Or rely on the SDK's examples and tools that automatically look for a `.env` file.
+`MIDAZ_AUTH_TOKEN` is not a configuration environment variable. `config.FromEnvironment()` does not read it.
+
+## Loading `.env` files
+
+The SDK calls `os.Getenv`. It does not parse `.env` files automatically.
+
+If you want to use `.env`, load it in your application before you call `config.FromEnvironment()`.
+
+```go
+import (
+    "github.com/joho/godotenv"
+
+    client "github.com/LerianStudio/midaz-sdk-golang/v2"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
+)
+
+func newClient() (*client.Client, error) {
+    _ = godotenv.Load()
+
+    cfg, err := config.NewConfig(config.FromEnvironment())
+    if err != nil {
+        return nil, err
+    }
+
+    return client.New(
+        client.WithConfig(cfg),
+        client.UseEntityAPI(),
+    )
+}
+```
 
 ## Authentication
 
-| Variable | Purpose | Default | Required |
-|----------|---------|---------|----------|
-| `MIDAZ_AUTH_TOKEN` | Authentication token for the Midaz API | None | Yes (except for testing) |
+The environment-based authentication path uses Access Manager.
 
-Example:
-```
-MIDAZ_AUTH_TOKEN=midaz-auth-token-123456
-```
-
-## Environment Configuration
-
-| Variable | Purpose | Default | Options |
-|----------|---------|---------|---------|
-| `MIDAZ_ENVIRONMENT` | Sets which Midaz environment to connect to | `local` | `local`, `development`, `production` |
-
-Example:
-```
-MIDAZ_ENVIRONMENT=development
+```env
+PLUGIN_AUTH_ENABLED=true
+PLUGIN_AUTH_ADDRESS=http://localhost:4000
+MIDAZ_CLIENT_ID=your-client-id
+MIDAZ_CLIENT_SECRET=your-client-secret
 ```
 
-## SDK Configuration
+When `PLUGIN_AUTH_ENABLED=true`, the entity client requests a token from:
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_USER_AGENT` | User agent string for API requests | `midaz-go-sdk/1.0.0` | Used for request identification |
-
-Example:
-```
-MIDAZ_USER_AGENT=MyApp/1.2.3 (Midaz-Go-SDK/1.0.0)
+```text
+{PLUGIN_AUTH_ADDRESS}/v1/login/oauth/access_token
 ```
 
-## API URLs
+The request sends a client credentials payload using `MIDAZ_CLIENT_ID` and `MIDAZ_CLIENT_SECRET`. The returned `accessToken` becomes the `Authorization: Bearer ...` header for Midaz API requests.
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_BASE_URL` | Base URL for all services | Depends on environment | Used if specific URLs not provided |
-| `MIDAZ_ONBOARDING_URL` | URL for the Onboarding API | `http://localhost:3000/v1` (local) | Overrides base URL |
-| `MIDAZ_TRANSACTION_URL` | URL for the Transaction API | `http://localhost:3001/v1` (local) | Overrides base URL |
+If `PLUGIN_AUTH_ENABLED=true` and `PLUGIN_AUTH_ADDRESS` is empty, config validation fails unless `MIDAZ_SKIP_AUTH_CHECK=true` is set for tests.
 
-The URLs take precedence in this order:
-1. Specific URL (`MIDAZ_ONBOARDING_URL`, `MIDAZ_TRANSACTION_URL`)
-2. Base URL with service path (`MIDAZ_BASE_URL/service`)
-3. Environment-based default URLs
+## Service URLs and precedence
 
-Example for local development:
-```
-MIDAZ_BASE_URL=http://localhost
-MIDAZ_ONBOARDING_URL=http://localhost:3000/v1
-MIDAZ_TRANSACTION_URL=http://localhost:3001/v1
-```
+`config.FromEnvironment()` applies URL variables in this order:
 
-Example for custom deployment:
-```
+1. `MIDAZ_BASE_URL`
+2. Service-specific overrides: `MIDAZ_ONBOARDING_URL`, `MIDAZ_TRANSACTION_URL`, and `MIDAZ_CRM_URL`
+3. Existing config defaults for any service you do not override
+
+Service-specific URLs override `MIDAZ_BASE_URL` for their service.
+
+```env
 MIDAZ_BASE_URL=https://midaz.example.com
+MIDAZ_ONBOARDING_URL=https://onboarding.example.com/v1
 ```
 
-## HTTP Configuration
+With this configuration:
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_TIMEOUT` | Timeout in seconds for HTTP requests | `60` | Controls request timeouts |
-| `MIDAZ_DEBUG` | Enable debug mode with verbose logging | `false` | Set to "true" for detailed logs |
+- Onboarding uses `https://onboarding.example.com/v1`
+- Transaction uses `https://midaz.example.com/v1`
+- CRM uses `https://midaz.example.com/v1`
 
-Example:
+`MIDAZ_BASE_URL` derives service URLs and appends `/v1` when needed. For localhost without a port, the SDK uses port `3002` for Ledger services and port `4003` for CRM.
+
+```env
+MIDAZ_BASE_URL=http://localhost
 ```
+
+This resolves to:
+
+```text
+Onboarding:  http://localhost:3002/v1
+Transaction: http://localhost:3002/v1
+CRM:         http://localhost:4003/v1
+```
+
+Note: in the current codebase, `MIDAZ_ENVIRONMENT` stores the environment label but does not recompute service URLs by itself after defaults are initialized. Set `MIDAZ_BASE_URL` or explicit service URLs when you need non-local endpoints.
+
+## HTTP behavior
+
+Set `MIDAZ_TIMEOUT` as an integer number of seconds.
+
+```env
 MIDAZ_TIMEOUT=30
+MIDAZ_USER_AGENT=MyService/1.0
 MIDAZ_DEBUG=true
 ```
 
-## Retry Configuration
+`MIDAZ_DEBUG=true` enables verbose request and response logging. Any value other than `true` leaves debug logging disabled.
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_MAX_RETRIES` | Maximum number of retry attempts | `3` | Controls retry attempts for failed requests |
-| `MIDAZ_ENABLE_RETRIES` | Enable retry mechanism | `true` | Set to "false" to disable retries |
-| `MIDAZ_RETRY_WAIT_MIN` | Minimum wait time between retries (ms) | `1000` | Initial delay before first retry |
-| `MIDAZ_RETRY_WAIT_MAX` | Maximum wait time between retries (ms) | `30000` | Maximum delay between retries |
+## Retry behavior
 
-Example:
-```
+The SDK supports retry configuration from both config and the entity HTTP layer.
+
+```env
 MIDAZ_MAX_RETRIES=5
-MIDAZ_ENABLE_RETRIES=true
-MIDAZ_RETRY_WAIT_MIN=500
-MIDAZ_RETRY_WAIT_MAX=10000
 ```
 
-## Feature Flags
+`MIDAZ_MAX_RETRIES` is read by:
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_IDEMPOTENCY` | Enable automatic idempotency key generation | `true` | Controls idempotency for API requests |
+- `config.FromEnvironment()`
+- `entities.NewHTTPClient()`
 
-Example:
+For the normal client path, use `config.FromEnvironment()` and `client.WithConfig(cfg)`. The client applies `cfg.MaxRetries` to the entity HTTP client during setup.
+
+`MIDAZ_ENABLE_RETRIES=false` is read only by `entities.NewHTTPClient()`. The normal client config does not read this variable, and client setup may override the entity HTTP value from config defaults.
+
+To disable retries at the client level, use `client.DisableRetries()`.
+
+```go
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
+
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.DisableRetries(),
+    client.UseEntityAPI(),
+)
 ```
+
+The SDK does not read retry wait environment variables. Configure retry timing in code with `client.WithRetries(...)` or config retry options.
+
+## Idempotency behavior
+
+`MIDAZ_IDEMPOTENCY` controls whether the SDK may add idempotency headers.
+
+```env
 MIDAZ_IDEMPOTENCY=true
 ```
 
-## Observability Configuration
+Idempotency support is enabled by default. Set it to `false` to disable SDK-generated idempotency behavior.
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_OTEL_ENDPOINT` | OpenTelemetry collector endpoint | None | For sending traces/metrics |
-| `MIDAZ_LOG_LEVEL` | Logging level | `info` | `debug`, `info`, `warn`, `error` |
+Automatic key generation is opt-in per request path. The entity HTTP client generates an `X-Idempotency` UUID only when all of these are true:
 
-Observability is primarily configured through code using the SDK's options:
+- Idempotency support is enabled.
+- The HTTP method is unsafe: `POST`, `PUT`, `PATCH`, or `DELETE`.
+- The request does not already include `X-Idempotency`.
+- The request includes the internal opt-in header `X-Midaz-Auto-Idempotency: true`.
+
+The SDK removes `X-Midaz-Auto-Idempotency` before sending the request.
+
+Transaction creation opts in automatically. If you set `CreateTransactionInput.IdempotencyKey`, the SDK uses your key. Otherwise, it generates one when idempotency is enabled.
+
+You can also provide an explicit key through context:
+
+```go
+ctx := entities.WithIdempotencyKey(context.Background(), "transaction-2026-04-27-001")
+```
+
+Unsafe requests without an `X-Idempotency` header do not retry, even when retries are enabled.
+
+## Observability
+
+Observability is programmatic only. The SDK does not read `MIDAZ_OTEL_ENDPOINT` or `MIDAZ_LOG_LEVEL`.
+
+Configure observability in code and pass the provider to the client.
 
 ```go
 provider, err := observability.New(ctx,
-  observability.WithServiceName("my-service"),
-  observability.WithEnvironment("production"),
-  observability.WithComponentEnabled(true, true, true), // Enable tracing, metrics, logging
+    observability.WithServiceName("my-service"),
+    observability.WithEnvironment("production"),
+    observability.WithComponentEnabled(true, true, true),
 )
+if err != nil {
+    return err
+}
 
-client, err := client.New(
-  client.WithObservabilityProvider(provider),
-  // Other options...
+c, err := client.New(
+    client.WithObservabilityProvider(provider),
+    client.UseEntityAPI(),
 )
+if err != nil {
+    return err
+}
+
+_ = c
 ```
 
-## Testing Configuration
+## Example environment
 
-| Variable | Purpose | Default | Notes |
-|----------|---------|---------|-------|
-| `MIDAZ_SKIP_AUTH_CHECK` | Skip auth token validation | `false` | For testing only |
-
-Example:
-```
-MIDAZ_SKIP_AUTH_CHECK=true
-```
-
-## Example Configuration
-
-Here's a complete example of a `.env` file with all available configuration options:
-
-```
-# Authentication
-MIDAZ_AUTH_TOKEN=midaz-auth-token-123456
-
-# Environment configuration
+```env
+# Environment label
 MIDAZ_ENVIRONMENT=local
 
-# SDK configuration
-MIDAZ_USER_AGENT=MyApp/1.0.0 (Midaz-Go-SDK/1.0.0)
-
-# API URLs
+# Service URLs
 MIDAZ_BASE_URL=http://localhost
-MIDAZ_ONBOARDING_URL=http://localhost:3000/v1
-MIDAZ_TRANSACTION_URL=http://localhost:3001/v1
+MIDAZ_ONBOARDING_URL=http://localhost:3002/v1
+MIDAZ_TRANSACTION_URL=http://localhost:3002/v1
+MIDAZ_CRM_URL=http://localhost:4003/v1
 
-# HTTP configuration
+# Access Manager authentication
+PLUGIN_AUTH_ENABLED=true
+PLUGIN_AUTH_ADDRESS=http://localhost:4000
+MIDAZ_CLIENT_ID=your-client-id
+MIDAZ_CLIENT_SECRET=your-client-secret
+
+# HTTP behavior
 MIDAZ_TIMEOUT=30
-MIDAZ_DEBUG=true
+MIDAZ_USER_AGENT=MyService/1.0
+MIDAZ_DEBUG=false
 
-# Retry configuration
+# Retries
 MIDAZ_MAX_RETRIES=3
-MIDAZ_ENABLE_RETRIES=true
-MIDAZ_RETRY_WAIT_MIN=1000
-MIDAZ_RETRY_WAIT_MAX=30000
 
-# Feature flags
+# Idempotency
 MIDAZ_IDEMPOTENCY=true
-
-# Testing configuration (for development only)
-MIDAZ_SKIP_AUTH_CHECK=false
-
-# Observability configuration
-MIDAZ_OTEL_ENDPOINT=http://localhost:4318
-MIDAZ_LOG_LEVEL=debug
 ```

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,335 +1,201 @@
-# Error Handling in the Midaz Go SDK
+# Error handling in the Midaz Go SDK
 
-The Midaz Go SDK provides a comprehensive error handling system that helps you understand and respond to errors that occur during API interactions. This document explains the error handling architecture and best practices for working with errors.
+The SDK uses structured errors from `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors`. Most SDK failures are represented as `*errors.Error`, which preserves category, code, operation, resource, HTTP status, request ID, and the wrapped underlying error.
 
-## Table of Contents
-
-- [Error Types](#error-types)
-- [Error Details](#error-details)
-- [Error Checking Functions](#error-checking-functions)
-- [Error Handling Patterns](#error-handling-patterns)
-- [Retry Mechanism](#retry-mechanism)
-- [Best Practices](#best-practices)
-- [Example Usage](#example-usage)
-
-## Error Types
-
-The SDK provides several specialized error types to represent different failure categories:
-
-| Error Type | Description | Common Causes |
-|------------|-------------|--------------|
-| `ValidationError` | Input validation failed | Invalid field values, missing required fields |
-| `AuthenticationError` | Authentication failed | Invalid or expired auth token |
-| `AuthorizationError` | Unauthorized access | Insufficient permissions |
-| `ResourceNotFoundError` | Resource not found | Invalid ID, deleted resource |
-| `ConflictError` | Resource conflict | Duplicate resource, version conflict |
-| `RateLimitError` | Rate limit exceeded | Too many requests |
-| `ServiceError` | Backend service error | Internal server error, service unavailable |
-| `NetworkError` | Network or transport error | Connection issues, timeouts |
-| `ParseError` | Response parsing error | Invalid response format, schema mismatch |
-| `SDKError` | SDK internal error | Configuration errors, programming errors |
-
-These error types all implement the standard Go `error` interface and can be accessed from the `pkg/errors` package:
+## Core error type
 
 ```go
-import "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
-```
-
-## Error Details
-
-Each error includes detailed information to help with troubleshooting:
-
-| Field | Description | Example |
-|-------|-------------|---------|
-| `Type` | Error type identifier | `"validation_error"` |
-| `Code` | Specific error code | `"invalid_input"` |
-| `Message` | Human-readable error message | `"Validation failed: invalid account ID"` |
-| `StatusCode` | HTTP status code (when applicable) | `400` |
-| `Resource` | Resource type related to the error | `"account"` |
-| `ResourceID` | ID of the resource (when applicable) | `"acc_123"` |
-| `Details` | Additional error details | `{"field": "id", "reason": "must be UUID"}` |
-| `RequestID` | Request ID for support (when available) | `"req_abc123"` |
-
-You can access these details using the `ErrorDetails` interface:
-
-```go
-if details, ok := err.(errors.ErrorDetails); ok {
-    fmt.Printf("Error type: %s, code: %s, message: %s\n", 
-        details.ErrorType(), details.ErrorCode(), details.ErrorMessage())
+type Error struct {
+    Category   errors.ErrorCategory
+    Code       errors.ErrorCode
+    Message    string
+    Operation  string
+    Resource   string
+    ResourceID string
+    StatusCode int
+    RequestID  string
+    Err        error
 }
 ```
 
-## Error Checking Functions
+`*errors.Error` implements `error`, `Unwrap`, and `Is`, so it works with the standard library `errors.Is` and `errors.As` helpers.
 
-The SDK provides helper functions to check for specific error types:
+## Error categories
+
+| Category | Common meaning |
+| --- | --- |
+| `validation` | Invalid input or malformed request data |
+| `authentication` | Missing, invalid, or expired credentials |
+| `authorization` | Authenticated caller lacks permission |
+| `not_found` | Requested resource does not exist |
+| `conflict` | Duplicate resource, idempotency conflict, or state conflict |
+| `limit_exceeded` | Rate limit or quota exceeded |
+| `timeout` | Operation timed out |
+| `cancellation` | Context or caller cancelled the operation |
+| `internal` | SDK or backend internal failure |
+| `unprocessable` | Domain-specific failure such as insufficient balance |
+
+## Sentinel errors
+
+The package exposes sentinel values for stable matching:
+
+- `errors.ErrValidation`
+- `errors.ErrAuthentication`
+- `errors.ErrPermission`
+- `errors.ErrNotFound`
+- `errors.ErrAlreadyExists`
+- `errors.ErrIdempotency`
+- `errors.ErrRateLimit`
+- `errors.ErrTimeout`
+- `errors.ErrCancellation`
+- `errors.ErrInternal`
+- `errors.ErrInsufficientBalance`
+- `errors.ErrAccountEligibility`
+- `errors.ErrAssetMismatch`
+
+## Checking errors
+
+Prefer SDK helper functions when branching on operational behavior:
 
 ```go
-import "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+import sdkerrors "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
 
-// Check for specific error types
-if errors.IsValidationError(err) {
-    // Handle validation error
-}
-
-if errors.IsResourceNotFoundError(err) {
-    // Handle not found error
-}
-
-if errors.IsRateLimitError(err) {
-    // Handle rate limit error
-    retry := errors.GetRetryAfter(err)
-    fmt.Printf("Rate limit exceeded. Retry after %v\n", retry)
-}
-
-// Check for specific HTTP status codes
-if errors.IsStatusCode(err, 400) {
-    // Handle 400 Bad Request
-}
-```
-
-## Error Handling Patterns
-
-### Basic Error Handling
-
-```go
-org, err := client.Entity.Organizations.CreateOrganization(ctx, input)
+account, err := c.Entity.Accounts.GetAccount(ctx, orgID, ledgerID, accountID)
 if err != nil {
-    if errors.IsValidationError(err) {
-        // Handle validation error
-        fmt.Printf("Validation error: %s\n", err)
-        return err
+    switch {
+    case sdkerrors.IsNotFoundError(err):
+        return nil, fmt.Errorf("account %s was not found: %w", accountID, err)
+    case sdkerrors.IsAuthenticationError(err):
+        return nil, fmt.Errorf("authentication failed: %w", err)
+    case sdkerrors.IsRateLimitError(err):
+        return nil, fmt.Errorf("rate limited while fetching account: %w", err)
+    default:
+        return nil, fmt.Errorf("failed to fetch account: %w", err)
     }
-    
-    if errors.IsAuthenticationError(err) {
-        // Handle authentication error
-        fmt.Println("Authentication failed. Please check your credentials.")
-        return err
-    }
-    
-    // Handle other errors
-    fmt.Printf("Error creating organization: %s\n", err)
-    return err
 }
-
-// Use the organization
-fmt.Printf("Organization created with ID: %s\n", org.ID)
 ```
 
-### Getting Field-Level Validation Errors
+Common checkers include:
 
-For validation errors, you can access field-specific error details:
+- `IsValidationError(err)`
+- `IsNotFoundError(err)`
+- `IsAuthenticationError(err)`
+- `IsAuthorizationError(err)`
+- `IsPermissionError(err)`
+- `IsConflictError(err)`
+- `IsAlreadyExistsError(err)`
+- `IsIdempotencyError(err)`
+- `IsRateLimitError(err)`
+- `IsTimeoutError(err)`
+- `IsNetworkError(err)`
+- `IsCancellationError(err)`
+- `IsInternalError(err)`
+- `IsInsufficientBalanceError(err)`
+- `IsAccountEligibilityError(err)`
+- `IsAssetMismatchError(err)`
+
+## Reading error details
+
+Use accessors instead of type-specific concrete error names:
 
 ```go
-org, err := client.Entity.Organizations.CreateOrganization(ctx, input)
 if err != nil {
-    if errors.IsValidationError(err) {
-        if fieldErrs, ok := errors.GetFieldErrors(err); ok {
-            for field, fieldErr := range fieldErrs {
-                fmt.Printf("Field '%s' error: %s\n", field, fieldErr.Message)
-                
-                // Get suggestions if available
-                if len(fieldErr.Suggestions) > 0 {
-                    fmt.Printf("Suggestions: %v\n", fieldErr.Suggestions)
-                }
-            }
-        }
-        return err
-    }
-    
-    // Handle other errors
-    return err
+    category := sdkerrors.GetErrorCategory(err)
+    statusCode := sdkerrors.GetStatusCode(err)
+    details := sdkerrors.GetErrorDetails(err)
+
+    log.Printf(
+        "category=%s status=%d code=%s message=%s original=%v",
+        category,
+        statusCode,
+        details.Code,
+        details.Message,
+        details.OriginalError,
+    )
 }
 ```
 
-### Handling Retryable Errors
+If you need fields only available on `*errors.Error`, use `errors.As` from the standard library:
 
 ```go
-const maxRetries = 3
-
-var org *models.Organization
-var err error
-
-for attempt := 0; attempt < maxRetries; attempt++ {
-    org, err = client.Entity.Organizations.CreateOrganization(ctx, input)
-    if err == nil {
-        break
-    }
-    
-    if errors.IsRetryableError(err) {
-        delay := errors.GetRetryDelay(err, attempt)
-        fmt.Printf("Retryable error occurred, retrying in %v...\n", delay)
-        time.Sleep(delay)
-        continue
-    }
-    
-    // Non-retryable error, exit the loop
-    break
+var sdkErr *sdkerrors.Error
+if stderrors.As(err, &sdkErr) {
+    log.Printf(
+        "operation=%s resource=%s resource_id=%s request_id=%s",
+        sdkErr.GetOperation(),
+        sdkErr.GetResource(),
+        sdkErr.GetResourceID(),
+        sdkErr.GetRequestID(),
+    )
 }
-
-if err != nil {
-    // Handle the error
-    return err
-}
-
-// Use the organization
-fmt.Printf("Organization created with ID: %s\n", org.ID)
 ```
 
-## Retry Mechanism
+## Validation field errors
 
-The SDK includes a built-in retry mechanism for handling transient errors. By default, the SDK will automatically retry:
-
-1. Temporary network errors
-2. Rate limit errors (with appropriate backoff)
-3. Server errors (5xx status codes)
-4. Specific API errors marked as retryable
-
-You can configure the retry behavior using:
+Model validation can return regular errors or `pkg/validation.FieldErrors` depending on the validator used. Field-level errors live in the validation package, not `pkg/errors`:
 
 ```go
-// Through client options
-client, err := client.New(
-    client.WithRetries(3, 500*time.Millisecond, 5*time.Second),
-    // Other options...
+import "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation"
+
+if fieldErrors, ok := err.(*validation.FieldErrors); ok {
+    for _, fieldErr := range fieldErrors.GetFieldErrors() {
+        log.Printf("field=%s message=%s", fieldErr.Field, fieldErr.Message)
+    }
+}
+```
+
+## Retry behavior
+
+Retry policies live in `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry`, not `pkg/errors`.
+
+The SDK HTTP layer retries transient failures by default. Retryable HTTP status codes are:
+
+- `408 Request Timeout`
+- `429 Too Many Requests`
+- `500 Internal Server Error`
+- `502 Bad Gateway`
+- `503 Service Unavailable`
+- `504 Gateway Timeout`
+
+Root-client retry defaults are:
+
+- Max retries: `3`
+- Initial delay: `1s`
+- Max delay: `30s`
+- Backoff factor: `2.0`
+- Jitter factor: `0.25`
+
+Unsafe HTTP methods are retried only when an idempotency key is present. Attach one with:
+
+```go
+ctx = entities.WithIdempotencyKey(ctx, "request-unique-key")
+```
+
+Configure client retries with:
+
+```go
+c, err := client.New(
+    client.WithRetries(3, 100*time.Millisecond, 10*time.Second),
+    client.UseAllAPIs(),
 )
-
-// Or through environment variables
-// MIDAZ_MAX_RETRIES=3
-// MIDAZ_RETRY_WAIT_MIN=500
-// MIDAZ_RETRY_WAIT_MAX=5000
-// MIDAZ_ENABLE_RETRIES=true
 ```
 
-## Best Practices
-
-1. **Always Check Errors**: Always check for errors and handle them appropriately.
-
-2. **Use Type-Specific Handling**: Use the error checking functions to provide type-specific error handling.
-
-3. **Provide Meaningful Error Messages**: When propagating errors, add context to help with troubleshooting.
-
-4. **Log Error Details**: Log the full error details for debugging and monitoring.
-
-5. **Handle Retryable Errors**: Use the retry mechanism for transient errors.
-
-6. **Check Field Errors**: For validation errors, check field-specific errors to provide better user feedback.
-
-7. **Be Careful with Parsing Errors**: When getting error details, check that the type assertion is successful.
-
-## Example Usage
-
-### Complete Error Handling Example
+Or disable them:
 
 ```go
-func CreateAccount(ctx context.Context, client *client.Client, orgID, ledgerID string, input *models.CreateAccountInput) (*models.Account, error) {
-    // Validate input
-    if err := input.Validate(); err != nil {
-        return nil, fmt.Errorf("invalid input: %w", err)
-    }
-    
-    // Create the account
-    account, err := client.Entity.Accounts.CreateAccount(ctx, orgID, ledgerID, input)
-    if err != nil {
-        // Check specific error types
-        switch {
-        case errors.IsValidationError(err):
-            // Handle validation error
-            if fieldErrs, ok := errors.GetFieldErrors(err); ok {
-                for field, fieldErr := range fieldErrs {
-                    log.Printf("Field '%s' error: %s\n", field, fieldErr.Message)
-                }
-            }
-            return nil, fmt.Errorf("validation error creating account: %w", err)
-            
-        case errors.IsAuthenticationError(err):
-            // Handle authentication error
-            log.Println("Authentication failed. Please check your credentials.")
-            return nil, fmt.Errorf("authentication error creating account: %w", err)
-            
-        case errors.IsResourceNotFoundError(err):
-            // Handle not found error (e.g., ledger not found)
-            log.Printf("Resource not found: %v\n", err)
-            return nil, fmt.Errorf("resource not found creating account: %w", err)
-            
-        case errors.IsRateLimitError(err):
-            // Handle rate limit error
-            retry := errors.GetRetryAfter(err)
-            log.Printf("Rate limit exceeded. Retry after %v\n", retry)
-            return nil, fmt.Errorf("rate limit exceeded creating account: %w", err)
-            
-        default:
-            // Handle other errors
-            log.Printf("Error creating account: %v\n", err)
-            return nil, fmt.Errorf("error creating account: %w", err)
-        }
-    }
-    
-    log.Printf("Account created with ID: %s\n", account.ID)
-    return account, nil
-}
+c, err := client.New(
+    client.DisableRetries(),
+    client.UseAllAPIs(),
+)
 ```
 
-### Implementing Retry Logic
+`config.FromEnvironment()` currently reads `MIDAZ_MAX_RETRIES`. It does not read `MIDAZ_RETRY_WAIT_MIN` or `MIDAZ_RETRY_WAIT_MAX`.
 
-```go
-func CreateAccountWithRetry(ctx context.Context, client *client.Client, orgID, ledgerID string, input *models.CreateAccountInput) (*models.Account, error) {
-    const maxRetries = 3
-    var account *models.Account
-    var err error
-    
-    for attempt := 0; attempt < maxRetries; attempt++ {
-        account, err = client.Entity.Accounts.CreateAccount(ctx, orgID, ledgerID, input)
-        if err == nil {
-            return account, nil
-        }
-        
-        if !errors.IsRetryableError(err) || attempt == maxRetries-1 {
-            break
-        }
-        
-        delay := errors.GetRetryDelay(err, attempt)
-        log.Printf("Retryable error occurred (attempt %d/%d), retrying in %v: %v\n", 
-            attempt+1, maxRetries, delay, err)
-        time.Sleep(delay)
-    }
-    
-    if err != nil {
-        return nil, fmt.Errorf("failed to create account after %d attempts: %w", maxRetries, err)
-    }
-    
-    return account, nil
-}
-```
+## Best practices
 
-### Using the Enhanced Error Details
-
-```go
-func GetErrorDetails(err error) {
-    if details, ok := err.(errors.ErrorDetails); ok {
-        fmt.Printf("Error type: %s\n", details.ErrorType())
-        fmt.Printf("Error code: %s\n", details.ErrorCode())
-        fmt.Printf("Error message: %s\n", details.ErrorMessage())
-        
-        if details.StatusCode() > 0 {
-            fmt.Printf("HTTP status: %d\n", details.StatusCode())
-        }
-        
-        if details.Resource() != "" {
-            fmt.Printf("Resource: %s\n", details.Resource())
-            if details.ResourceID() != "" {
-                fmt.Printf("Resource ID: %s\n", details.ResourceID())
-            }
-        }
-        
-        if details.RequestID() != "" {
-            fmt.Printf("Request ID: %s\n", details.RequestID())
-        }
-        
-        if errorDetails := details.Details(); errorDetails != nil {
-            fmt.Printf("Additional details: %v\n", errorDetails)
-        }
-    } else {
-        fmt.Printf("Generic error: %v\n", err)
-    }
-}
-```
+- Always wrap SDK errors with operation context when returning them from your application.
+- Use SDK checker functions for business branching.
+- Use `GetStatusCode` for HTTP status-specific behavior.
+- Use `errors.As` when you need request ID, resource, or operation fields.
+- Use idempotency keys for unsafe calls that may be retried.
+- Treat validation field errors as validation package errors, not transport errors.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -118,6 +118,13 @@ if err != nil {
 If you need fields only available on `*errors.Error`, use `errors.As` from the standard library:
 
 ```go
+import (
+    stderrors "errors"
+    "log"
+
+    sdkerrors "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+)
+
 var sdkErr *sdkerrors.Error
 if stderrors.As(err, &sdkErr) {
     log.Printf(

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,224 +1,219 @@
-# Midaz Go SDK Examples
+# Midaz Go SDK examples
 
-This guide provides comprehensive examples of common operations with the Midaz Go SDK, including basic operations and advanced features.
+This guide shows the current SDK access patterns for configuration, entity services, pagination, transactions, tracing, and the mass demo generator.
 
-## Table of Contents
+## Client initialization
 
-- [Client Initialization](#client-initialization)
-- [Working with Organizations](#working-with-organizations)
-- [Account and Asset Management](#account-and-asset-management)
-- [Transaction Processing](#transaction-processing)
-- [Using Pagination](#using-pagination)
-- [Example Applications](#example-applications)
-- [Mass Demo Generator](#mass-demo-generator)
-
-## Client Initialization
+Environment loading is explicit. Use `config.FromEnvironment()` when you want process environment values to configure the SDK. If you use a `.env` file, load it first with your application's dotenv loader:
 
 ```go
 import (
-	client "github.com/LerianStudio/midaz-sdk-golang/v2"
-	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
+    "context"
+
+    client "github.com/LerianStudio/midaz-sdk-golang/v2"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config"
 )
 
-// Create a client with default options
-c, err := client.New(
-	client.WithEnvironment(config.EnvironmentProduction),
-	client.UseAllAPIs(),
-)
+cfg, err := config.NewConfig(config.FromEnvironment())
 if err != nil {
-	// Handle error
+    return err
 }
 
-// Create a client with observability enabled
 c, err := client.New(
-	client.WithEnvironment(config.EnvironmentLocal),
-	client.WithObservability(true, true, true), // tracing, metrics, logging
-	client.UseAllAPIs(),
+    client.WithConfig(cfg),
+    client.UseAllAPIs(),
 )
 if err != nil {
-	// Handle error
+    return err
 }
+defer c.Shutdown(context.Background())
 ```
 
-## Working with Organizations
+For local testing with a direct base URL:
 
 ```go
-// Create an organization
-org, err := c.Entity.Organizations.CreateOrganization(ctx, &models.CreateOrganizationInput{
-	LegalName:       "Example Organization",
-	LegalDocument:   "123456789",
-	DoingBusinessAs: "Example",
-	Address: &models.Address{
-		Line1:   "123 Main St",
-		City:    "San Francisco",
-		State:   "CA",
-		Country: "US",
-		ZipCode: "94105",
-	},
-	Metadata: map[string]any{
-		"industry": "fintech",
-		"size":     "startup",
-	},
-})
-
-// Get an organization
-org, err := c.Entity.Organizations.GetOrganization(ctx, "org-id")
-
-// List organizations with filtering
-orgs, err := c.Entity.Organizations.ListOrganizations(ctx, &models.ListOptions{
-	Limit: 20,
-	Filters: map[string]string{
-		"status": "ACTIVE",
-	},
-})
-```
-
-## Account and Asset Management
-
-```go
-// Create an asset
-asset, err := c.Entity.Assets.CreateAsset(ctx, orgID, ledgerID, &models.CreateAssetInput{
-	Name: "US Dollar",
-	Type: "currency",
-	Code: "USD",
-	Scale: 2,
-	Metadata: map[string]any{
-		"symbol": "$",
-		"country": "US",
-	},
-})
-
-// Create an account
-account, err := c.Entity.Accounts.CreateAccount(ctx, orgID, ledgerID, &models.CreateAccountInput{
-	Name:      "Customer Checking Account",
-	Type:      "checking",
-	AssetCode: "USD",
-	Alias:     "customer-123",
-	Metadata: map[string]any{
-		"customer_id": "cust-123",
-		"tier":        "premium",
-	},
-})
-
-// Get account balance
-balance, err := c.Entity.Balances.GetBalance(ctx, orgID, ledgerID, accountID)
-```
-
-## Transaction Processing
-
-```go
-// Create a simple transaction
-tx, err := c.Entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, &models.CreateTransactionInput{
-	Description: "Payment from customer to merchant",
-	Operations: []models.CreateOperationInput{
-		{
-			Type:      "debit",
-			AssetCode: "USD",
-			Amount:    10000, // $100.00 (scale 2)
-			AccountID: customerAccountID,
-		},
-		{
-			Type:      "credit",
-			AssetCode: "USD",
-			Amount:    10000,
-			AccountID: merchantAccountID,
-		},
-	},
-})
-
-// Create a transaction using DSL
-dsl := `
-send [USD 100] (
-  source = @customer
+c, err := client.New(
+    client.WithBaseURL("http://localhost:3000"),
+    client.UseAllAPIs(),
 )
-distribute [USD 100] (
-  destination = {
-    85% to @merchant
-    10% to @platform-fee
-    5% to @processor-fee
-  }
-)
-`
+```
 
+## Working with organizations
+
+Prefer model builders for wrapped Midaz model inputs:
+
+```go
+orgInput := models.NewCreateOrganizationInput("Example Organization", "123456789").
+    WithDoingBusinessAs("Example").
+    WithAddress(models.Address{
+        Line1:   "123 Main St",
+        City:    "San Francisco",
+        State:   "CA",
+        Country: "US",
+        ZipCode: "94105",
+    }).
+    WithMetadata(map[string]any{
+        "industry": "fintech",
+        "size":     "startup",
+    })
+
+org, err := c.Entity.Organizations.CreateOrganization(ctx, orgInput)
+if err != nil {
+    return err
+}
+
+org, err = c.Entity.Organizations.GetOrganization(ctx, org.ID)
+if err != nil {
+    return err
+}
+
+orgs, err := c.Entity.Organizations.ListOrganizations(ctx,
+    models.NewListOptions().WithLimit(20).WithFilter("status", "ACTIVE"),
+)
+```
+
+## Account and asset management
+
+```go
+assetInput := models.NewCreateAssetInput("US Dollar", "USD").
+    WithType("currency").
+    WithMetadata(map[string]any{
+        "symbol":  "$",
+        "country": "US",
+    })
+
+asset, err := c.Entity.Assets.CreateAsset(ctx, orgID, ledgerID, assetInput)
+if err != nil {
+    return err
+}
+
+accountInput := models.NewCreateAccountInput("Customer Checking Account", asset.Code, "deposit").
+    WithAlias("customer-123").
+    WithMetadata(map[string]any{
+        "customer_id": "cust-123",
+        "tier":        "premium",
+    })
+
+account, err := c.Entity.Accounts.CreateAccount(ctx, orgID, ledgerID, accountInput)
+if err != nil {
+    return err
+}
+
+balance, err := c.Entity.Accounts.GetBalance(ctx, orgID, ledgerID, account.ID)
+```
+
+Use `BalancesService` when you need balance records by balance ID, all balances for an account, history, alias lookup, or external-code lookup:
+
+```go
+balances, err := c.Entity.Balances.ListAccountBalances(ctx, orgID, ledgerID, account.ID, nil)
+```
+
+## Transaction processing
+
+The current transaction contract uses a `send` payload. You can build it explicitly:
+
+```go
+txInput := models.NewCreateTransactionInput("USD", "100.00").
+    WithDescription("Payment from customer to merchant").
+    WithSend(&models.SendInput{
+        Asset: "USD",
+        Value: "100.00",
+        Source: &models.SourceInput{
+            From: []models.FromToInput{
+                {
+                    Account: customerAccountAlias,
+                    Amount: models.AmountInput{Asset: "USD", Value: "100.00"},
+                },
+            },
+        },
+        Distribute: &models.DistributeInput{
+            To: []models.FromToInput{
+                {
+                    Account: merchantAccountAlias,
+                    Amount: models.AmountInput{Asset: "USD", Value: "100.00"},
+                },
+            },
+        },
+    }).
+    WithMetadata(map[string]any{
+        "payment_id":  "pay-123",
+        "customer_id": "cust-123",
+    })
+
+tx, err := c.Entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, txInput)
+```
+
+For DSL-style structured transactions, use `TransactionDSLInput`:
+
+```go
 tx, err := c.Entity.Transactions.CreateTransactionWithDSL(ctx, orgID, ledgerID, &models.TransactionDSLInput{
-	Script:      dsl,
-	Description: "Split payment transaction",
-	Metadata: map[string]any{
-		"payment_id": "pay-123",
-		"customer_id": "cust-123",
-	},
+    Description: "Split payment transaction",
+    Send: &models.DSLSend{
+        Asset: "USD",
+        Value: "100.00",
+        Source: &models.DSLSource{
+            From: []models.DSLFromTo{
+                {Account: customerAccountAlias, Amount: &models.DSLAmount{Asset: "USD", Value: "100.00"}},
+            },
+        },
+        Distribute: &models.DSLDistribute{
+            To: []models.DSLFromTo{
+                {Account: merchantAccountAlias, Amount: &models.DSLAmount{Asset: "USD", Value: "85.00"}},
+                {Account: platformFeeAlias, Amount: &models.DSLAmount{Asset: "USD", Value: "10.00"}},
+                {Account: processorFeeAlias, Amount: &models.DSLAmount{Asset: "USD", Value: "5.00"}},
+            },
+        },
+    },
 })
 ```
 
-## Using Pagination
+For raw DSL file content, use `CreateTransactionWithDSLFile(ctx, orgID, ledgerID, []byte(content))`.
+
+## Using pagination
 
 ```go
-// Create pagination options
 options := models.NewListOptions().
-	WithLimit(25).
-	WithOrderBy("createdAt").
-	WithOrderDirection(models.SortDescending).
-	WithFilter("status", "ACTIVE")
+    WithLimit(25).
+    WithOrderDirection(models.SortDescending).
+    WithFilter("status", "ACTIVE")
 
-// List accounts with pagination
-accounts, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
-if err != nil {
-	// Handle error
-}
-
-// Process first page
-for _, account := range accounts.Items {
-	// Process each account
-}
-
-// Check for more pages
-if accounts.Pagination.HasNextPage() {
-	nextPageOptions := accounts.Pagination.NextPageOptions()
-	nextPage, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, nextPageOptions)
-	// Process next page...
-}
-
-// Alternative: iterate through all pages
 for {
-	page, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
-	if err != nil {
-		// Handle error
-		break
-	}
+    page, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
+    if err != nil {
+        return err
+    }
 
-	// Process items on this page
-	for _, account := range page.Items {
-		// Process each account
-	}
+    for _, account := range page.Items {
+        process(account)
+    }
 
-	// Check if we've reached the last page
-	if !page.Pagination.HasNextPage() {
-		break
-	}
+    if !page.Pagination.HasNextPage() {
+        break
+    }
 
-	// Update options for the next page
-	options = page.Pagination.NextPageOptions()
+    options = page.Pagination.NextPageOptions()
 }
 ```
 
-## Example Applications
+See [pagination](./pagination.md) for details on `page`, `limit`, cursor behavior, and sort serialization.
 
-The SDK includes several example applications in the `examples/` directory:
+## Example applications
 
-### Available Examples
+Runnable examples live in `examples/`:
 
-- **`access-manager-example/`** - Authentication integration example
-- **`clean-transaction/`** - Simple transaction processing
-- **`concurrency-example/`** - Concurrent operations and balance fetching
-- **`configuration-examples/`** - SDK configuration patterns
-- **`context-example/`** - Context management and cancellation
-- **`mass-demo-generator/`** - Comprehensive demo data generation (see below)
-- **`observability-demo/`** - Observability and monitoring setup
-- **`retry-example/`** - Retry mechanisms and error handling
-- **`validation-example/`** - Input validation patterns
-- **`workflow-with-entities/`** - Complete workflow implementation
-
-### Running Examples
+- `access-manager-example/` - Access Manager authentication configuration.
+- `clean-transaction/` - Simple transaction flow.
+- `concurrency-example/` - Concurrent SDK usage.
+- `concurrency-example/balance-fetch/` - Concurrent balance fetching.
+- `configuration-examples/` - Client and config setup patterns.
+- `context-example/` - Context timeout and cancellation usage.
+- `mass-demo-generator/` - End-to-end demo data generation.
+- `observability-demo/` - Observability setup.
+- `retry-example/` - Retry behavior.
+- `tracing-example/` - Client-side tracing propagation.
+- `tracing-server-example/` - Server-side tracing propagation.
+- `validation-example/` - Input validation patterns.
+- `workflow-with-entities/` - Complete entity workflow.
 
 Most examples can be run with:
 
@@ -227,258 +222,103 @@ cd examples/example-name
 go run .
 ```
 
-For more detailed examples, refer to the `examples` directory in the SDK repository.
+## Mass demo generator
 
-## Mass Demo Generator
+The `examples/mass-demo-generator` app creates realistic organizations, ledgers, assets, accounts, balances, routes, transactions, and reports. It uses concurrent processing and is the best starting point for demo data.
 
-The `examples/mass-demo-generator` app creates realistic demo data (organizations, ledgers, accounts, transactions) using advanced SDK features including concurrent processing, circuit breakers, and comprehensive reporting.
+### Basic usage
 
-### Features
-
-- **Concurrent Processing**: Uses worker pools for parallel entity creation
-- **Circuit Breaker**: Protects against API overload with automatic failure detection
-- **DSL Transaction Patterns**: Demonstrates complex transaction flows using DSL
-- **Routing System**: Creates account types, operation routes, and transaction routes
-- **Integrity Verification**: Performs balance checks and double-entry validation
-- **Comprehensive Reporting**: Generates detailed HTML and JSON reports
-- **Flexible Configuration**: Interactive and non-interactive modes with extensive options
-
-### Basic Usage
-
-#### Interactive Mode
+Interactive mode:
 
 ```bash
 cd examples/mass-demo-generator
 go run .
 ```
 
-The interactive mode will prompt you for:
-
-- Number of organizations to create
-- Ledgers per organization
-- Accounts per ledger
-- Transactions per account
-- Concurrent workers count
-- Organization locale (US/Brazil)
-- Enable DSL pattern demonstrations
-- Funding amount for initial balances
-
-#### Non-Interactive Mode
+Non-interactive mode:
 
 ```bash
 cd examples/mass-demo-generator
 DEMO_NON_INTERACTIVE=1 go run . \
   --orgs=3 \
-  --ledgers-per-org=2 \
-  --accounts-per-ledger=50 \
+  --ledgers=2 \
+  --accounts=50 \
   --tx=100 \
   --concurrency=10 \
   --batch=25 \
-  --org-locale=br \
-  --patterns=true
+  --org-locale=br
 ```
 
-### Command Line Options
+### Command line options
 
-| Flag                    | Type     | Default | Description                                              |
-| ----------------------- | -------- | ------- | -------------------------------------------------------- |
-| `--timeout`             | duration | 30m     | Overall generation timeout                               |
-| `--orgs`                | int      | 2       | Number of organizations to create                        |
-| `--ledgers-per-org`     | int      | 2       | Ledgers per organization                                 |
-| `--accounts-per-ledger` | int      | 20      | Accounts per ledger                                      |
-| `--tx`                  | int      | 50      | Transactions per account                                 |
-| `--concurrency`         | int      | 5       | Worker pool size for parallel operations                 |
-| `--batch`               | int      | 10      | Batch size for grouped operations                        |
-| `--org-locale`          | string   | us      | Organization locale (`us` or `br`) - toggles EIN vs CNPJ |
-| `--patterns`            | bool     | false   | Enable DSL pattern demonstrations                        |
+| Flag | Type | Default from `default.yaml` | Description |
+| --- | --- | --- | --- |
+| `--timeout` | int | `120` | Overall generation timeout in seconds |
+| `--orgs` | int | `2` | Number of organizations to create |
+| `--ledgers` | int | `2` | Ledgers per organization |
+| `--accounts` | int | `100` | Accounts per ledger |
+| `--tx` | int | `50` | Transactions per account for the demo batch |
+| `--concurrency` | int | `32` | Worker pool size; `0` means auto when not overridden by defaults |
+| `--batch` | int | `50` | Batch size for parallel operations |
+| `--org-locale` | string | `us` | Organization locale (`us` or `br`) |
 
-### Generated Data Structure
+### Non-interactive environment controls
 
-The generator creates a complete financial ecosystem:
+The generator also reads non-interactive defaults from `examples/mass-demo-generator/default.yaml`. Batch-demo controls include:
 
-1. **Organizations** with realistic business data and addresses
-2. **Ledgers** for each organization with proper metadata
-3. **Assets** including USD, EUR, BTC, and loyalty points
-4. **Account Types** (checking, savings, credit, expense, revenue, liability, equity)
-5. **Accounts** linked to types with hierarchical relationships
-6. **Portfolios** and **Segments** for organizing accounts
-7. **Operation Routes** and **Transaction Routes** for validation
-8. **Transactions** using both standard and DSL formats
+- `DEMO_RUN_BATCH` - Enable the send-based transfer batch demo.
+- `DEMO_ASSET_CODE` - Asset code used by the batch demo.
+- `DEMO_CHART_GROUP` - Chart of accounts group for transaction creation.
 
-### DSL Pattern Demonstrations
+### Generated data structure
 
-When `--patterns=true` is enabled, the generator demonstrates:
+The generator creates:
 
-#### Subscription Pattern
+- Organizations with locale-aware legal documents.
+- Ledgers for each organization.
+- Assets such as USD, EUR, and BTC depending on configuration.
+- Account types and accounts.
+- Portfolio and segment hierarchy when enabled.
+- Operation routes and transaction routes.
+- Transactions using the current send-based transaction contract.
 
-```dsl
-send [USD 29.99] (
-  source = @customer
-)
-distribute [USD 29.99] (
-  destination = {
-    85% to @merchant
-    10% to @platform-fee
-    5% to @payment-processor
-  }
-)
-```
+### Reports and output
 
-#### Split Payment Pattern
+The generator writes report files in its working directory, including machine-readable entity references and generation summaries. Console output includes progress and performance metrics.
 
-```dsl
-send [USD 100] (
-  source = @customer
-)
-distribute [USD 100] (
-  destination = {
-    70% to @merchant-a
-    25% to @merchant-b
-    5% to @platform-fee
-  }
-)
-```
+### Example scenarios
 
-### Routing System
-
-The generator creates a complete routing infrastructure:
-
-#### Account Types
-
-- **CHECKING**: Standard transaction accounts
-- **SAVINGS**: Interest-bearing accounts
-- **CREDIT_CARD**: Credit accounts with limits
-- **EXPENSE**: Business expense tracking
-- **REVENUE**: Revenue recognition accounts
-- **LIABILITY**: Liability tracking
-- **EQUITY**: Equity accounts
-
-#### Operation Routes
-
-Routes define valid source and destination patterns:
-
-- **Customer Routes**: Checking accounts for customer transactions
-- **Merchant Routes**: Business account patterns
-- **Fee Routes**: Platform and processor fee destinations
-- **Settlement Routes**: Account settlement patterns
-
-#### Transaction Routes
-
-Higher-level transaction flows:
-
-- **Payment Flow**: Customer → Merchant (+ fees)
-- **Refund Flow**: Merchant → Customer
-- **Transfer Flow**: Account-to-account transfers
-- **Settlement Flow**: Multi-party settlements
-
-### Integrity Verification
-
-After generation, the system performs comprehensive checks:
-
-#### Balance Aggregation
-
-- Aggregates balances per asset across all accounts
-- Tracks available and on-hold amounts separately
-- Identifies overdrawn accounts (negative available balance)
-
-#### Double-Entry Validation
-
-- Computes internal net total (excluding `@external/` prefixed accounts)
-- Validates double-entry consistency (net should be zero)
-- Flags any discrepancies for investigation
-
-#### Scale Consistency
-
-- Verifies amounts respect asset scale configuration
-- Reports any precision violations
-- Ensures currency amounts use proper decimal places
-
-### Reporting and Output
-
-The generator produces comprehensive reports:
-
-#### Console Output
-
-Real-time progress indicators and performance metrics during generation.
-
-#### JSON Report (`mass-demo-report.json`)
-
-Machine-readable report containing:
-
-- Entity counts and creation times
-- API call statistics and performance metrics
-- Transaction volumes by account
-- Asset usage statistics
-- Balance summaries with integrity status
-
-#### HTML Report (`mass-demo-report.html`)
-
-Human-readable report with:
-
-- Executive summary and key metrics
-- Data integrity status and warnings
-- Performance analysis and recommendations
-- Entity relationship visualizations
-
-#### Entity Reference (`mass-demo-entities.json`)
-
-Complete list of created entity IDs for reference and cleanup.
-
-### Performance Characteristics
-
-The generator is optimized for high-performance data generation:
-
-- **Concurrent Processing**: Parallel entity creation with configurable worker pools
-- **Circuit Breaker**: Automatic API protection with failure threshold detection
-- **Rate Limiting**: Configurable throttling to prevent API overload
-- **Batch Operations**: Grouped operations for efficiency
-- **Progress Monitoring**: Real-time performance metrics and ETA calculation
-
-### Example Scenarios
-
-#### Small Demo Dataset
+Small demo dataset:
 
 ```bash
 DEMO_NON_INTERACTIVE=1 go run . \
   --orgs=1 \
-  --ledgers-per-org=1 \
-  --accounts-per-ledger=10 \
+  --ledgers=1 \
+  --accounts=10 \
   --tx=20 \
   --org-locale=us
 ```
 
-#### Large Performance Test
+Larger performance dataset:
 
 ```bash
 DEMO_NON_INTERACTIVE=1 go run . \
   --orgs=10 \
-  --ledgers-per-org=3 \
-  --accounts-per-ledger=100 \
+  --ledgers=3 \
+  --accounts=100 \
   --tx=500 \
   --concurrency=20 \
-  --batch=50 \
-  --patterns=true
+  --batch=50
 ```
 
-#### Brazilian Organization Demo
+Brazilian organization demo:
 
 ```bash
-DEMO_NON_INTERACTIVE=1 go run . \
-  --org-locale=br \
-  --patterns=false
+DEMO_NON_INTERACTIVE=1 go run . --org-locale=br
 ```
 
-### Integration with CI/CD
-
-The generator can be used for:
-
-- **Development Environment Setup**: Create realistic test data
-- **Performance Testing**: Generate large datasets for load testing
-- **Demo Environments**: Populate demo instances with sample data
-- **Integration Testing**: Provide consistent test datasets
-
-For CI/CD integration, use non-interactive mode with appropriate timeout settings:
+CI-friendly bounded run:
 
 ```bash
-timeout 600 go run . --timeout=10m --orgs=5 --tx=100
+timeout 600 go run . --timeout=600 --orgs=5 --tx=100
 ```

--- a/docs/godoc/models/index.txt
+++ b/docs/godoc/models/index.txt
@@ -97,7 +97,7 @@ type CreateAccountTypeInput struct{ ... }
     func WithCreateAccountTypeDescription(input *CreateAccountTypeInput, description string) *CreateAccountTypeInput
     func WithCreateAccountTypeMetadata(input *CreateAccountTypeInput, metadata map[string]any) *CreateAccountTypeInput
 type CreateAnnotationInput struct{ ... }
-    func NewCreateAnnotationInput(description string) *CreateAnnotationInput
+    func NewCreateAnnotationInput(description string, send ...*SendInput) *CreateAnnotationInput
 type CreateAssetInput struct{ ... }
     func NewCreateAssetInput(name, code string) *CreateAssetInput
 type CreateAssetRateInput struct{ ... }
@@ -105,7 +105,7 @@ type CreateAssetRateInput struct{ ... }
 type CreateBalanceInput struct{ ... }
     func NewCreateBalanceInput(key string) *CreateBalanceInput
 type CreateInflowInput struct{ ... }
-    func NewCreateInflowInput(asset, value string, distribute *DistributeInput) *CreateInflowInput
+    func NewCreateInflowInput(asset string, value any, distribute *DistributeInput) *CreateInflowInput
 type CreateLedgerInput struct{ ... }
     func NewCreateLedgerInput(name string) *CreateLedgerInput
 type CreateOperationInput struct{ ... }
@@ -115,15 +115,15 @@ type CreateOperationRouteInput struct{ ... }
     func WithCreateOperationRouteAccountType(input *CreateOperationRouteInput, accountTypes []string) *CreateOperationRouteInput
     func WithCreateOperationRouteMetadata(input *CreateOperationRouteInput, metadata map[string]any) *CreateOperationRouteInput
 type CreateOrganizationInput struct{ ... }
-    func NewCreateOrganizationInput(legalName string) *CreateOrganizationInput
+    func NewCreateOrganizationInput(legalName, legalDocument string) *CreateOrganizationInput
 type CreateOutflowInput struct{ ... }
-    func NewCreateOutflowInput(asset, value string, source *SourceInput) *CreateOutflowInput
+    func NewCreateOutflowInput(asset string, value any, source *SourceInput) *CreateOutflowInput
 type CreatePortfolioInput struct{ ... }
     func NewCreatePortfolioInput(entityID, name string) *CreatePortfolioInput
 type CreateSegmentInput struct{ ... }
     func NewCreateSegmentInput(name string) *CreateSegmentInput
 type CreateTransactionInput struct{ ... }
-    func NewCreateTransactionInput(assetCode string, amount string) *CreateTransactionInput
+    func NewCreateTransactionInput(assetCode string, amount any) *CreateTransactionInput
 type CreateTransactionRouteInput struct{ ... }
     func NewCreateTransactionRouteInput(title, description string, operationRoutes []string) *CreateTransactionRouteInput
     func WithTransactionRouteMetadata(input *CreateTransactionRouteInput, metadata map[string]any) *CreateTransactionRouteInput

--- a/docs/mapping/external_apis.md
+++ b/docs/mapping/external_apis.md
@@ -1,494 +1,366 @@
-# Midaz Go SDK Method Map
-
-This document provides a comprehensive overview of all public methods available in the Midaz Go SDK, organized by package and purpose.
-
-## Table of Contents
-
-- [I. Client Package (`midaz`)](#i-client-package-midaz)
-- [II. Entities Package (`midaz/entities`)](#ii-entities-package-midazentities)
-- [III. Error Handling Package (`midaz/pkg/errors`)](#iii-error-handling-package-midazpkgerrors)
-- [IV. Configuration Package (`midaz/pkg/config`)](#iv-configuration-package-midazpkgconfig)
-- [V. Concurrent Package (`midaz/pkg/concurrent`)](#v-concurrent-package-midazpkgconcurrent)
-- [VI. Observability Package (`midaz/pkg/observability`)](#vi-observability-package-midazpkgobservability)
-- [VII. Pagination Package (`midaz/pkg/pagination`)](#vii-pagination-package-midazpkgpagination)
-- [VIII. Retry Package (`midaz/pkg/retry`)](#viii-retry-package-midazpkgretry)
-- [IX. Validation Package (`midaz/pkg/validation`)](#ix-validation-package-midazpkgvalidation)
-- [X. Models Package (`midaz/models`)](#x-models-package-midazmodels)
-
-## I. Client Package (`midaz`)
-
-The client package provides the main entry point for the Midaz SDK.
-
-### Client
-
-- `New()` - Creates a new Midaz client with the provided options
-- `WithAccessManager()` - Sets the authentication token for the client
-- `WithOnboardingURL()` - Sets the base URL for the onboarding API
-- `WithTransactionURL()` - Sets the base URL for the transaction API
-- `WithServiceURLs()` - Sets a map of service-specific URLs for different API services
-- `WithHTTPClient()` - Sets a custom HTTP client for the client
-- `WithTimeout()` - Sets the timeout for requests made by the client
-- `WithDebug()` - Enables or disables debug mode for the client
-- `WithUserAgent()` - Sets a custom user agent string for API requests
-- `WithObservability()` - Sets the observability provider for metrics, tracing, and logging
-- `WithContext()` - Sets the context for the client
-- `WithRetryOptions()` - Sets retry options for API requests
-- `Client.Entity` - Provides access to the Entity API interface
-- `Client.GetVersion()` - Returns the current version of the SDK
-
-## II. Entities Package (`midaz/entities`)
-
-The entities package provides direct access to Midaz API resources.
-
-### Entity
-
-- `NewEntity()` - Creates a new Entity instance that provides access to all service interfaces with a single base URL
-- `NewWithServiceURLs()` - Creates a new Entity instance with separate URLs for each service (preferred method)
-- `Entity.Accounts` - Returns the AccountsService interface for account operations
-- `Entity.Assets` - Returns the AssetsService interface for asset operations
-- `Entity.Balances` - Returns the BalancesService interface for balance operations
-- `Entity.Ledgers` - Returns the LedgersService interface for ledger operations
-- `Entity.Operations` - Returns the OperationsService interface for operation operations
-- `Entity.Organizations` - Returns the OrganizationsService interface for organization operations
-- `Entity.Portfolios` - Returns the PortfoliosService interface for portfolio operations
-- `Entity.Segments` - Returns the SegmentsService interface for segment operations
-- `Entity.Transactions` - Returns the TransactionsService interface for transaction operations
-
-### Accounts Service
-
-- `AccountsService.List()` - Lists accounts for a ledger with pagination
-- `AccountsService.Get()` - Gets an account by ID
-- `AccountsService.GetByAlias()` - Gets an account by alias
-- `AccountsService.Create()` - Creates a new account
-- `AccountsService.Update()` - Updates an account
-- `AccountsService.Delete()` - Deletes an account
-
-### Assets Service
-
-- `AssetsService.List()` - Lists assets for a ledger with pagination
-- `AssetsService.Get()` - Gets an asset by ID
-- `AssetsService.Create()` - Creates a new asset
-- `AssetsService.Update()` - Updates an asset
-- `AssetsService.Delete()` - Deletes an asset
-
-### Asset Rates Service
-
-
-### Balances Service
-
-- `BalancesService.List()` - Lists balances for a ledger with pagination
-- `BalancesService.ListForAccount()` - Lists balances for a specific account
-- `BalancesService.Get()` - Gets a balance by ID
-- `BalancesService.Update()` - Updates a balance
-
-### Ledgers Service
-
-- `LedgersService.List()` - Lists ledgers for an organization with pagination
-- `LedgersService.Get()` - Gets a ledger by ID
-- `LedgersService.Create()` - Creates a new ledger
-- `LedgersService.Update()` - Updates a ledger
-- `LedgersService.Delete()` - Deletes a ledger
-
-### Operations Service
-
-- `OperationsService.List()` - Lists operations for a ledger with pagination
-- `OperationsService.Get()` - Gets an operation by ID
-
-### Organizations Service
-
-- `OrganizationsService.List()` - Lists organizations with pagination
-- `OrganizationsService.Get()` - Gets an organization by ID
-- `OrganizationsService.Create()` - Creates a new organization
-- `OrganizationsService.Update()` - Updates an organization
-- `OrganizationsService.Delete()` - Deletes an organization
-
-### Portfolios Service
-
-- `PortfoliosService.List()` - Lists portfolios for a ledger with pagination
-- `PortfoliosService.Get()` - Gets a portfolio by ID
-- `PortfoliosService.Create()` - Creates a new portfolio
-- `PortfoliosService.Update()` - Updates a portfolio
-- `PortfoliosService.Delete()` - Deletes a portfolio
-
-### Segments Service
-
-- `SegmentsService.List()` - Lists segments for a portfolio with pagination
-- `SegmentsService.Get()` - Gets a segment by ID
-- `SegmentsService.Create()` - Creates a new segment
-- `SegmentsService.Update()` - Updates a segment
-- `SegmentsService.Delete()` - Deletes a segment
-
-### Transactions Service
-
-- `TransactionsService.List()` - Lists transactions for a ledger with pagination
-- `TransactionsService.Get()` - Gets a transaction by ID
-- `TransactionsService.Create()` - Creates a new transaction
-- `TransactionsService.Commit()` - Commits a pending transaction
-- `TransactionsService.Cancel()` - Cancels a pending transaction
-
-## III. Error Handling Package (`midaz/pkg/errors`)
-
-The errors package provides standardized error types and utilities for working with errors in the Midaz SDK.
-
-### Error Type
-
-- `Error` - Core error type that contains detailed error information
-  - `Category` - General category of the error (e.g., validation, not_found)
-  - `Code` - Specific error code
-  - `Message` - Human-readable error message
-  - `Operation` - Operation that was being performed
-  - `Resource` - Type of resource involved
-  - `ResourceID` - Identifier of the resource involved
-  - `StatusCode` - HTTP status code
-  - `RequestID` - API request ID for debugging
-  - `Err` - The underlying error
-
-### Error Type Checking
-
-- `IsValidationError(err error) bool` - Checks if the error is a validation error
-- `IsNotFoundError(err error) bool` - Checks if the error is a not found error
-- `IsAuthenticationError(err error) bool` - Checks if the error is an authentication error
-- `IsAuthorizationError(err error) bool` - Checks if the error is an authorization error
-- `IsPermissionError(err error) bool` - Checks if the error is a permission error
-- `IsConflictError(err error) bool` - Checks if the error is a conflict error
-- `IsAlreadyExistsError(err error) bool` - Checks if the error is an already exists error
-- `IsRateLimitError(err error) bool` - Checks if the error is a rate limit error
-- `IsTimeoutError(err error) bool` - Checks if the error is a timeout error
-- `IsNetworkError(err error) bool` - Checks if the error is a network error
-- `IsCancellationError(err error) bool` - Checks if the error is a cancellation error
-- `IsInternalError(err error) bool` - Checks if the error is an internal error
-
-### Transaction Error Checking
-
-- `IsInsufficientBalanceError(err error) bool` - Checks if the error is an insufficient balance error
-- `IsAccountEligibilityError(err error) bool` - Checks if the error is an account eligibility error
-- `IsAssetMismatchError(err error) bool` - Checks if the error is an asset mismatch error
-- `IsIdempotencyError(err error) bool` - Checks if the error is an idempotency error
-
-### Error Utilities
-
-- `GetErrorCategory(err error) ErrorCategory` - Gets the category of an error
-- `GetStatusCode(err error) int` - Gets the HTTP status code for an error
-- `FormatErrorForDisplay(err error) string` - Formats an error for display to end users
-- `FormatTransactionError(err error, operationType string) string` - Formats a transaction error with operation context
-- `CategorizeTransactionError(err error) string` - Returns a string indicating the category of a transaction error
-- `ErrorFromHTTPResponse(statusCode int, requestID, message, code, entityType, resourceID string) error` - Creates an error from HTTP response details
-
-### Error Creation
-
-- `NewValidationError(operation, message string, err error) *Error` - Creates a validation error
-- `NewInvalidInputError(operation string, err error) *Error` - Creates an invalid input error
-- `NewNotFoundError(operation, resource, resourceID string, err error) *Error` - Creates a not found error
-- `NewAuthenticationError(operation, message string, err error) *Error` - Creates an authentication error
-- `NewAuthorizationError(operation, message string, err error) *Error` - Creates an authorization error
-- `NewConflictError(operation, resource, resourceID string, err error) *Error` - Creates a conflict error
-- `NewRateLimitError(operation, message string, err error) *Error` - Creates a rate limit error
-- `NewTimeoutError(operation, message string, err error) *Error` - Creates a timeout error
-- `NewInternalError(operation string, err error) *Error` - Creates an internal error
-- `NewInsufficientBalanceError(operation, accountID string, err error) *Error` - Creates an insufficient balance error
-- `NewAssetMismatchError(operation, expected, actual string, err error) *Error` - Creates an asset mismatch error
-- `NewAccountEligibilityError(operation, accountID string, err error) *Error` - Creates an account eligibility error
-
-## IV. Configuration Package (`midaz/pkg/config`)
-
-The config package provides configuration management for the Midaz SDK.
-
-### Core Functions and Types
-
-- `NewConfig(options ...Option) (*Config, error)` - Creates a new configuration with the provided options
-- `DefaultConfig() *Config` - Creates a new configuration with default values
-- `NewLocalConfig(authToken string, options ...Option) (*Config, error)` - Creates a configuration for local development
-
-### Configuration Options
-
-- `WithEnvironment(env Environment) Option` - Sets the environment (local, development, production)
-- `WithAccessManager(token string) Option` - Sets the authentication token
-- `WithOnboardingURL(url string) Option` - Sets the base URL for the Onboarding API
-- `WithTransactionURL(url string) Option` - Sets the base URL for the Transaction API
-- `WithBaseURL(baseURL string) Option` - Sets a common base URL for all services
-- `WithHTTPClient(client *http.Client) Option` - Sets a custom HTTP client
-- `WithTimeout(timeout time.Duration) Option` - Sets the timeout for HTTP requests
-- `WithUserAgent(userAgent string) Option` - Sets the user agent for HTTP requests
-- `WithRetryConfig(maxRetries int, minWait, maxWait time.Duration) Option` - Sets the retry configuration
-- `WithMaxRetries(maxRetries int) Option` - Sets the maximum number of retries
-- `WithRetryWaitMin(waitTime time.Duration) Option` - Sets the minimum wait time between retries
-- `WithRetryWaitMax(waitTime time.Duration) Option` - Sets the maximum wait time between retries
-- `WithRetries(enable bool) Option` - Enables or disables retries
-- `WithDebug(enable bool) Option` - Enables or disables debug mode
-- `WithObservabilityProvider(provider observability.Provider) Option` - Sets the observability provider
-- `WithIdempotency(enable bool) Option` - Enables or disables automatic idempotency key generation
-- `FromEnvironment() Option` - Loads configuration from environment variables
-
-### Config Methods
-
-- `Config.GetBaseURLs() map[string]string` - Returns a map of service names to URLs
-- `Config.GetHTTPClient() *http.Client` - Returns the HTTP client
-- `Config.GetAuthToken() string` - Returns the authentication token
-- `Config.GetObservabilityProvider() observability.Provider` - Returns the observability provider
-
-## V. Concurrent Package (`midaz/pkg/concurrent`)
-
-The concurrent package provides utilities for working with concurrent operations in the Midaz SDK.
-
-### Worker Pool
-
-- `WorkerPool[T, R any](ctx context.Context, items []T, workFn WorkFunc[T, R], opts ...PoolOption) []Result[T, R]` - Creates a pool of workers for parallel processing
-- `Batch[T, R any](ctx context.Context, items []T, batchSize int, workFn func(ctx context.Context, batch []T) ([]R, error), opts ...PoolOption) []Result[T, R]` - Processes items in batches using a worker pool
-- `ForEach[T any](ctx context.Context, items []T, fn func(ctx context.Context, item T) error, opts ...PoolOption) error` - Executes a function for each item in parallel
-
-### Worker Pool Options
-
-- `WithWorkers(workers int) PoolOption` - Sets the number of worker goroutines
-- `WithBufferSize(size int) PoolOption` - Sets the size of the channel buffers
-- `WithUnorderedResults() PoolOption` - Configures the pool to return results as they are completed
-- `WithRateLimit(operationsPerSecond int) PoolOption` - Sets the maximum number of operations per second
-- `WithWaitGroup(wg *sync.WaitGroup) PoolOption` - Creates a worker pool that utilizes an external wait group
-
-### Rate Limiting
-
-- `NewRateLimiter(opsPerSecond int, maxBurst int) *RateLimiter` - Creates a new rate limiter
-- `RateLimiter.Wait(ctx context.Context) error` - Blocks until a token is available or the context is cancelled
-- `RateLimiter.Stop()` - Stops the rate limiter and releases resources
-
-### Types
-
-- `WorkFunc[T, R any]` - A generic worker function that processes an item and returns a result and error
-- `Result[T, R any]` - Holds the result of a processed item along with any error that occurred
-- `RateLimiter` - Provides a simple mechanism to limit the rate of operations
-
-## VI. Observability Package (`midaz/pkg/observability`)
-
-The observability package provides utilities for adding observability capabilities to the Midaz SDK, including metrics, logging, and distributed tracing.
-
-### Core Functions and Types
-
-- `New(ctx context.Context, opts ...Option) (Provider, error)` - Creates a new observability provider
-- `NewWithConfig(ctx context.Context, config *Config) (Provider, error)` - Creates a provider with the given configuration
-- `WithSpan(ctx context.Context, provider Provider, name string, fn func(context.Context) error, opts ...trace.SpanStartOption) error` - Executes a function within a new span
-- `RecordMetric(ctx context.Context, provider Provider, name string, value float64, attrs ...attribute.KeyValue)` - Records a metric
-- `RecordDuration(ctx context.Context, provider Provider, name string, start time.Time, attrs ...attribute.KeyValue)` - Records a duration metric
-- `ExtractContext(ctx context.Context, headers map[string]string) context.Context` - Extracts context from HTTP headers
-- `InjectContext(ctx context.Context, headers map[string]string)` - Injects context into HTTP headers
-
-### Provider Interface
-
-- `Provider.Tracer() trace.Tracer` - Returns a tracer for creating spans
-- `Provider.Meter() metric.Meter` - Returns a meter for creating metrics
-- `Provider.Logger() Logger` - Returns a logger
-- `Provider.Shutdown(ctx context.Context) error` - Gracefully shuts down the provider
-- `Provider.IsEnabled() bool` - Returns true if observability is enabled
-
-### Configuration Options
-
-- `WithServiceName(name string) Option` - Sets the service name for observability
-- `WithServiceVersion(version string) Option` - Sets the service version
-- `WithSDKVersion(version string) Option` - Sets the SDK version
-- `WithEnvironment(env string) Option` - Sets the environment (production, development, etc.)
-- `WithCollectorEndpoint(endpoint string) Option` - Sets the OpenTelemetry collector endpoint
-- `WithLogLevel(level LogLevel) Option` - Sets the minimum log level
-- `WithLogOutput(output io.Writer) Option` - Sets the writer for logs
-- `WithTraceSampleRate(rate float64) Option` - Sets the trace sampling rate
-- `WithComponentEnabled(tracing, metrics, logging bool) Option` - Enables/disables components
-- `WithAttributes(attrs ...attribute.KeyValue) Option` - Adds attributes to telemetry
-- `WithHighTracingSampling() Option` - Sets a high trace sampling rate (0.5)
-- `WithFullTracingSampling() Option` - Sets a full trace sampling rate (1.0)
-- `WithDevelopmentDefaults() Option` - Sets reasonable defaults for development
-- `WithProductionDefaults() Option` - Sets reasonable defaults for production
-
-### Logging Interface
-
-- `Logger.Debug(args ...interface{})` - Logs at debug level
-- `Logger.Debugf(format string, args ...interface{})` - Logs formatted message at debug level
-- `Logger.Info(args ...interface{})` - Logs at info level
-- `Logger.Infof(format string, args ...interface{})` - Logs formatted message at info level
-- `Logger.Warn(args ...interface{})` - Logs at warn level
-- `Logger.Warnf(format string, args ...interface{})` - Logs formatted message at warn level
-- `Logger.Error(args ...interface{})` - Logs at error level
-- `Logger.Errorf(format string, args ...interface{})` - Logs formatted message at error level
-- `Logger.Fatal(args ...interface{})` - Logs at fatal level and exits
-- `Logger.Fatalf(format string, args ...interface{})` - Logs formatted message at fatal level and exits
-- `Logger.With(fields map[string]interface{}) Logger` - Returns a logger with added fields
-- `Logger.WithContext(ctx trace.SpanContext) Logger` - Returns a logger with context information
-- `Logger.WithSpan(span trace.Span) Logger` - Returns a logger with span information
-
-## VII. Pagination Package (`midaz/pkg/pagination`)
-
-The pagination package provides utilities for working with paginated API responses.
-
-### Core Functions and Types
-
-- `NewPaginator[T any](fetcher PageFetcher[T], options ...PaginatorOption) (Paginator[T], error)` - Creates a new paginator
-- `NewPaginatorWithDefaults[T any](operationName, entityType string, fetcher PageFetcher[T], initialOptions PageOptions, observer Observer) Paginator[T]` - Creates a paginator with minimal parameters
-- `CollectAll[T any](ctx context.Context, operationName, entityType string, fetcher PageFetcher[T], options PageOptions) ([]T, error)` - Creates a paginator and collects all items
-- `NewObserver() Observer` - Creates a new pagination observer
-- `GetEntityTypeFromURL(url string) string` - Extracts the entity type from a URL
-
-### Paginator Interface
-
-- `Paginator[T].Next(ctx context.Context) bool` - Advances to the next page of results
-- `Paginator[T].Items() []T` - Returns the items in the current page
-- `Paginator[T].Err() error` - Returns any error that occurred during pagination
-- `Paginator[T].PageInfo() PageInfo` - Returns information about the current page
-- `Paginator[T].All(ctx context.Context) ([]T, error)` - Retrieves all remaining items
-- `Paginator[T].ForEach(ctx context.Context, fn func(item T) error) error` - Iterates through all items
-- `Paginator[T].Concurrent(ctx context.Context, workers int, fn func(item T) error) error` - Processes items concurrently
-
-### Paginator Options
-
-- `WithLimit(limit int) PaginatorOption` - Sets the initial page limit
-- `WithOffset(offset int) PaginatorOption` - Sets the initial page offset
-- `WithCursor(cursor string) PaginatorOption` - Sets the initial cursor
-- `WithFilters(filters map[string]string) PaginatorOption` - Sets the initial filters
-- `WithPageOptions(options PageOptions) PaginatorOption` - Sets all initial page options
-- `WithObserver(observer Observer) PaginatorOption` - Sets the observer for monitoring
-- `WithOperationName(operationName string) PaginatorOption` - Sets the operation name
-- `WithEntityType(entityType string) PaginatorOption` - Sets the entity type
-- `WithWorkerCount(workerCount int) PaginatorOption` - Sets the number of workers
-- `WithDefaultLimit(defaultLimit int) PaginatorOption` - Sets the default limit
-
-### Types
-
-- `PageFetcher[T any]` - A function type for fetching a page of results
-- `PageOptions` - Options for fetching a page (limit, offset, cursor, filters)
-- `PageResult[T any]` - Represents a single page of results
-- `PageInfo` - Contains information about the current page
-- `Observer` - Interface for observing pagination events
-- `Event` - Represents a pagination operation event
-
-## VIII. Retry Package (`midaz/pkg/retry`)
-
-The retry package provides utilities for implementing retry logic with exponential backoff and jitter for resilient operations.
-
-### Core Functions
-
-- `Do(ctx context.Context, fn func() error, opts ...Option) error` - Executes a function with retries
-- `DoWithContext(ctx context.Context, fn func() error) error` - Executes a function with retry options from context
-- `IsRetryableError(err error, options *Options) bool` - Checks if an error is retryable
-- `WithOptionsContext(ctx context.Context, options *Options) context.Context` - Returns a context with retry options
-- `GetOptionsFromContext(ctx context.Context) *Options` - Gets retry options from context
-
-### Retry Options
-
-- `WithMaxRetries(maxRetries int) Option` - Sets the maximum number of retry attempts
-- `WithInitialDelay(delay time.Duration) Option` - Sets the initial delay before first retry
-- `WithMaxDelay(delay time.Duration) Option` - Sets the maximum delay between retries
-- `WithBackoffFactor(factor float64) Option` - Sets the factor by which to increase delay
-- `WithRetryableErrors(errors []string) Option` - Sets the error strings that trigger retry
-- `WithRetryableHTTPCodes(codes []int) Option` - Sets the HTTP status codes that trigger retry
-- `WithJitterFactor(factor float64) Option` - Sets the amount of jitter to add to delay
-- `WithHighReliability() Option` - Configures options for high reliability
-- `WithNoRetry() Option` - Disables retries
-
-### HTTP Retry Functions
-
-- `DoHTTPRequest(ctx context.Context, client *http.Client, req *http.Request, opts ...HTTPOption) (*HTTPResponse, error)` - Performs HTTP request with retries
-- `DoHTTPRequestWithContext(ctx context.Context, client *http.Client, req *http.Request) (*HTTPResponse, error)` - Performs HTTP request with options from context
-- `DoHTTP(ctx context.Context, client *http.Client, method, url string, body io.Reader, opts ...HTTPOption) (*HTTPResponse, error)` - Simplified HTTP request with retries
-- `WithHTTPOptionsContext(ctx context.Context, options *HTTPOptions) context.Context` - Returns context with HTTP retry options
-- `GetHTTPOptionsFromContext(ctx context.Context) *HTTPOptions` - Gets HTTP retry options from context
-
-### HTTP Retry Options
-
-- `WithHTTPMaxRetries(maxRetries int) HTTPOption` - Sets the maximum number of retry attempts
-- `WithHTTPInitialDelay(delay time.Duration) HTTPOption` - Sets the initial delay before first retry
-- `WithHTTPMaxDelay(delay time.Duration) HTTPOption` - Sets the maximum delay between retries
-- `WithHTTPBackoffFactor(factor float64) HTTPOption` - Sets the factor by which to increase delay
-- `WithHTTPRetryableHTTPCodes(codes []int) HTTPOption` - Sets HTTP status codes for retry
-- `WithHTTPRetryableNetworkErrors(errors []string) HTTPOption` - Sets network errors for retry
-- `WithHTTPRetryAllServerErrors(retry bool) HTTPOption` - Sets whether to retry all 5xx errors
-- `WithHTTPRetryOn4xx(codes []int) HTTPOption` - Sets 4xx status codes to retry
-- `WithHTTPPreRetryHook(hook func(ctx context.Context, req *http.Request, resp *HTTPResponse) error) HTTPOption` - Sets hook before retry
-- `WithHTTPJitterFactor(factor float64) HTTPOption` - Sets jitter factor for HTTP retries
-- `WithHTTPHighReliability() HTTPOption` - Configures HTTP options for high reliability
-- `WithHTTPNoRetry() HTTPOption` - Disables HTTP retries
-
-## IX. Validation Package (`midaz/pkg/validation`)
-
-The validation package provides utilities for validating various aspects of Midaz data.
-
-### Core Validation Functions
-
-- `DefaultValidator() *Validator` - Returns a validator with default configuration
-- `NewValidator(options ...core.ValidationOption) (*Validator, error)` - Creates a validator with options
-- `ValidateTransactionDSL(input TransactionDSLValidator) error` - Validates transaction DSL input
-- `ValidateAssetCode(assetCode string) error` - Validates asset code format (3-4 uppercase letters)
-- `ValidateAccountAlias(alias string) error` - Validates account alias format
-- `ValidateTransactionCode(code string) error` - Validates transaction code format
-- `ValidateMetadata(metadata map[string]any) error` - Validates metadata types and structure
-- `ValidateDateRange(start, end time.Time) error` - Validates that start is not after end
-- `ValidateCreateTransactionInput(input map[string]any) ValidationSummary` - Comprehensive validation
-- `ValidateAssetType(assetType string) error` - Validates asset type is supported
-- `ValidateAccountType(accountType string) error` - Validates account type is supported
-- `ValidateCurrencyCode(code string) error` - Validates ISO 4217 currency code
-- `ValidateCountryCode(code string) error` - Validates ISO 3166-1 alpha-2 country code
-- `ValidateAddress(address *Address) error` - Validates address structure
-- `GetExternalAccountReference(assetCode string) string` - Creates external account reference
-
-### Validation Methods
-
-- `Validator.ValidateMetadata(metadata map[string]any) error` - Validates metadata with configuration
-- `Validator.ValidateAddress(address *Address) error` - Validates address with configuration
-
-### Validation Configuration Options
-
-- `core.WithMaxMetadataSize(size int) ValidationOption` - Sets maximum metadata size
-- `core.WithMaxStringLength(length int) ValidationOption` - Sets maximum string length
-- `core.WithMaxAddressLineLength(length int) ValidationOption` - Sets maximum address line length
-- `core.WithMaxZipCodeLength(length int) ValidationOption` - Sets maximum zip code length
-- `core.WithMaxCityLength(length int) ValidationOption` - Sets maximum city name length
-- `core.WithMaxStateLength(length int) ValidationOption` - Sets maximum state name length
-- `core.WithStrictMode(strict bool) ValidationOption` - Enables additional validation checks
-
-### Validation Results
-
-- `ValidationSummary` - Holds results of validation with multiple potential errors
-- `ValidationSummary.AddError(err error)` - Adds an error to the validation summary
-- `ValidationSummary.GetErrorMessages() []string` - Returns all error messages as strings
-- `ValidationSummary.GetErrorSummary() string` - Returns a single string with all errors
-
-## X. Models Package (`midaz/models`)
-
-The models package defines the data structures used throughout the SDK.
-
-### Resource Models
-
-- `Organization` - Represents an organization in the system
-- `Ledger` - Represents a ledger in the system
-- `Account` - Represents an account in the system
-- `Asset` - Represents an asset in the system
-- `Portfolio` - Represents a portfolio in the system
-- `Segment` - Represents a segment in the system
-- `Transaction` - Represents a transaction in the system
-- `Operation` - Represents an operation within a transaction
-- `Balance` - Represents an account balance
-
-### Input Models
-
-- `CreateOrganizationInput` - Input for creating an organization
-- `UpdateOrganizationInput` - Input for updating an organization
-- `CreateLedgerInput` - Input for creating a ledger
-- `UpdateLedgerInput` - Input for updating a ledger
-- `CreateAccountInput` - Input for creating an account
-- `UpdateAccountInput` - Input for updating an account
-- `CreateAssetInput` - Input for creating an asset
-- `UpdateAssetInput` - Input for updating an asset
-- `CreatePortfolioInput` - Input for creating a portfolio
-- `UpdatePortfolioInput` - Input for updating a portfolio
-- `CreateSegmentInput` - Input for creating a segment
-- `UpdateSegmentInput` - Input for updating a segment
-- `CreateTransactionInput` - Input for creating a transaction
-- `CreateOperationInput` - Input for creating an operation
-- `UpdateBalanceInput` - Input for updating a balance
-
-### Response Models
-
-- `ListResponse` - Generic paginated response for list operations
-- `ListOptions` - Options for list operations
-
-### Common Types and Constants
-
-- `Status` - Enum for resource status
-- `Address` - Struct for address information
-- `TransactionStatus` constants - Pending, Committed, Canceled
-- `OperationType` constants - Debit, Credit
-- `AssetType` constants - Currency, Stock, Crypto
+# Midaz Go SDK public API map
+
+This map documents the recommended public SDK surface that consumers should use. It is not a replacement for generated Go docs. The root module is `github.com/LerianStudio/midaz-sdk-golang/v2`; the Go package name is `client`.
+
+## Root package
+
+### Constructor
+
+- `client.New(options ...client.Option) (*client.Client, error)` - Creates an SDK client.
+
+### Client options
+
+- `client.WithConfig(*config.Config)` - Uses a pre-built SDK configuration.
+- `client.WithBaseURL(string)` - Sets a shared base URL and derives Ledger/CRM service URLs.
+- `client.WithOnboardingURL(string)` - Sets the onboarding alias URL.
+- `client.WithTransactionURL(string)` - Sets the transaction alias URL.
+- `client.WithCRMURL(string)` - Sets the CRM service URL.
+- `client.WithEnvironment(config.Environment)` - Uses a named environment preset.
+- `client.WithHTTPClient(*http.Client)` - Supplies a custom HTTP client.
+- `client.WithTimeout(time.Duration)` - Sets request timeout.
+- `client.WithRetries(maxRetries int, initialDelay, maxDelay time.Duration)` - Configures retry behavior.
+- `client.WithCustomRetryPolicy(*retry.Options)` - Uses a custom retry policy.
+- `client.DisableRetries()` - Disables client retries.
+- `client.WithDebug(bool)` - Enables or disables debug logging.
+- `client.WithTenantID(string)` - Sets a default tenant ID on entity clients.
+- `client.WithContext(context.Context)` - Sets the client base context.
+- `client.WithObservability(tracing, metrics, logging bool)` - Enables SDK-created observability components.
+- `client.WithObservabilityOptions(...observability.Option)` - Configures SDK-created observability.
+- `client.WithObservabilityProvider(observability.Provider)` - Uses an existing observability provider.
+- `client.WithCollectorEndpoint(string)` - Configures the OTLP collector endpoint for SDK-created observability.
+- `client.UseAllAPIs()` - Enables all currently supported API surfaces.
+- `client.UseEntityAPI()` - Enables the entity API surface.
+- `client.UseEntity()` - Compatibility alias for `UseEntityAPI()`.
+
+### Client fields and methods
+
+- `Client.Entity` - Entity service access point. Initialized only when entity APIs are enabled.
+- `Client.GetVersion() string` - Returns the SDK version.
+- `Client.Shutdown(context.Context) error` - Releases observability resources.
+- `Client.Trace(name string, fn func(context.Context) error) error` - Runs a function inside a span when observability is enabled.
+- `Client.Logger() observability.Logger` - Returns the configured logger.
+- `Client.GetObservabilityProvider() observability.Provider` - Returns the active observability provider.
+- `Client.GetMetricsCollector() *observability.MetricsCollector` - Returns the metrics collector when available.
+- `Client.GetContext() context.Context` - Returns the client base context.
+- `Client.GetConfiguration() *config.Config` - Returns the current configuration.
+- `Client.GetConfig() *config.Config` - Compatibility alias for `GetConfiguration`.
+
+## Configuration package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/config`.
+
+### Constructors and options
+
+- `config.DefaultConfig() *config.Config`
+- `config.NewConfig(options ...config.Option) (*config.Config, error)`
+- `config.NewLocalConfig(options ...config.Option) (*config.Config, error)`
+- `config.FromEnvironment() config.Option`
+- `config.WithEnvironment(config.Environment) config.Option`
+- `config.WithBaseURL(string) config.Option`
+- `config.WithOnboardingURL(string) config.Option`
+- `config.WithTransactionURL(string) config.Option`
+- `config.WithCRMURL(string) config.Option`
+- `config.WithAccessManager(auth.AccessManager) config.Option`
+- `config.WithHTTPClient(*http.Client) config.Option`
+- `config.WithTimeout(time.Duration) config.Option`
+- `config.WithUserAgent(string) config.Option`
+- `config.WithRetryConfig(maxRetries int, minWait, maxWait time.Duration) config.Option`
+- `config.WithMaxRetries(int) config.Option`
+- `config.WithRetryWaitMin(time.Duration) config.Option`
+- `config.WithRetryWaitMax(time.Duration) config.Option`
+- `config.WithRetries(bool) config.Option`
+- `config.WithDebug(bool) config.Option`
+- `config.WithTenantID(string) config.Option`
+- `config.WithIdempotency(bool) config.Option`
+- `config.WithObservabilityProvider(observability.Provider) config.Option`
+
+### Environment variables read by `config.FromEnvironment`
+
+- `MIDAZ_ENVIRONMENT`
+- `MIDAZ_BASE_URL`
+- `MIDAZ_ONBOARDING_URL`
+- `MIDAZ_TRANSACTION_URL`
+- `MIDAZ_CRM_URL`
+- `MIDAZ_USER_AGENT`
+- `MIDAZ_TIMEOUT`
+- `MIDAZ_DEBUG`
+- `MIDAZ_MAX_RETRIES`
+- `MIDAZ_IDEMPOTENCY`
+- `PLUGIN_AUTH_ENABLED`
+- `PLUGIN_AUTH_ADDRESS`
+- `MIDAZ_CLIENT_ID`
+- `MIDAZ_CLIENT_SECRET`
+
+## Access Manager package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager` with alias `auth`.
+
+- `auth.AccessManager` - Plugin authentication configuration with `Enabled`, `Address`, `ClientID`, and `ClientSecret`.
+- `config.WithAccessManager(auth.AccessManager)` - Attaches Access Manager configuration to SDK config.
+
+## Entity package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/entities`. Consumers usually access services through `c.Entity`.
+
+### Entity access point
+
+- `Entity.Accounts`
+- `Entity.AccountTypes`
+- `Entity.Assets`
+- `Entity.AssetRates`
+- `Entity.Balances`
+- `Entity.Holders`
+- `Entity.Aliases`
+- `Entity.Ledgers`
+- `Entity.MetadataIndexes`
+- `Entity.Operations`
+- `Entity.OperationRoutes`
+- `Entity.Organizations`
+- `Entity.Portfolios`
+- `Entity.Segments`
+- `Entity.Transactions`
+- `Entity.TransactionRoutes`
+
+### OrganizationsService
+
+- `ListOrganizations(ctx, opts)`
+- `GetOrganization(ctx, id)`
+- `CreateOrganization(ctx, input)`
+- `UpdateOrganization(ctx, id, input)`
+- `DeleteOrganization(ctx, id)`
+
+### LedgersService
+
+- `ListLedgers(ctx, organizationID, opts)`
+- `GetLedger(ctx, organizationID, id)`
+- `CreateLedger(ctx, organizationID, input)`
+- `UpdateLedger(ctx, organizationID, id, input)`
+- `DeleteLedger(ctx, organizationID, id)`
+
+### AccountsService
+
+- `ListAccounts(ctx, organizationID, ledgerID, opts)`
+- `GetAccount(ctx, organizationID, ledgerID, id)`
+- `GetAccountByAlias(ctx, organizationID, ledgerID, alias)`
+- `CreateAccount(ctx, organizationID, ledgerID, input)`
+- `UpdateAccount(ctx, organizationID, ledgerID, id, input)`
+- `DeleteAccount(ctx, organizationID, ledgerID, id)`
+- `GetBalance(ctx, organizationID, ledgerID, accountID)`
+- `GetAccountsMetricsCount(ctx, organizationID, ledgerID)`
+- `GetExternalAccount(ctx, organizationID, ledgerID, assetCode)`
+- `GetExternalAccountBalance(ctx, organizationID, ledgerID, assetCode)`
+- `GetAccountByAliasPath(ctx, organizationID, ledgerID, alias)`
+
+### AccountTypesService
+
+- `ListAccountTypes(ctx, organizationID, ledgerID, opts)`
+- `GetAccountType(ctx, organizationID, ledgerID, id)`
+- `CreateAccountType(ctx, organizationID, ledgerID, input)`
+- `UpdateAccountType(ctx, organizationID, ledgerID, id, input)`
+- `DeleteAccountType(ctx, organizationID, ledgerID, id)`
+- `GetAccountTypesMetricsCount(ctx, organizationID, ledgerID)`
+
+### AssetsService
+
+- `ListAssets(ctx, organizationID, ledgerID, opts)`
+- `GetAsset(ctx, organizationID, ledgerID, id)`
+- `CreateAsset(ctx, organizationID, ledgerID, input)`
+- `UpdateAsset(ctx, organizationID, ledgerID, id, input)`
+- `DeleteAsset(ctx, organizationID, ledgerID, id)`
+
+### AssetRatesService
+
+- `CreateOrUpdateAssetRate(ctx, organizationID, ledgerID, input)`
+- `GetAssetRate(ctx, organizationID, ledgerID, externalID)`
+- `ListAssetRatesByAssetCode(ctx, organizationID, ledgerID, assetCode, opts)`
+
+### BalancesService
+
+- `ListBalances(ctx, orgID, ledgerID, opts)`
+- `ListAccountBalances(ctx, orgID, ledgerID, accountID, opts)`
+- `GetBalance(ctx, orgID, ledgerID, balanceID)`
+- `GetBalanceHistory(ctx, orgID, ledgerID, balanceID, date)`
+- `UpdateBalance(ctx, orgID, ledgerID, balanceID, input)`
+- `DeleteBalance(ctx, orgID, ledgerID, balanceID)`
+- `CreateBalance(ctx, orgID, ledgerID, accountID, input)`
+- `ListBalancesByAccountAlias(ctx, orgID, ledgerID, alias, opts)`
+- `ListBalancesByExternalCode(ctx, orgID, ledgerID, code, opts)`
+- `GetAccountBalancesHistory(ctx, orgID, ledgerID, accountID, date)`
+
+### PortfoliosService
+
+- `ListPortfolios(ctx, organizationID, ledgerID, opts)`
+- `GetPortfolio(ctx, organizationID, ledgerID, id)`
+- `CreatePortfolio(ctx, organizationID, ledgerID, input)`
+- `UpdatePortfolio(ctx, organizationID, ledgerID, id, input)`
+- `DeletePortfolio(ctx, organizationID, ledgerID, id)`
+
+### SegmentsService
+
+- `ListSegments(ctx, organizationID, ledgerID, opts)`
+- `GetSegment(ctx, organizationID, ledgerID, id)`
+- `CreateSegment(ctx, organizationID, ledgerID, input)`
+- `UpdateSegment(ctx, organizationID, ledgerID, id, input)`
+- `DeleteSegment(ctx, organizationID, ledgerID, id)`
+
+### OperationsService
+
+- `ListOperations(ctx, orgID, ledgerID, accountID, opts)`
+- `GetOperation(ctx, orgID, ledgerID, accountID, operationID)`
+- `UpdateTransactionOperation(ctx, orgID, ledgerID, transactionID, operationID, input)`
+- `UpdateOperation(ctx, orgID, ledgerID, accountID, operationID, input)` - Deprecated compatibility method.
+
+### OperationRoutesService
+
+- `ListOperationRoutes(ctx, organizationID, ledgerID, opts)`
+- `GetOperationRoute(ctx, organizationID, ledgerID, operationRouteID)`
+- `CreateOperationRoute(ctx, organizationID, ledgerID, input)`
+- `UpdateOperationRoute(ctx, organizationID, ledgerID, operationRouteID, input)`
+- `DeleteOperationRoute(ctx, organizationID, ledgerID, operationRouteID)`
+
+### TransactionRoutesService
+
+- `ListTransactionRoutes(ctx, organizationID, ledgerID, opts)`
+- `GetTransactionRoute(ctx, organizationID, ledgerID, transactionRouteID)`
+- `CreateTransactionRoute(ctx, organizationID, ledgerID, input)`
+- `UpdateTransactionRoute(ctx, organizationID, ledgerID, transactionRouteID, input)`
+- `DeleteTransactionRoute(ctx, organizationID, ledgerID, transactionRouteID)`
+
+### TransactionsService
+
+- `CreateTransaction(ctx, orgID, ledgerID, input)`
+- `CreateTransactionWithDSL(ctx, orgID, ledgerID, input)`
+- `CreateTransactionWithDSLFile(ctx, orgID, ledgerID, dslContent)`
+- `GetTransaction(ctx, orgID, ledgerID, transactionID)`
+- `ListTransactions(ctx, orgID, ledgerID, opts)`
+- `GetTransactionsMetricsCount(ctx, orgID, ledgerID, opts)`
+- `UpdateTransaction(ctx, orgID, ledgerID, transactionID, input)`
+- `RevertTransaction(ctx, orgID, ledgerID, transactionID)`
+- `CommitTransaction(ctx, orgID, ledgerID, transactionID)`
+- `CancelTransaction(ctx, orgID, ledgerID, transactionID)`
+- `CancelTransactionWithResponse(ctx, orgID, ledgerID, transactionID)`
+- `CreateInflowTransaction(ctx, orgID, ledgerID, input)`
+- `CreateOutflowTransaction(ctx, orgID, ledgerID, input)`
+- `CreateAnnotationTransaction(ctx, orgID, ledgerID, input)`
+
+### MetadataIndexesService
+
+- `ListMetadataIndexes(ctx, entityName)`
+- `CreateMetadataIndex(ctx, entityName, input)`
+- `DeleteMetadataIndex(ctx, entityName, metadataKey)`
+
+### CRM services
+
+CRM services use the CRM base URL and set the organization through the `X-Organization-Id` header.
+
+#### HoldersService
+
+- `ListHolders(ctx, organizationID, opts)`
+- `CreateHolder(ctx, organizationID, input)`
+- `GetHolder(ctx, organizationID, holderID, includeDeleted)`
+- `UpdateHolder(ctx, organizationID, holderID, input)`
+- `DeleteHolder(ctx, organizationID, holderID, hardDelete)`
+
+#### AliasesService
+
+- `ListAliases(ctx, organizationID, opts)`
+- `CreateAlias(ctx, organizationID, holderID, input)`
+- `GetAlias(ctx, organizationID, holderID, aliasID, includeDeleted)`
+- `UpdateAlias(ctx, organizationID, holderID, aliasID, input)`
+- `DeleteAlias(ctx, organizationID, holderID, aliasID, hardDelete)`
+- `DeleteRelatedParty(ctx, organizationID, holderID, aliasID, relatedPartyID)`
+
+## Models package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/models`.
+
+### List and pagination
+
+- `models.NewListOptions()`
+- `(*models.ListOptions).WithLimit(int)`
+- `(*models.ListOptions).WithOffset(int)` - Compatibility input; query serialization uses `page`.
+- `(*models.ListOptions).WithPage(int)`
+- `(*models.ListOptions).WithCursor(string)`
+- `(*models.ListOptions).WithOrderBy(string)` - Stored for compatibility; not sent by common query serialization.
+- `(*models.ListOptions).WithOrderDirection(models.SortDirection)` - Sent as `sort_order`.
+- `(*models.ListOptions).WithFilter(key, value string)`
+- `(*models.ListOptions).WithFilters(map[string]string)`
+- `(*models.ListOptions).WithDateRange(startDate, endDate string)`
+- `(*models.ListOptions).WithAdditionalParam(key, value string)`
+- `(*models.ListOptions).WithIncludeDeleted(bool)`
+- `(*models.ListOptions).WithHolderID(string)`
+- `(*models.ListOptions).WithExternalID(string)`
+- `(*models.ListOptions).WithDocument(string)`
+- `(*models.ListOptions).WithAccountID(string)`
+- `(*models.ListOptions).WithLedgerID(string)`
+- `(*models.ListOptions).WithParticipantDocument(string)`
+- `(*models.ListOptions).WithRelatedPartyDocument(string)`
+- `(*models.ListOptions).ToQueryParams()`
+- `(*models.Pagination).HasNextPage()`
+- `(*models.Pagination).NextPageOptions()`
+- `(*models.Pagination).HasPrevPage()`
+- `(*models.Pagination).PrevPageOptions()`
+- `(*models.Pagination).CurrentPage()`
+- `(*models.Pagination).TotalPages()`
+
+### Common input builders
+
+- `models.NewCreateOrganizationInput(legalName, legalDocument)`
+- `models.NewUpdateOrganizationInput()`
+- `models.NewCreateAssetInput(name, code)`
+- `models.NewUpdateAssetInput()`
+- `models.NewCreateTransactionInput(assetCode, amount)`
+- `models.NewCreateAccountInput(name, assetCode, accountType)`
+- `models.NewAssetRateListOptions()`
+
+## Errors package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors`.
+
+- Core type: `*errors.Error`.
+- Sentinel errors: `ErrValidation`, `ErrAuthentication`, `ErrPermission`, `ErrNotFound`, `ErrAlreadyExists`, `ErrIdempotency`, `ErrRateLimit`, `ErrTimeout`, `ErrCancellation`, `ErrInternal`, `ErrInsufficientBalance`, `ErrAccountEligibility`, `ErrAssetMismatch`.
+- Checkers: `IsValidationError`, `IsNotFoundError`, `IsAuthenticationError`, `IsAuthorizationError`, `IsPermissionError`, `IsConflictError`, `IsAlreadyExistsError`, `IsRateLimitError`, `IsTimeoutError`, `IsNetworkError`, `IsCancellationError`, `IsInternalError`, `IsInsufficientBalanceError`, `IsAccountEligibilityError`, `IsAssetMismatchError`, `IsIdempotencyError`.
+- Accessors: `GetErrorCategory`, `GetStatusCode`, `GetErrorCode`, `GetErrorDetails`, `GetTransactionErrorContext`.
+- Constructors: `NewValidationError`, `NewInvalidInputError`, `NewNotFoundError`, `NewAuthenticationError`, `NewAuthorizationError`, `NewConflictError`, `NewRateLimitError`, `NewTimeoutError`, `NewInternalError`.
+
+## Observability package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/observability`.
+
+- `observability.New(ctx, opts...)`
+- `observability.WithServiceName(string)`
+- `observability.WithServiceVersion(string)`
+- `observability.WithEnvironment(string)`
+- `observability.WithCollectorEndpoint(string)` - OTLP gRPC endpoint in `host:port` form.
+- `observability.WithSDKVersion(string)`
+- `observability.WithLogLevel(observability.LogLevel)`
+- `observability.WithTraceSampleRate(float64)`
+- `observability.WithComponentEnabled(tracing, metrics, logging bool)`
+- `observability.WithAttributes(...attribute.KeyValue)`
+- `observability.WithPropagationHeaders(...string)`
+- `observability.WithRegisterGlobally(bool)`
+- `observability.WithProvider(context.Context, observability.Provider)`
+- `observability.WithDevelopmentDefaults()`
+- `observability.WithProductionDefaults()`
+- `observability.ExtractContext(ctx, headers)`
+- `observability.InjectContext(ctx, headers)`
+- `observability.TraceID(ctx)`
+- `observability.SpanID(ctx)`
+- `observability.RecordMetric(ctx, provider, name, value, attrs...)`
+- `observability.RecordDuration(ctx, provider, name, start, attrs...)`
+
+## Retry package
+
+Use `github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry`.
+
+- `retry.Do(ctx, fn, opts...)`
+- `retry.DoWithContext(ctx, fn)`
+- `retry.IsRetryableError(err, options)`
+- `retry.WithMaxRetries(int)`
+- `retry.WithInitialDelay(time.Duration)`
+- `retry.WithMaxDelay(time.Duration)`
+- `retry.WithBackoffFactor(float64)`
+- `retry.WithJitterFactor(float64)`
+- `retry.WithRetryableHTTPCodes([]int)`
+- `retry.WithHighReliability()`
+- `retry.WithNoRetry()`

--- a/docs/mapping/internal_apis.md
+++ b/docs/mapping/internal_apis.md
@@ -1,725 +1,254 @@
-# Midaz Go SDK Internal API Map
+# Midaz Go SDK internal API map
 
-This document provides a comprehensive overview of the internal APIs used by the Midaz Go SDK, organized by package and purpose. These APIs are not intended for direct use by SDK consumers but are documented here for SDK maintainers and contributors.
+This map is for SDK maintainers. It describes the implementation structure behind the public API. SDK consumers should prefer [external_apis.md](./external_apis.md).
 
-## Table of Contents
+## Runtime architecture
 
-- [I. Client Package](#i-client-package-midazclient)
-- [II. Resource Clients](#ii-resource-clients-midazclient)
-- [III. Models Package](#iii-models-package-midazmodels)
-- [IV. Error Handling](#iv-error-handling-midazerrors)
-- [V. Implementation Patterns](#v-implementation-patterns)
+The current SDK is organized around a root client and an entity layer:
 
-## I. Client Package (`midaz/client`)
+1. `client.Client` owns configuration, observability, lifecycle, and optional API surface initialization.
+2. `pkg/config.Config` resolves service URLs, Access Manager settings, retry/debug options, HTTP client, and observability provider.
+3. `entities.Entity` exposes the service interfaces used by consumers.
+4. Private entity implementations such as `accountsEntity`, `transactionsEntity`, and `holdersEntity` translate service methods into HTTP requests.
+5. `entities.HTTPClient` handles request construction, authentication headers, tenant/idempotency headers, tracing propagation, retry behavior, debug logging, and response/error conversion.
+6. `models` contains public request/response structures, Midaz model aliases, list options, pagination metadata, and builder helpers.
 
-The client package provides the foundation for all API interactions, handling HTTP requests, authentication, and error processing.
+The SDK does not currently use the older `apiClient`, `httpClient`, or per-resource `organizationClient` style architecture.
 
-### HTTP Client
+## Root client internals
 
-- `httpClient` - Handles all HTTP requests to the Midaz API
+`client.Client` includes:
 
-  ```go
-  type httpClient struct {
-      baseURL       string
-      authToken     string
-      httpClient    *http.Client
-      debug         bool
-      userAgent     string
-      retryOptions  *retry.Options
-      jsonPool      *performance.JSONPool
-      metrics       observability.MetricsProvider
-      observability observability.Provider
-  }
-  ```
+- `Entity *entities.Entity` - Set only when `UseAllAPIs`, `UseEntityAPI`, or `UseEntity` is provided.
+- `config *config.Config` - Resolved SDK configuration.
+- `observability observability.Provider` - Optional tracing, metrics, and logging provider.
+- `httpClient *http.Client` - Underlying HTTP client.
+- Retry, timeout, debug, and URL override fields used while applying client options.
 
-  - `Do(ctx context.Context, req *http.Request) (*http.Response, error)` - Executes an HTTP request with retries and error handling
+Entity initialization is gated by the `useEntity` flag. Docs and examples that access `c.Entity` must create the client with `client.UseAllAPIs()` or `client.UseEntityAPI()`.
 
-    ```go
-    // Implementation pattern
-    func (c *httpClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
-        // Add authentication headers
-        req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
-        req.Header.Set("User-Agent", c.userAgent)
+## Configuration flow
 
-        // Execute request with retry logic
-        var resp *http.Response
-        var err error
-        for attempt := 0; attempt < maxRetries; attempt++ {
-            resp, err = c.httpClient.Do(req.WithContext(ctx))
-            if err == nil || !isRetryableError(err) {
-                break
-            }
-            time.Sleep(backoffDuration(attempt))
-        }
-
-        // Handle response errors
-        if err != nil {
-            return nil, err
-        }
-
-        if resp.StatusCode >= 400 {
-            return resp, handleErrorResponse(resp)
-        }
-
-        return resp, nil
-    }
-    ```
-
-  - `Get(ctx context.Context, path string, params url.Values) (*http.Response, error)` - Performs an HTTP GET request
-  - `Post(ctx context.Context, path string, body interface{}) (*http.Response, error)` - Performs an HTTP POST request
-  - `Put(ctx context.Context, path string, body interface{}) (*http.Response, error)` - Performs an HTTP PUT request
-  - `Delete(ctx context.Context, path string) (*http.Response, error)` - Performs an HTTP DELETE request
-  - `Patch(ctx context.Context, path string, body interface{}) (*http.Response, error)` - Performs an HTTP PATCH request
-
-### API Client
-
-- `apiClient` - Base client for all API operations
-
-  ```go
-  type apiClient struct {
-      httpClient      *httpClient
-      serviceURLs     map[string]string // Map of service names to URLs
-      timeout         time.Duration
-      debug           bool
-      userAgent       string
-      observability   observability.Provider
-  }
-  ```
-
-  - `SetAuthToken(token string)` - Sets the authentication token
-
-    ```go
-    func (c *apiClient) SetAuthToken(token string) {
-        c.httpClient.authToken = token
-    }
-    ```
-
-  - `SetServiceURLs(serviceURLs map[string]string)` - Sets the service-specific URLs
-
-    ```go
-    func (c *apiClient) SetServiceURLs(serviceURLs map[string]string) {
-        c.serviceURLs = serviceURLs
-    }
-    ```
-
-  - `SetTimeout(seconds int)` - Sets the request timeout
-  - `SetDebug(debug bool)` - Enables or disables debug mode
-  - `SetUserAgent(userAgent string)` - Sets the user agent string used for API requests
-
-## II. Resource Clients (`midaz/client`)
-
-These clients handle specific resource operations. Each client encapsulates the API operations for a specific resource type.
-
-### Organization Client
-
-- `organizationClient` - Handles organization-related API operations
-
-  ```go
-  type organizationClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.Organization], error)` - Lists organizations
-
-    ```go
-    // Implementation pattern
-    func (c *organizationClient) List(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.Organization], error) {
-        path := "/organizations"
-        params := url.Values{}
-
-        // Add pagination parameters
-        if opts != nil {
-            if opts.Page > 0 {
-                params.Set("page", strconv.Itoa(opts.Page))
-            }
-            if opts.Limit > 0 {
-                params.Set("limit", strconv.Itoa(opts.Limit))
-            }
-            // Add other filter parameters
-        }
-
-        resp, err := c.apiClient.httpClient.Get(ctx, path, params)
-        if err != nil {
-            return nil, err
-        }
-        defer resp.Body.Close()
-
-        var result models.ListResponse[models.Organization]
-        if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-            return nil, err
-        }
-
-        return &result, nil
-    }
-    ```
-
-  - `Get(ctx context.Context, id string) (*models.Organization, error)` - Gets an organization by ID
-  - `Create(ctx context.Context, input *models.CreateOrganizationInput) (*models.Organization, error)` - Creates a new organization
-  - `Update(ctx context.Context, id string, input *models.UpdateOrganizationInput) (*models.Organization, error)` - Updates an organization
-  - `Delete(ctx context.Context, id string) error` - Deletes an organization
-
-### Ledger Client
-
-- `ledgerClient` - Handles ledger-related API operations
-
-  ```go
-  type ledgerClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Ledger], error)` - Lists ledgers for an organization
-  - `Get(ctx context.Context, organizationID, id string) (*models.Ledger, error)` - Gets a ledger by ID
-  - `Create(ctx context.Context, organizationID string, input *models.CreateLedgerInput) (*models.Ledger, error)` - Creates a new ledger
-  - `Update(ctx context.Context, organizationID, id string, input *models.UpdateLedgerInput) (*models.Ledger, error)` - Updates a ledger
-  - `Delete(ctx context.Context, organizationID, id string) error` - Deletes a ledger
-
-### Account Client
-
-- `accountClient` - Handles account-related API operations
-
-  ```go
-  type accountClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Account], error)` - Lists accounts for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.Account, error)` - Gets an account by ID
-  - `GetByAlias(ctx context.Context, organizationID, ledgerID, alias string) (*models.Account, error)` - Gets an account by alias
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateAccountInput) (*models.Account, error)` - Creates a new account
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateAccountInput) (*models.Account, error)` - Updates an account
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes an account
-
-### Asset Client
-
-- `assetClient` - Handles asset-related API operations
-
-  ```go
-  type assetClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Asset], error)` - Lists assets for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.Asset, error)` - Gets an asset by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateAssetInput) (*models.Asset, error)` - Creates a new asset
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateAssetInput) (*models.Asset, error)` - Updates an asset
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes an asset
-
-### Portfolio Client
-
-- `portfolioClient` - Handles portfolio-related API operations
-
-  ```go
-  type portfolioClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Portfolio], error)` - Lists portfolios for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.Portfolio, error)` - Gets a portfolio by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreatePortfolioInput) (*models.Portfolio, error)` - Creates a new portfolio
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdatePortfolioInput) (*models.Portfolio, error)` - Updates a portfolio
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes a portfolio
-
-### Segment Client
-
-- `segmentClient` - Handles segment-related API operations
-
-  ```go
-  type segmentClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID, portfolioID string, opts *models.ListOptions) (*models.ListResponse[models.Segment], error)` - Lists segments for a portfolio
-  - `Get(ctx context.Context, organizationID, ledgerID, portfolioID, id string) (*models.Segment, error)` - Gets a segment by ID
-  - `Create(ctx context.Context, organizationID, ledgerID, portfolioID string, input *models.CreateSegmentInput) (*models.Segment, error)` - Creates a new segment
-  - `Update(ctx context.Context, organizationID, ledgerID, portfolioID, id string, input *models.UpdateSegmentInput) (*models.Segment, error)` - Updates a segment
-  - `Delete(ctx context.Context, organizationID, ledgerID, portfolioID, id string) error` - Deletes a segment
-
-### Transaction Client
-
-- `transactionClient` - Handles transaction-related API operations
-
-  ```go
-  type transactionClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Transaction], error)` - Lists transactions for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.Transaction, error)` - Gets a transaction by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateTransactionInput) (*models.Transaction, error)` - Creates a new transaction
-
-    ```go
-    // Implementation pattern
-    func (c *transactionClient) Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateTransactionInput) (*models.Transaction, error) {
-        path := fmt.Sprintf("/organizations/%s/ledgers/%s/transactions", organizationID, ledgerID)
-
-        resp, err := c.apiClient.httpClient.Post(ctx, path, input)
-        if err != nil {
-            return nil, err
-        }
-        defer resp.Body.Close()
-
-        var result models.Transaction
-        if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-            return nil, err
-        }
-
-        return &result, nil
-    }
-    ```
-
-  - `Commit(ctx context.Context, organizationID, ledgerID, id string) (*models.Transaction, error)` - Commits a pending transaction
-  - `Cancel(ctx context.Context, organizationID, ledgerID, id string) (*models.Transaction, error)` - Cancels a pending transaction
-
-### Balance Client
-
-- `balanceClient` - Handles balance-related API operations
-
-  ```go
-  type balanceClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Balance], error)` - Lists balances for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.Balance, error)` - Gets a balance by ID
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateBalanceInput) (*models.Balance, error)` - Updates a balance
-
-### Account Type Client
-
-- `accountTypeClient` - Handles account type-related API operations
-
-  ```go
-  type accountTypeClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.AccountType], error)` - Lists account types for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.AccountType, error)` - Gets an account type by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateAccountTypeInput) (*models.AccountType, error)` - Creates a new account type
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateAccountTypeInput) (*models.AccountType, error)` - Updates an account type
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes an account type
-
-### Operation Route Client
-
-- `operationRouteClient` - Handles operation route-related API operations
-
-  ```go
-  type operationRouteClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.OperationRoute], error)` - Lists operation routes for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.OperationRoute, error)` - Gets an operation route by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateOperationRouteInput) (*models.OperationRoute, error)` - Creates a new operation route
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateOperationRouteInput) (*models.OperationRoute, error)` - Updates an operation route
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes an operation route
-
-### Transaction Route Client
-
-- `transactionRouteClient` - Handles transaction route-related API operations
-
-  ```go
-  type transactionRouteClient struct {
-      apiClient *apiClient
-  }
-  ```
-
-  - `List(ctx context.Context, organizationID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.TransactionRoute], error)` - Lists transaction routes for a ledger
-  - `Get(ctx context.Context, organizationID, ledgerID, id string) (*models.TransactionRoute, error)` - Gets a transaction route by ID
-  - `Create(ctx context.Context, organizationID, ledgerID string, input *models.CreateTransactionRouteInput) (*models.TransactionRoute, error)` - Creates a new transaction route
-  - `Update(ctx context.Context, organizationID, ledgerID, id string, input *models.UpdateTransactionRouteInput) (*models.TransactionRoute, error)` - Updates a transaction route
-  - `Delete(ctx context.Context, organizationID, ledgerID, id string) error` - Deletes a transaction route
-
-## III. Models Package (`midaz/models`)
-
-The models package defines the data structures used throughout the SDK, representing API resources, request inputs, and responses.
-
-### Resource Models
-
-These structs represent the core resources in the Midaz API:
-
-- `Organization` - Represents an organization in the system
-
-  ```go
-  type Organization struct {
-      ID            string     `json:"id"`
-      LegalName     string     `json:"legalName"`
-      LegalDocument string     `json:"legalDocument,omitempty"`
-      Status        Status     `json:"status"`
-      Address       *Address   `json:"address,omitempty"`
-      CreatedAt     time.Time  `json:"createdAt"`
-      UpdatedAt     time.Time  `json:"updatedAt"`
-      DeletedAt     *time.Time `json:"deletedAt,omitempty"`
-      Metadata      map[string]any `json:"metadata,omitempty"`
-      Tags          []string   `json:"tags,omitempty"`
-  }
-  ```
-
-- `Ledger` - Represents a ledger in the system
-- `Account` - Represents an account in the system
-- `Asset` - Represents an asset in the system
-- `Portfolio` - Represents a portfolio in the system
-- `Segment` - Represents a segment in the system
-- `Transaction` - Represents a transaction in the system
-- `Operation` - Represents an operation within a transaction
-- `Balance` - Represents an account balance
-
-### Input Models
-
-These structs represent the input data for API operations:
-
-- `CreateOrganizationInput` - Input for creating an organization
-
-  ```go
-  type CreateOrganizationInput struct {
-      LegalName     string      `json:"legalName"`
-      LegalDocument string      `json:"legalDocument,omitempty"`
-      Status        Status      `json:"status,omitempty"`
-      Address       *Address    `json:"address,omitempty"`
-      Metadata      map[string]any  `json:"metadata,omitempty"`
-      Tags          []string    `json:"tags,omitempty"`
-  }
-  ```
-
-- `UpdateOrganizationInput` - Input for updating an organization
-- `CreateLedgerInput` - Input for creating a ledger
-- `UpdateLedgerInput` - Input for updating a ledger
-- `CreateAccountInput` - Input for creating an account
-- `UpdateAccountInput` - Input for updating an account
-- `CreateAssetInput` - Input for creating an asset
-- `UpdateAssetInput` - Input for updating an asset
-- `CreatePortfolioInput` - Input for creating a portfolio
-- `UpdatePortfolioInput` - Input for updating a portfolio
-- `CreateSegmentInput` - Input for creating a segment
-- `UpdateSegmentInput` - Input for updating a segment
-- `CreateTransactionInput` - Input for creating a transaction
-- `CreateOperationInput` - Input for creating an operation
-- `UpdateBalanceInput` - Input for updating a balance
-- `CreateAccountTypeInput` - Input for creating an account type
-- `CreateOperationRouteInput` - Input for creating an operation route
-- `CreateTransactionRouteInput` - Input for creating a transaction route
-- `TransactionDSLInput` - Input for creating transactions using DSL
-
-### Response Models
-
-These structs represent API responses:
-
-- `ListResponse` - Generic paginated response for list operations
-
-  ```go
-  type ListResponse[T any] struct {
-      Items      []T   `json:"items"`
-      Page       int   `json:"page"`
-      Limit      int   `json:"limit"`
-      TotalItems int   `json:"totalItems"`
-      TotalPages int   `json:"totalPages"`
-  }
-  ```
-
-- `ListOptions` - Options for list operations
-  ```go
-  type ListOptions struct {
-      Page    int               `json:"page,omitempty"`
-      Limit   int               `json:"limit,omitempty"`
-      Filters map[string]string `json:"filters,omitempty"`
-      Sort    map[string]string `json:"sort,omitempty"`
-  }
-  ```
-
-### Common Types and Constants
-
-- `Status` - Enum for resource status
-
-  ```go
-  type Status string
-
-  const (
-      StatusActive   Status = "active"
-      StatusInactive Status = "inactive"
-      StatusPending  Status = "pending"
-  )
-  ```
-
-- `Address` - Struct for address information
-- Transaction status constants
-- Operation type constants
-- Asset type constants
-
-## IV. Error Handling (`midaz/errors`)
-
-The errors package provides standardized error types and utilities for handling errors in a consistent way.
-
-### Error Types
-
-- `MidazError` - Custom error type with additional context
-
-  ```go
-  type MidazError struct {
-      Code      string
-      Message   string
-      Err       error
-      Resource  string
-      RequestID string
-  }
-
-  // Implements the error interface
-  func (e *MidazError) Error() string {
-      if e.Resource != "" {
-          return fmt.Sprintf("%s: %s (resource: %s)", e.Code, e.Message, e.Resource)
-      }
-      return fmt.Sprintf("%s: %s", e.Code, e.Message)
-  }
-
-  // Implements the Unwrap interface for errors.Is and errors.As
-  func (e *MidazError) Unwrap() error {
-      return e.Err
-  }
-  ```
-
-### Standard Error Codes
-
-- `ErrNotFound` - Returned when a resource is not found
-- `ErrValidation` - Returned when a request fails validation
-- `ErrTimeout` - Returned when a request times out
-- `ErrAuthentication` - Returned when authentication fails
-- `ErrPermission` - Returned when the user does not have permission
-- `ErrRateLimit` - Returned when the API rate limit is exceeded
-- `ErrInternal` - Returned when an unexpected error occurs
-
-### Transaction-Specific Errors
-
-- `ErrAccountEligibility` - Returned when accounts are not eligible for a transaction
-- `ErrAssetMismatch` - Returned when accounts have different asset types
-- `ErrInsufficientBalance` - Returned when a transaction would result in a negative balance
-
-### Error Handling Utilities
-
-- `NewError()` - Creates a new MidazError with the given code and error
-- `NewErrorf()` - Creates a new MidazError with the given code and formatted message
-- `APIErrorToError()` - Converts an internal API error type to a public error
-
-### Error Type Checking
-
-- `IsNotFoundError()` - Checks if the error is a not found error
-- `IsValidationError()` - Checks if the error is a validation error
-- `IsAccountEligibilityError()` - Checks if the error is related to account eligibility
-- `IsInsufficientBalanceError()` - Checks if the error is an insufficient balance error
-- `IsAssetMismatchError()` - Checks if the error is related to asset mismatch
-- `IsTimeoutError()` - Checks if the error is related to timeout
-- `IsAuthenticationError()` - Checks if the error is related to authentication
-- `IsPermissionError()` - Checks if the error is related to permissions
-- `IsRateLimitError()` - Checks if the error is related to rate limiting
-- `IsInternalError()` - Checks if the error is an internal error
-
-### Transaction Error Utilities
-
-- `FormatTransactionError()` - Produces a standardized error message for transaction errors
-- `CategorizeTransactionError()` - Provides the error category as a string
-- `GetTransactionErrorContext()` - Returns detailed context information for transaction errors
-- `IsTransactionRetryable()` - Determines if a transaction error can be safely retried
-
-## V. Implementation Patterns
-
-This section describes common implementation patterns used throughout the SDK.
-
-### Environment Variables
-
-The SDK uses environment variables for configuration, allowing users to customize behavior without changing code:
+Configuration is explicit:
 
 ```go
-// In config/config.go
-func configFromEnvironment() Config {
-    c := Config{
-        AuthToken:       os.Getenv("MIDAZ_AUTH_TOKEN"),
-        UserAgent:       "Midaz-Go-SDK/" + Version, // Uses version constant
-        Environment:     os.Getenv("MIDAZ_ENVIRONMENT"),
-    }
+cfg, err := config.NewConfig(config.FromEnvironment())
+if err != nil {
+    return err
+}
 
-    // Override defaults with environment variables if provided
-    if onboardingURL := os.Getenv("MIDAZ_ONBOARDING_URL"); onboardingURL != "" {
-        c.OnboardingURL = onboardingURL
-    }
+c, err := client.New(
+    client.WithConfig(cfg),
+    client.UseAllAPIs(),
+)
+```
 
-    if transactionURL := os.Getenv("MIDAZ_TRANSACTION_URL"); transactionURL != "" {
-        c.TransactionURL = transactionURL
-    }
+`config.FromEnvironment()` reads:
 
-    if userAgent := os.Getenv("MIDAZ_USER_AGENT"); userAgent != "" {
-        c.UserAgent = userAgent
-    }
+- `MIDAZ_ENVIRONMENT`
+- `MIDAZ_BASE_URL`
+- `MIDAZ_ONBOARDING_URL`
+- `MIDAZ_TRANSACTION_URL`
+- `MIDAZ_CRM_URL`
+- `MIDAZ_USER_AGENT`
+- `MIDAZ_TIMEOUT`
+- `MIDAZ_DEBUG`
+- `MIDAZ_MAX_RETRIES`
+- `MIDAZ_IDEMPOTENCY`
+- `PLUGIN_AUTH_ENABLED`
+- `PLUGIN_AUTH_ADDRESS`
+- `MIDAZ_CLIENT_ID`
+- `MIDAZ_CLIENT_SECRET`
 
-    return c
+Access Manager configuration uses `auth.AccessManager` and `config.WithAccessManager`. `MIDAZ_AUTH_TOKEN` is not part of `config.FromEnvironment()`.
+
+## Service URL model
+
+The entity layer receives a service URL map. The current service keys are:
+
+- `onboarding`
+- `transaction`
+- `crm`
+
+Ledger resources are split between onboarding and transaction URL aliases for compatibility. CRM resources use the CRM URL and pass organization context via `X-Organization-Id`.
+
+## Entity service implementations
+
+Each service has a public interface and a private implementation type. Method names are explicit (`ListAccounts`, `CreateOrganization`, `CreateTransactionWithDSL`) rather than generic CRUD (`List`, `Create`).
+
+### Ledger API services
+
+- `OrganizationsService` implemented by `organizationsEntity`
+- `LedgersService` implemented by `ledgersEntity`
+- `AccountsService` implemented by `accountsEntity`
+- `AccountTypesService` implemented by `accountTypesEntity`
+- `AssetsService` implemented by `assetsEntity`
+- `AssetRatesService` implemented by `assetRatesEntity`
+- `BalancesService` implemented by `balancesEntity`
+- `PortfoliosService` implemented by `portfoliosEntity`
+- `SegmentsService` implemented by `segmentsEntity`
+- `OperationsService` implemented by `operationsEntity`
+- `OperationRoutesService` implemented by `operationRoutesEntity`
+- `TransactionRoutesService` implemented by `transactionRoutesEntity`
+- `TransactionsService` implemented by `transactionsEntity`
+- `MetadataIndexesService` implemented by `metadataIndexesEntity`
+
+### CRM services
+
+- `HoldersService` implemented by `holdersEntity`
+- `AliasesService` implemented by `aliasesEntity`
+
+CRM requests set `X-Organization-Id` and use paths under `/holders` and `/aliases`.
+
+## Transport pattern
+
+The shared `entities.HTTPClient` is responsible for the transport cross-cutting concerns:
+
+- Adds authorization after Access Manager resolves a token.
+- Adds default tenant ID when configured.
+- Adds idempotency keys from `entities.WithIdempotencyKey(ctx, key)`.
+- Injects OpenTelemetry trace context and baggage into outbound HTTP headers when observability is enabled.
+- Applies retry behavior for retryable responses and transient network failures.
+- Avoids retrying unsafe methods unless `X-Idempotency` is present.
+- Converts HTTP failures into `pkg/errors` structured errors.
+- Emits debug logs when `MIDAZ_DEBUG=true` or debug options are enabled.
+
+## Request path construction
+
+The SDK currently builds endpoint paths inside each entity implementation instead of using a central endpoint registry.
+
+Important path groups:
+
+- Organizations: `/organizations`, `/organizations/{id}`
+- Ledgers: `/organizations/{organizationID}/ledgers`, `/organizations/{organizationID}/ledgers/{ledgerID}`
+- Accounts: `/organizations/{organizationID}/ledgers/{ledgerID}/accounts`, `/accounts/{id}`, `/accounts/alias/{alias}`, `/accounts/external/{assetCode}`
+- Account balances: `/accounts/{accountID}/balances`, `/balances/{balanceID}`, balance history endpoints
+- Assets: `/organizations/{organizationID}/ledgers/{ledgerID}/assets`
+- Asset rates: asset-rate endpoints under organization/ledger scope, including asset-code filtered listing
+- Transactions: `/transactions/json`, `/transactions/dsl`, `/transactions/{id}`, `/transactions/{id}/commit`, `/transactions/{id}/cancel`, `/transactions/{id}/revert`, `/transactions/inflow`, `/transactions/outflow`, `/transactions/annotation`
+- Operations: account-scoped operation listing plus transaction operation update paths
+- Routes: operation route and transaction route endpoints under organization/ledger scope
+- Metadata indexes: `/settings/metadata-indexes`
+- CRM holders: `/holders`, `/holders/{holderID}`
+- CRM aliases: `/aliases`, `/holders/{holderID}/aliases`, `/holders/{holderID}/aliases/{aliasID}/related-parties/{relatedPartyID}`
+
+## Model compatibility layer
+
+Several SDK inputs wrap Midaz `mmodel` types to preserve the public SDK package path while using Midaz model contracts internally. Prefer fluent constructors in examples because wrapper fields can differ from direct composite literal expectations.
+
+Common builders:
+
+- `models.NewCreateOrganizationInput(legalName, legalDocument)`
+- `models.NewUpdateOrganizationInput()`
+- `models.NewCreateAssetInput(name, code)`
+- `models.NewUpdateAssetInput()`
+- `models.NewCreateAccountInput(name, assetCode, accountType)`
+- `models.NewCreateTransactionInput(assetCode, amount)`
+- `models.NewAssetRateListOptions()`
+
+## List options and pagination internals
+
+`models.ListOptions` fields:
+
+```go
+type ListOptions struct {
+    Limit            int
+    Offset           int
+    Filters          map[string]string
+    OrderBy          string
+    OrderDirection   string
+    Page             int
+    Cursor           string
+    StartDate        string
+    EndDate          string
+    AdditionalParams map[string]string
 }
 ```
 
-### Service URL Management
+Query serialization rules:
 
-The SDK supports multi-service architecture by mapping service names to URLs:
+- `limit` is always emitted.
+- `Offset` is retained as compatibility input and serialized as `page`.
+- `Page` is emitted as `page` when set.
+- `Cursor` is emitted as `cursor` when set.
+- `Filters` are emitted as query parameters by key.
+- `OrderBy` is retained but not emitted by common serialization.
+- `OrderDirection` is emitted as `sort_order`.
+- `StartDate`, `EndDate`, and `AdditionalParams` are emitted when set.
+- Transactions remove `page` when cursor pagination is used.
+
+`models.ListResponse[T]` contains `Items []T` and `Pagination models.Pagination`. JSON unmarshalling supports both current top-level pagination fields and legacy nested `pagination` payloads.
+
+## Error model internals
+
+The core SDK error type is `*errors.Error` in `pkg/errors`:
 
 ```go
-// Map of service names to URLs
-serviceURLs := map[string]string{
-    "onboarding":  "https://onboarding.api.midaz.com",
-    "transaction": "https://transaction.api.midaz.com",
-}
-
-// Getting the correct URL for a specific service
-func (e *Entity) getServiceURL(service string) string {
-    if url, ok := e.baseURLs[service]; ok {
-        return url
-    }
-    // Fall back to default URL if service-specific URL not found
-    return e.baseURL
+type Error struct {
+    Category   ErrorCategory
+    Code       ErrorCode
+    Message    string
+    Operation  string
+    Resource   string
+    ResourceID string
+    StatusCode int
+    RequestID  string
+    Err        error
 }
 ```
 
-### HTTP Client Configuration
+It implements `error`, `Unwrap`, and `Is`, so callers can use `errors.Is`, `errors.As`, and SDK helper functions.
 
-The HTTP client includes detailed debugging and customizable user agent support:
+Standard sentinel errors include:
 
-```go
-// Creating an HTTP client with debug logging and custom user agent
-client := &HTTPClient{
-    client:     optimizedClient,
-    authToken:  authToken,
-    userAgent:  getUserAgent(), // Gets from environment or uses default
-    debug:      debug,
-    // Additional fields omitted for brevity
-}
+- `ErrValidation`
+- `ErrAuthentication`
+- `ErrPermission`
+- `ErrNotFound`
+- `ErrAlreadyExists`
+- `ErrIdempotency`
+- `ErrRateLimit`
+- `ErrTimeout`
+- `ErrCancellation`
+- `ErrInternal`
+- `ErrInsufficientBalance`
+- `ErrAccountEligibility`
+- `ErrAssetMismatch`
 
-// Debug logging for requests and responses
-if c.debug {
-    c.debugLog("Request URL: %s %s", method, requestURL)
-    c.debugLog("Request headers: %v", req.Header)
-    c.debugLog("Request body: %s", string(bodyBytes))
-}
+## Observability internals
 
-// After the request
-if c.debug {
-    c.debugLog("Response from: %s %s", method, requestURL)
-    c.debugLog("Response status: %d", resp.StatusCode)
-    c.debugLog("Response headers: %v", resp.Header)
-    c.debugLog("Response body: %s", string(responseBody))
-}
-```
+The SDK observability package wraps OpenTelemetry and exposes a `Provider` interface with:
 
-### Interface-Based Design
+- `Tracer()`
+- `Meter()`
+- `Logger()`
+- `Shutdown(ctx)`
+- `IsEnabled()`
 
-The SDK uses interfaces to define the public API, with private implementations:
+Entity HTTP requests inject propagation headers through `observability.InjectContext`. Server-side code can extract incoming context with `observability.ExtractContext` or use the HTTP middleware helpers.
 
-```go
-// Public interface
-type SomeService interface {
-    List(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.SomeResource], error)
-    Get(ctx context.Context, id string) (*models.SomeResource, error)
-    Create(ctx context.Context, input *models.CreateSomeResourceInput) (*models.SomeResource, error)
-    Update(ctx context.Context, id string, input *models.UpdateSomeResourceInput) (*models.SomeResource, error)
-    Delete(ctx context.Context, id string) error
-}
+Collector endpoints are passed to the OTLP gRPC exporter as `host:port` values, for example `localhost:4317`.
 
-// Private implementation
-type someServiceImpl struct {
-    client *client.Client
-}
+## Retry internals
 
-// Constructor that returns the interface
-func NewSomeService(client *client.Client) SomeService {
-    return &someServiceImpl{
-        client: client,
-    }
-}
+Retry behavior is implemented in `pkg/retry` and integrated into `entities.HTTPClient`.
 
-// Implementation methods
-func (s *someServiceImpl) List(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.SomeResource], error) {
-    // Implementation
-}
+Root-client retry defaults come from `pkg/config` and are applied to entity HTTP clients during setup:
 
-// ... other methods
-```
+- Maximum retries: 3
+- Initial delay: 1s
+- Maximum delay: 30s
+- Backoff factor: 2.0
+- Jitter factor: 0.25
+- Retryable status codes: 408, 429, 500, 502, 503, 504
 
-This pattern allows for:
+Unsafe requests are retried only when an idempotency key is present.
 
-- Clean separation between public API and implementation details
-- Easier testing through interface mocking
-- Future extensibility without breaking changes
+## Maintainer checklist
 
-### Error Wrapping
+When changing public API shape:
 
-The SDK uses error wrapping to preserve context:
-
-```go
-func (c *someClient) Get(ctx context.Context, id string) (*models.SomeResource, error) {
-    resp, err := c.httpClient.Get(ctx, fmt.Sprintf("/resources/%s", id), nil)
-    if err != nil {
-        return nil, fmt.Errorf("failed to get resource: %w", err)
-    }
-
-    // Process response
-}
-```
-
-This pattern allows:
-
-- Preserving the original error for inspection with `errors.Is` and `errors.As`
-- Adding context to errors for better debugging
-- Standardized error handling throughout the SDK
-
-### Pagination Handling
-
-The SDK uses a consistent pattern for handling paginated results:
-
-```go
-func (c *someClient) List(ctx context.Context, opts *models.ListOptions) (*models.ListResponse[models.SomeResource], error) {
-    path := "/resources"
-    params := url.Values{}
-
-    // Add pagination parameters
-    if opts != nil {
-        if opts.Page > 0 {
-            params.Set("page", strconv.Itoa(opts.Page))
-        }
-        if opts.Limit > 0 {
-            params.Set("limit", strconv.Itoa(opts.Limit))
-        }
-
-        // Add filters
-        for key, value := range opts.Filters {
-            params.Set(key, value)
-        }
-
-        // Add sorting
-        for key, value := range opts.Sort {
-            params.Set(fmt.Sprintf("sort[%s]", key), value)
-        }
-    }
-
-    // Execute request
-    resp, err := c.httpClient.Get(ctx, path, params)
-    if err != nil {
-        return nil, err
-    }
-
-    // Parse response
-    var result models.ListResponse[models.SomeResource]
-    if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-        return nil, err
-    }
-
-    return &result, nil
-}
-```
-
-This pattern provides:
-
-- Consistent pagination across all list operations
-- Support for filtering and sorting
-- Clear separation of concerns between pagination, filtering, and API calls
+- Update service interfaces and private implementations together.
+- Update `README.md`, `docs/README.md`, `docs/examples.md`, and `docs/mapping/external_apis.md`.
+- Update this internal map when transport, config, retry, observability, or service URL behavior changes.
+- Run targeted tests for changed packages and prefer `make ci` before PRs.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,214 +1,144 @@
 # Pagination in the Midaz Go SDK
 
-The Midaz Go SDK provides a standardized pagination system that makes it easy to work with large collections of resources. This document explains how to use the pagination features effectively.
+The SDK uses `models.ListOptions` for list request parameters and `models.ListResponse[T]` for paginated results. Entity list methods are accessed through `c.Entity`, for example `c.Entity.Accounts.ListAccounts(...)`.
 
-## Table of Contents
+## List options
 
-- [Basic Concepts](#basic-concepts)
-- [Pagination Options](#pagination-options)
-- [Working with Paginated Results](#working-with-paginated-results)
-- [Pagination Helpers](#pagination-helpers)
-- [Examples](#examples)
-
-## Basic Concepts
-
-The SDK supports two primary pagination methods:
-
-1. **Offset-based Pagination**: Uses `limit` and `offset` parameters to specify how many items to return and where to start.
-2. **Cursor-based Pagination**: Uses a cursor to navigate through large datasets efficiently.
-
-By default, the SDK uses offset-based pagination, but it maintains compatibility with cursor-based pagination where appropriate.
-
-## Pagination Options
-
-To control pagination, use the `ListOptions` structure and its helper methods:
+Create options with defaults:
 
 ```go
-// Create options with default values
-options := models.NewListOptions()
-
-// Customize as needed
-options.WithLimit(10).               // Set items per page
-       WithOffset(20).               // Start from item 20
-       WithOrderBy("createdAt").     // Sort by creation date
-       WithOrderDirection(models.SortDescending) // Sort newest first
+options := models.NewListOptions().
+    WithLimit(25).
+    WithPage(1).
+    WithOrderDirection(models.SortDescending).
+    WithFilter("status", "ACTIVE")
 ```
 
-### Available Settings
+Available common helpers:
 
-| Method | Description |
-|--------|-------------|
-| `WithLimit(int)` | Sets the maximum number of items per page |
-| `WithOffset(int)` | Sets the starting position for pagination |
-| `WithPage(int)` | Sets the page number (backward compatibility) |
-| `WithCursor(string)` | Sets the cursor for cursor-based pagination |
-| `WithOrderBy(string)` | Sets the field to sort by |
-| `WithOrderDirection(SortDirection)` | Sets the sort direction (SortAscending or SortDescending) |
-| `WithFilter(string, string)` | Adds a filter criteria |
-| `WithFilters(map[string]string)` | Sets multiple filters at once |
-| `WithDateRange(string, string)` | Sets date range filters |
-| `WithAdditionalParam(string, string)` | Adds a custom query parameter |
+| Helper | Behavior |
+| --- | --- |
+| `WithLimit(int)` | Sets maximum items per page, capped by `models.MaxLimit` |
+| `WithOffset(int)` | Compatibility input; common serialization converts it to `page` |
+| `WithPage(int)` | Sets page number |
+| `WithCursor(string)` | Sets cursor for cursor-aware endpoints |
+| `WithOrderBy(string)` | Stored for compatibility; common serialization does not send it |
+| `WithOrderDirection(models.SortDirection)` | Sends sort direction as `sort_order` |
+| `WithFilter(string, string)` | Adds one filter query parameter |
+| `WithFilters(map[string]string)` | Replaces the filter map |
+| `WithDateRange(string, string)` | Adds `start_date` and `end_date` filters |
+| `WithAdditionalParam(string, string)` | Adds an endpoint-specific query parameter |
 
-### Constants
+CRM helper filters are also available on `ListOptions`:
 
-The SDK defines helpful constants for pagination:
+- `WithIncludeDeleted(bool)`
+- `WithHolderID(string)`
+- `WithExternalID(string)`
+- `WithDocument(string)`
+- `WithAccountID(string)`
+- `WithLedgerID(string)`
+- `WithParticipantDocument(string)`
+
+## Constants
 
 ```go
-// Default values
-models.DefaultLimit       // Default items per page (10)
-models.MaxLimit          // Maximum items per page (100)
-models.DefaultOffset     // Default starting position (0)
-models.DefaultPage       // Default page number (1)
-
-// Sort directions
-models.SortAscending     // Ascending order ("asc")
-models.SortDescending    // Descending order ("desc")
+models.DefaultLimit
+models.MaxLimit
+models.DefaultOffset
+models.DefaultPage
+models.SortAscending
+models.SortDescending
 ```
 
-## Working with Paginated Results
+## Paginated responses
 
-List operations return a `ListResponse` containing:
-
-1. The collection of items for the current page
-2. Pagination metadata in the `Pagination` field
+List methods return `*models.ListResponse[T]`:
 
 ```go
-// Fetch the first page
-response, err := client.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
-if err != nil {
-    // Handle error
-}
-
-// Access the items for this page
-for _, account := range response.Items {
-    // Process each account
-}
-
-// Access pagination information
-pagination := response.Pagination
-fmt.Printf("Showing %d of %d total accounts (page %d of %d)",
-    len(response.Items),
-    pagination.Total,
-    pagination.CurrentPage(),
-    pagination.TotalPages())
-```
-
-## Pagination Helpers
-
-The `Pagination` structure provides several helper methods:
-
-### Navigation Helpers
-
-| Method | Description |
-|--------|-------------|
-| `HasMorePages()` | Returns true if there are more pages available |
-| `HasPrevPage()` | Returns true if there is a previous page |
-| `HasNextPage()` | Returns true if there is a next page |
-| `NextPageOptions()` | Returns options for fetching the next page |
-| `PrevPageOptions()` | Returns options for fetching the previous page |
-
-### Information Helpers
-
-| Method | Description |
-|--------|-------------|
-| `CurrentPage()` | Returns the current page number (1-based) |
-| `TotalPages()` | Returns the total number of pages |
-
-## Examples
-
-### Basic Pagination
-
-```go
-// Create pagination options
-options := models.NewListOptions().WithLimit(10)
-
-// Fetch the first page
-accounts, err := client.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
+accounts, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
 if err != nil {
     return err
 }
 
-// Process the first page
 for _, account := range accounts.Items {
-    // Process each account
+    fmt.Println(account.ID)
 }
 
-// Check if there are more pages
-if accounts.Pagination.HasNextPage() {
-    // Get options for the next page
-    nextPageOptions := accounts.Pagination.NextPageOptions()
-    
-    // Fetch the next page
-    nextPage, err := client.Accounts.ListAccounts(ctx, orgID, ledgerID, nextPageOptions)
-    if err != nil {
-        return err
-    }
-    
-    // Process the next page
-    for _, account := range nextPage.Items {
-        // Process each account
-    }
-}
+fmt.Printf(
+    "page=%d total_pages=%d has_next=%t",
+    accounts.Pagination.CurrentPage(),
+    accounts.Pagination.TotalPages(),
+    accounts.Pagination.HasNextPage(),
+)
 ```
 
-### Iterating Through All Pages
+`ListResponse` unmarshalling supports both current top-level pagination fields and legacy nested `pagination` responses.
+
+## Navigating pages
+
+Use pagination helpers to avoid manually rebuilding options:
 
 ```go
-// Initial pagination options
-options := models.NewListOptions().WithLimit(25)
+options := models.NewListOptions().WithLimit(50)
 
-// Iterate through all pages
 for {
-    // Fetch the current page
-    page, err := client.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
+    page, err := c.Entity.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
     if err != nil {
         return err
     }
-    
-    // Process items on this page
+
     for _, account := range page.Items {
-        // Process each account
+        process(account)
     }
-    
-    // Check if we've reached the last page
+
     if !page.Pagination.HasNextPage() {
         break
     }
-    
-    // Update options for the next page
+
     options = page.Pagination.NextPageOptions()
 }
 ```
 
-### Filtering and Sorting
+Navigation helpers:
+
+- `HasMorePages()`
+- `HasPrevPage()`
+- `HasNextPage()`
+- `NextPageOptions()`
+- `PrevPageOptions()`
+- `CurrentPage()`
+- `TotalPages()`
+
+## Cursor behavior
+
+Cursor support is endpoint-specific. `ListOptions.WithCursor(...)` sets the `cursor` query parameter. Transaction listing has explicit cursor behavior: when a cursor is set, the SDK removes `page` and sends the cursor-based request.
 
 ```go
-// Create options with filtering and sorting
 options := models.NewListOptions().
-    WithLimit(20).
-    WithOrderBy("name").
-    WithOrderDirection(models.SortAscending).
-    WithFilter("status", models.StatusActive).
-    WithFilter("type", "ASSET").
-    WithDateRange("2023-01-01", "2023-12-31")
+    WithLimit(100).
+    WithCursor(nextCursor)
 
-// Fetch accounts matching the criteria
-accounts, err := client.Accounts.ListAccounts(ctx, orgID, ledgerID, options)
-if err != nil {
-    return err
-}
-
-// Process the accounts
-for _, account := range accounts.Items {
-    // Process each account
-}
+transactions, err := c.Entity.Transactions.ListTransactions(ctx, orgID, ledgerID, options)
 ```
 
-## Best Practices
+## Filtering and sorting
 
-1. Use `NewListOptions()` to create options with default values
-2. Always specify a reasonable limit to avoid large result sets
-3. Validate user-provided limit values to prevent excessive requests
-4. Use the helper methods (HasNextPage, NextPageOptions) for pagination
-5. Prefer offset-based pagination for simple use cases
-6. Use cursor-based pagination (when available) for efficient navigation through large datasets
+Filters are sent as query parameters:
+
+```go
+options := models.NewListOptions().
+    WithLimit(20).
+    WithFilter("status", "ACTIVE").
+    WithFilter("assetCode", "USD").
+    WithDateRange("2026-01-01", "2026-12-31")
+```
+
+`WithOrderDirection` is sent as `sort_order`. `WithOrderBy` is retained on the options struct for compatibility, but common query serialization does not currently send it.
+
+## Best practices
+
+- Always set a bounded `Limit` for list calls.
+- Prefer `NewListOptions()` instead of constructing `ListOptions` manually.
+- Use `NextPageOptions()` and `PrevPageOptions()` when following response metadata.
+- Treat `WithOffset` as compatibility input; current requests use `page` and `limit`.
+- Use cursor pagination only for endpoints that document or return cursor metadata.

--- a/docs/tracing-implementation.md
+++ b/docs/tracing-implementation.md
@@ -1,192 +1,234 @@
-# Tracing Implementation Changelog
+# Tracing implementation note
 
-## OpenTelemetry Tracing Propagation Enhancement
+This note records the tracing propagation implementation in `midaz-sdk-golang`. It is a changelog-style implementation note, not the main tracing guide.
 
-### Overview
-Implemented comprehensive OpenTelemetry tracing propagation throughout the Midaz SDK to enable distributed tracing across service boundaries.
+For usage guidance, keep `docs/tracing.md` as the user-facing guide.
 
-### Changes Made
+## Status
 
-#### 1. HTTP Client Enhancement (`entities/http.go`)
-- **Enhanced `NewHTTPClient`**: Automatically wraps HTTP clients with observability middleware when a provider is configured
-- **Automatic Trace Injection**: HTTP requests now automatically include OpenTelemetry trace headers (`traceparent`, `tracestate`, `baggage`)
-- **Backward Compatibility**: Changes are non-breaking - existing code continues to work without modification
+Tracing propagation is implemented for outbound Entity API HTTP requests.
 
-#### 2. Comprehensive Testing Suite
-- **Created `pkg/observability/tracing_test.go`**: Comprehensive test suite covering:
-  - Basic inject/extract functionality
-  - HTTP middleware trace propagation  
-  - Distributed tracing across services
-  - Baggage propagation
-  - Trace persistence across multiple requests
-  - Performance benchmarks
+The SDK:
 
-- **Created `entities/http_tracing_test.go`**: Integration tests for HTTP client tracing:
-  - Automatic trace header injection
-  - Tracing disabled scenarios
-  - Custom headers with tracing
-  - Error handling with tracing
-  - Distributed tracing between services
+- Stores the configured observability provider on `entities.HTTPClient`.
+- Starts SDK HTTP spans when the tracing component is enabled.
+- Injects trace context into outbound request paths.
+- Uses standard W3C Trace Context and Baggage propagation.
+- Keeps existing SDK calls backward compatible when observability is disabled.
 
-- **Created `pkg/observability/middleware_test.go`**: Direct middleware testing
+## Implementation summary
 
-#### 3. Example Applications
-- **Created `examples/tracing-example/main.go`**: Complete client-side example showing:
-  - Observability provider setup
-  - Complex workflows with nested spans
-  - Custom attributes and baggage
-  - Error handling and span status
-  - Multiple API calls with trace correlation
+### `entities.HTTPClient`
 
-- **Created `examples/tracing-server-example/main.go`**: Server-side example demonstrating:
-  - HTTP middleware for trace extraction
-  - Server span creation
-  - Downstream API calls with propagation
-  - Request correlation with baggage
-  - Error handling in distributed context
+`HTTPClient` stores the observability provider in the `observability` field.
 
-#### 4. Documentation
-- **Created `docs/tracing.md`**: Comprehensive documentation covering:
-  - Quick start guide
-  - Configuration options
-  - Advanced features (baggage, custom middleware)
-  - Testing instructions
-  - Performance considerations
-  - Troubleshooting guide
-  - Integration with popular tracing tools (Jaeger, Zipkin, OTEL Collector)
-  - Best practices
+`NewHTTPClient` accepts the provider and stores it on the client:
 
-### Key Features Implemented
-
-#### Automatic Trace Propagation
-- HTTP clients automatically inject OpenTelemetry headers into outgoing requests
-- No code changes required for existing applications
-- Trace context flows seamlessly across service boundaries
-
-#### Comprehensive Context Support
-- Full W3C Trace Context support (`traceparent`, `tracestate`)
-- Baggage propagation for correlation data
-- Custom propagation headers support
-
-#### Performance Optimized
-- Minimal overhead when tracing is disabled
-- Efficient middleware with minimal allocations
-- Configurable sampling rates
-
-#### Testing Coverage
-- 100% test coverage for new tracing functionality
-- Integration tests with real HTTP servers
-- Performance benchmarks
-- Error scenario coverage
-
-### Usage Examples
-
-#### Basic Setup
 ```go
-// Create observability provider
-provider, err := observability.New(context.Background(),
-    observability.WithServiceName("my-service"),
-    observability.WithComponentEnabled(true, true, true),
-    observability.WithTraceSampleRate(0.1),
-)
-
-// Create Midaz client with tracing
-client, err := client.New(
-    client.WithObservabilityProvider(provider),
-    // ... other options
-)
-
-// API calls automatically include trace context
-ctx, span := provider.Tracer().Start(context.Background(), "business_operation")
-defer span.End()
-
-result, err := client.Organizations().Create(ctx, input)
+func NewHTTPClient(client *http.Client, authToken string, provider observability.Provider) *HTTPClient
 ```
 
-#### Server-side Context Extraction
+The client uses the provider for:
+
+- Span creation through `setupObservabilityContext`.
+- Trace context injection before request execution.
+- Metrics collection when configured.
+
+### Request paths with propagation
+
+Trace context injection happens in these request paths:
+
+- `doRequest`
+- `doRawRequest`
+- `doCountRequest`
+
+`sendRequest` reuses `doRawRequest`, so requests created by service methods also receive trace context injection.
+
+Each path uses:
+
 ```go
-// Extract trace context from incoming requests
-headers := make(map[string]string)
-for name, values := range r.Header {
-    if len(values) > 0 {
-        headers[name] = values[0]
+propagator := propagation.NewCompositeTextMapPropagator(
+    propagation.TraceContext{},
+    propagation.Baggage{},
+)
+propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+```
+
+This injects W3C-compatible propagation headers such as:
+
+- `traceparent`
+- `tracestate`
+- `baggage`
+
+## Propagation scope
+
+The SDK-owned outbound request paths support standard W3C Trace Context and Baggage propagation only.
+
+The observability config still stores propagation-related configuration, including `PropagationHeaders`, for compatibility with existing configuration shape. The current HTTP request injection path does not use that list to emit custom propagation headers.
+
+The SDK does not currently provide custom trace propagation header support beyond stored configuration fields.
+
+## Client example
+
+Client examples should import the root module as `client` and enable Entity API access with `client.UseEntityAPI()` or `client.UseAllAPIs()`.
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    client "github.com/LerianStudio/midaz-sdk-golang/v2"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/models"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/observability"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/codes"
+)
+
+func main() {
+    ctx := context.Background()
+
+    provider, err := observability.New(ctx,
+        observability.WithServiceName("my-service"),
+        observability.WithServiceVersion("1.0.0"),
+        observability.WithEnvironment("development"),
+        observability.WithComponentEnabled(true, true, true),
+        observability.WithCollectorEndpoint("localhost:4317"),
+        observability.WithTraceSampleRate(0.1),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer provider.Shutdown(ctx)
+
+    c, err := client.New(
+        client.WithBaseURL("https://api.midaz.io"),
+        client.WithObservabilityProvider(provider),
+        client.UseEntityAPI(),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    tracer := provider.Tracer()
+    ctx, span := tracer.Start(ctx, "create_organization_workflow")
+    defer span.End()
+
+    input := models.NewCreateOrganizationInput(
+        "Example Corporation",
+        "123456789",
+    ).WithDoingBusinessAs("Example Inc.")
+
+    organization, err := c.Entity.Organizations.CreateOrganization(ctx, input)
+    if err != nil {
+        span.RecordError(err)
+        span.SetStatus(codes.Error, err.Error())
+        log.Fatal(err)
+    }
+
+    span.SetAttributes(attribute.String("organization.id", organization.ID))
+    span.SetStatus(codes.Ok, "organization created")
+}
+```
+
+Collector endpoints must use `host:port` format, for example `localhost:4317`. Do not include `http://` or `https://`.
+
+## Server example blocks
+
+The following server snippets are fragments. They depend on imports for `context`, `encoding/json`, `net/http`, `client`, `models`, `observability`, and `go.opentelemetry.io/otel/trace`.
+
+### Extract incoming trace context
+
+```go
+func extractTraceContext(r *http.Request) context.Context {
+    headers := make(map[string]string)
+
+    for name, values := range r.Header {
+        if len(values) > 0 {
+            headers[name] = values[0]
+        }
+    }
+
+    return observability.ExtractContext(r.Context(), headers)
+}
+```
+
+### Create a server span
+
+```go
+func tracingMiddleware(provider observability.Provider, next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        ctx := extractTraceContext(r)
+
+        tracer := provider.Tracer()
+        ctx, span := tracer.Start(ctx, r.Method+" "+r.URL.Path,
+            trace.WithSpanKind(trace.SpanKindServer),
+        )
+        defer span.End()
+
+        r = r.WithContext(ctx)
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+### Propagate context into downstream SDK calls
+
+```go
+func createOrganizationHandler(c *client.Client) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        input := models.NewCreateOrganizationInput(
+            "Example Corporation",
+            "123456789",
+        )
+
+        organization, err := c.Entity.Organizations.CreateOrganization(r.Context(), input)
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+
+        _ = json.NewEncoder(w).Encode(organization)
     }
 }
-ctx := observability.ExtractContext(r.Context(), headers)
-
-// Start child span
-tracer := provider.Tracer()
-ctx, span := tracer.Start(ctx, "handle_request")
-defer span.End()
 ```
 
-### Testing Results
+When the request context contains a valid span, the SDK injects W3C trace context and baggage into the outbound Midaz request.
 
-All new tests pass successfully:
-- `TestTracingPropagation`: ✅ All subtests pass
-- `TestHTTPClientTracingIntegration`: ✅ All subtests pass  
-- `TestHTTPClientDistributedTracing`: ✅ Distributed tracing verified
-- `TestHTTPMiddlewareDirectly`: ✅ Middleware functionality confirmed
+## Tests
 
-### Backward Compatibility
+Tracing coverage is verified by unit and integration-style tests in:
 
-- ✅ No breaking changes to existing APIs
-- ✅ Existing applications continue to work without modification
-- ✅ Tracing can be enabled/disabled via configuration
-- ✅ Zero overhead when observability provider is nil
+- `pkg/observability/tracing_test.go`
+- `pkg/observability/middleware_test.go`
+- `entities/http_tracing_test.go`
 
-### Performance Impact
+Run tracing-specific tests with:
 
-- **Tracing Enabled**: Minimal overhead (~1-2% in benchmarks)
-- **Tracing Disabled**: Zero overhead (noop operations)
-- **Memory Usage**: Traces are batched and exported asynchronously
-- **Network**: Headers add ~100-200 bytes per request
-
-### Future Enhancements
-
-Potential areas for future improvement:
-1. Server-side middleware package for easier integration
-2. Automatic service mesh integration
-3. Custom span processors for business logic
-4. Integration with popular frameworks (Gin, Echo, etc.)
-5. Metrics correlation with traces
-
-### Migration Guide
-
-For existing applications wanting to enable tracing:
-
-1. **Add observability provider** to client creation:
-   ```go
-   client.WithObservabilityProvider(provider)
-   ```
-
-2. **Use context in API calls** (if not already):
-   ```go
-   result, err := client.API().Method(ctx, params)
-   ```
-
-3. **Optional: Add custom spans** for business logic:
-   ```go
-   ctx, span := tracer.Start(ctx, "business_operation")
-   defer span.End()
-   ```
-
-### Testing Instructions
-
-Run the new test suites:
 ```bash
-# Test tracing propagation
 go test ./pkg/observability -v -run TestTracingPropagation
-
-# Test HTTP client integration  
-go test ./entities -v -run TestHTTPClientTracingIntegration
-
-# Test distributed tracing
-go test ./entities -v -run TestHTTPClientDistributedTracing
-
-# Run examples
-go run examples/tracing-example/main.go
-go run examples/tracing-server-example/main.go
+go test ./pkg/observability -v -run TestHTTPMiddlewareDirectly
+go test ./entities -v -run 'TestHTTPClientTracingIntegration|TestHTTPClientDistributedTracing'
 ```
 
-This implementation provides a solid foundation for distributed tracing in the Midaz SDK while maintaining backward compatibility and optimal performance.
+Run the current repository test targets with:
+
+```bash
+make test-fast
+make test
+```
+
+Use the full local pipeline before release work:
+
+```bash
+make ci
+```
+
+## Compatibility notes
+
+- Existing clients continue to work without tracing changes.
+- If observability is disabled, the SDK uses no-op tracing behavior.
+- Entity API access still requires `client.UseEntityAPI()` or `client.UseAllAPIs()`.
+- Authentication remains configured through SDK configuration and Access Manager paths, not through a tracing-specific client option.
+- The SDK exports OTLP through the OpenTelemetry provider configuration. Route Jaeger, Zipkin, or vendor backends through an OpenTelemetry Collector.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,334 +1,196 @@
-# OpenTelemetry Tracing Propagation in Midaz SDK
+# OpenTelemetry tracing in the Midaz Go SDK
 
-This document describes how OpenTelemetry tracing is automatically propagated through Midaz APIs and provides examples of how to use this functionality.
+The SDK can propagate OpenTelemetry trace context through outbound entity HTTP requests. Tracing is configured with `pkg/observability` and attached to the client with `client.WithObservabilityProvider` or SDK-created observability options.
 
-## Overview
+## What the SDK provides
 
-The Midaz Go SDK now includes comprehensive OpenTelemetry tracing support with automatic trace propagation across service boundaries. This enables distributed tracing throughout your application stack.
+- OpenTelemetry tracer, meter, and logger provider abstraction.
+- Automatic trace context and baggage injection on outbound entity HTTP requests.
+- Context extraction and injection helpers for HTTP boundaries.
+- Baggage helpers for cross-service correlation.
+- HTTP middleware helpers for server applications.
+- No-op behavior when observability is disabled.
 
-## Features
+## Client setup
 
-- **Automatic Trace Propagation**: HTTP clients automatically inject trace context into outgoing requests
-- **Server-side Context Extraction**: Utilities to extract trace context from incoming requests  
-- **Baggage Support**: Cross-service correlation data propagation
-- **Comprehensive Testing**: Full test coverage for tracing scenarios
-- **Performance Optimized**: Minimal overhead when tracing is disabled
-
-## Quick Start
-
-### 1. Enable Tracing in Midaz Client
+Import the root module and alias it as `client`:
 
 ```go
 import (
     "context"
+    "encoding/json"
+    "log"
     "net/http"
     "time"
-    
-    "github.com/LerianStudio/midaz-sdk-golang/v2/client"
-    "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/observability"
-)
 
-// Create observability provider with tracing enabled
+    client "github.com/LerianStudio/midaz-sdk-golang/v2"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/models"
+    "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/observability"
+    "go.opentelemetry.io/otel/attribute"
+    "go.opentelemetry.io/otel/codes"
+)
+```
+
+Create an observability provider and enable entity APIs:
+
+```go
 provider, err := observability.New(context.Background(),
     observability.WithServiceName("my-service"),
     observability.WithServiceVersion("1.0.0"),
     observability.WithEnvironment("production"),
-    observability.WithComponentEnabled(true, true, true), // tracing, metrics, logging
-    observability.WithCollectorEndpoint("http://localhost:4317"), // Optional OTEL collector
-    observability.WithTraceSampleRate(0.1), // Sample 10% of traces
+    observability.WithComponentEnabled(true, true, true),
+    observability.WithCollectorEndpoint("localhost:4317"),
+    observability.WithTraceSampleRate(0.1),
 )
 if err != nil {
     log.Fatal(err)
 }
 defer provider.Shutdown(context.Background())
 
-// Create Midaz client with observability
 midazClient, err := client.New(
     client.WithBaseURL("https://api.midaz.com"),
-    client.WithAuth("Bearer your-api-token"),
     client.WithHTTPClient(&http.Client{Timeout: 30 * time.Second}),
-    client.WithObservabilityProvider(provider), // Enables automatic tracing
+    client.WithObservabilityProvider(provider),
+    client.UseAllAPIs(),
 )
 if err != nil {
     log.Fatal(err)
 }
 ```
 
-### 2. Using Tracing in Your Application
+`client.UseAllAPIs()` or `client.UseEntityAPI()` is required before accessing `midazClient.Entity`.
+
+Authentication is configured through SDK config and Access Manager, not through a `client.WithAuth` option.
+
+## Tracing an operation
 
 ```go
-// Start a trace for your business operation
 tracer := provider.Tracer()
 ctx, span := tracer.Start(context.Background(), "create_organization_workflow")
 defer span.End()
 
-// Add custom attributes
-span.SetAttributes(
-    attribute.String("workflow.type", "organization_creation"),
-    attribute.String("business.unit", "onboarding"),
-)
+orgInput := models.NewCreateOrganizationInput("Example Corporation", "123456789").
+    WithDoingBusinessAs("Example Inc.")
 
-// API calls will automatically include trace context
-organization, err := midazClient.Organizations().Create(ctx, orgInput)
+organization, err := midazClient.Entity.Organizations.CreateOrganization(ctx, orgInput)
 if err != nil {
-    span.SetStatus(codes.Error, err.Error())
     span.RecordError(err)
+    span.SetStatus(codes.Error, err.Error())
     return err
 }
 
-span.SetAttributes(
-    attribute.String("organization.id", organization.ID),
-)
-span.SetStatus(codes.Ok, "Organization created successfully")
+span.SetAttributes(attribute.String("organization.id", organization.ID))
+span.SetStatus(codes.Ok, "organization created")
 ```
 
-### 3. Server-side Trace Context Extraction
+Outbound SDK calls automatically inject trace headers from `ctx`.
+
+## Server-side context extraction
 
 ```go
-// Extract trace context from incoming HTTP requests
 func handleRequest(w http.ResponseWriter, r *http.Request) {
-    // Extract trace context from headers
     headers := make(map[string]string)
     for name, values := range r.Header {
         if len(values) > 0 {
             headers[name] = values[0]
         }
     }
+
     ctx := observability.ExtractContext(r.Context(), headers)
-    
-    // Start child span
     tracer := provider.Tracer()
     ctx, span := tracer.Start(ctx, "handle_request")
     defer span.End()
-    
-    // Your business logic here - trace context is now available
+
     result, err := processRequest(ctx)
     if err != nil {
         span.RecordError(err)
+        http.Error(w, err.Error(), http.StatusInternalServerError)
         return
     }
-    
-    // Return response with trace ID for correlation
+
     w.Header().Set("X-Trace-ID", observability.TraceID(ctx))
-    json.NewEncoder(w).Encode(result)
+    _ = json.NewEncoder(w).Encode(result)
 }
 ```
 
-## Advanced Features
+## Baggage
 
-### Baggage for Cross-service Correlation
+Use baggage for small correlation values that must cross service boundaries:
 
 ```go
-// Add correlation data that persists across service boundaries
 ctx, err := observability.WithBaggageItem(ctx, "user-id", "user-123")
-ctx, err = observability.WithBaggageItem(ctx, "request-id", "req-456")
+if err != nil {
+    return err
+}
 
-// Later, extract baggage in another service
+ctx, err = observability.WithBaggageItem(ctx, "request-id", "req-456")
+if err != nil {
+    return err
+}
+
 userID := observability.GetBaggageItem(ctx, "user-id")
 requestID := observability.GetBaggageItem(ctx, "request-id")
 ```
 
-### Custom HTTP Middleware
+Keep baggage small. Baggage is propagated on every downstream request.
+
+## Trace IDs for logs
 
 ```go
-// For server applications
-func tracingMiddleware(provider observability.Provider) func(http.Handler) http.Handler {
-    return func(next http.Handler) http.Handler {
-        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            // Extract trace context
-            headers := make(map[string]string)
-            for name, values := range r.Header {
-                if len(values) > 0 {
-                    headers[name] = values[0]
-                }
-            }
-            ctx := observability.ExtractContext(r.Context(), headers)
-            
-            // Start span
-            tracer := provider.Tracer()
-            ctx, span := tracer.Start(ctx, fmt.Sprintf("%s %s", r.Method, r.URL.Path))
-            defer span.End()
-            
-            // Add request attributes
-            span.SetAttributes(
-                attribute.String("http.method", r.Method),
-                attribute.String("http.url", r.URL.String()),
-            )
-            
-            // Process request
-            r = r.WithContext(ctx)
-            next.ServeHTTP(w, r)
-        })
-    }
-}
-```
-
-### Trace Information Extraction
-
-```go
-// Get trace and span IDs for logging correlation
 traceID := observability.TraceID(ctx)
 spanID := observability.SpanID(ctx)
 
-log.Printf("Processing request [trace_id=%s] [span_id=%s]", traceID, spanID)
+log.Printf("processing request trace_id=%s span_id=%s", traceID, spanID)
 ```
 
-## Configuration Options
+## Configuration options
 
-### Environment Variables
+Common observability options:
 
-- `MIDAZ_OTEL_ENDPOINT`: OpenTelemetry collector endpoint
-- `MIDAZ_LOG_LEVEL`: Logging level (debug, info, warn, error)
+- `observability.WithServiceName(string)`
+- `observability.WithServiceVersion(string)`
+- `observability.WithEnvironment(string)`
+- `observability.WithComponentEnabled(tracing, metrics, logging bool)`
+- `observability.WithTraceSampleRate(float64)`
+- `observability.WithHighTracingSampling()`
+- `observability.WithFullTracingSampling()`
+- `observability.WithCollectorEndpoint(string)`
+- `observability.WithDevelopmentDefaults()`
+- `observability.WithProductionDefaults()`
 
-### Programmatic Configuration
+Collector endpoint values are passed to the OTLP gRPC exporter as `host:port`, for example `localhost:4317`. Do not include `http://` in this value.
+
+The SDK does not currently load observability configuration from `MIDAZ_OTEL_ENDPOINT` or `MIDAZ_LOG_LEVEL`. Configure observability programmatically.
+
+## Local collector example
+
+Run an OpenTelemetry Collector locally on OTLP gRPC port `4317`, then configure:
 
 ```go
-provider, err := observability.New(context.Background(),
-    // Service identification
-    observability.WithServiceName("my-service"),
-    observability.WithServiceVersion("1.0.0"),
-    observability.WithEnvironment("production"),
-    
-    // Component enablement
-    observability.WithComponentEnabled(true, true, true), // tracing, metrics, logging
-    
-    // Sampling configuration
-    observability.WithTraceSampleRate(0.1), // 0.0 to 1.0
-    observability.WithFullTracingSampling(), // For development (1.0)
-    observability.WithHighTracingSampling(), // For development (0.5)
-    
-    // Propagation configuration
-    observability.WithPropagationHeaders("traceparent", "tracestate", "baggage"),
-    observability.WithPropagators(propagation.TraceContext{}, propagation.Baggage{}),
-    
-    // Export configuration  
-    observability.WithCollectorEndpoint("http://localhost:4317"),
-    
-    // Convenience presets
-    observability.WithDevelopmentDefaults(), // High sampling, debug logging
-    observability.WithProductionDefaults(),  // Low sampling, info logging
-)
+observability.WithCollectorEndpoint("localhost:4317")
 ```
 
-## Testing
+If you want Jaeger or Zipkin, route traces through the OpenTelemetry Collector. The SDK exports OTLP gRPC; it does not directly export Zipkin spans.
 
-The SDK includes comprehensive tests for tracing propagation:
+## Tests
+
+Run tracing-related tests with:
 
 ```bash
-# Run tracing propagation tests
 go test ./pkg/observability -v -run TestTracingPropagation
-
-# Run HTTP client tracing integration tests  
-go test ./entities -v -run TestHTTPClientTracingIntegration
-
-# Run distributed tracing tests
-go test ./entities -v -run TestHTTPClientDistributedTracing
+go test ./entities -v -run 'TestHTTPClientTracingIntegration|TestHTTPClientDistributedTracing'
 ```
 
 ## Examples
 
-See the following example applications:
+- [`examples/tracing-example/`](../examples/tracing-example/) - Client-side tracing workflow.
+- [`examples/tracing-server-example/`](../examples/tracing-server-example/) - Server-side trace extraction and middleware-style propagation.
 
-- [`examples/tracing-example/`](../examples/tracing-example/) - Client-side tracing with complex workflows
-- [`examples/tracing-server-example/`](../examples/tracing-server-example/) - Server-side tracing and middleware
+## Best practices
 
-## Performance Considerations
-
-- **Sampling**: Use appropriate sampling rates for production (typically 0.01-0.1)
-- **Overhead**: When tracing is disabled, overhead is minimal (noop operations)
-- **Memory**: Traces are batched and exported asynchronously
-- **Network**: Consider collector placement to minimize latency
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Missing trace headers**: Ensure the observability provider is properly configured with the HTTP client
-2. **Trace context not propagating**: Verify that the context is being passed through your application layers
-3. **High resource usage**: Reduce sampling rate or disable tracing in high-throughput scenarios
-
-### Debug Mode
-
-Enable debug logging to see tracing operations:
-
-```go
-provider, err := observability.New(context.Background(),
-    observability.WithLogLevel(observability.DebugLevel),
-    // ... other options
-)
-```
-
-### Verification
-
-Check that traces are being generated correctly:
-
-```go
-// Check if tracing is enabled
-if provider.IsEnabled() {
-    log.Println("Tracing is enabled")
-}
-
-// Verify trace context exists
-if traceID := observability.TraceID(ctx); traceID != "" {
-    log.Printf("Current trace ID: %s", traceID)
-}
-```
-
-## Integration with Popular Tools
-
-### Jaeger
-
-```bash
-# Run Jaeger locally
-docker run -d --name jaeger \
-  -p 16686:16686 \
-  -p 14250:14250 \
-  jaegertracing/all-in-one:latest
-
-# Configure SDK
-observability.WithCollectorEndpoint("http://localhost:14250")
-```
-
-### Zipkin
-
-```bash
-# Run Zipkin locally  
-docker run -d -p 9411:9411 openzipkin/zipkin
-
-# Use OTLP HTTP endpoint
-observability.WithCollectorEndpoint("http://localhost:9411/api/v2/spans")
-```
-
-### OTEL Collector
-
-```yaml
-# otel-collector.yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-exporters:
-  jaeger:
-    endpoint: jaeger:14250
-    tls:
-      insecure: true
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [jaeger]
-```
-
-## Best Practices
-
-1. **Use meaningful operation names**: `"create_organization"` vs `"POST /api/organizations"`
-2. **Add relevant attributes**: Include business context like user IDs, operation types
-3. **Handle errors properly**: Always record errors and set appropriate span status
-4. **Use baggage sparingly**: Only include essential correlation data
-5. **Monitor sampling rates**: Adjust based on traffic volume and storage costs
-6. **Test trace propagation**: Verify traces flow correctly through your system
+- Pass `context.Context` from your incoming request through every SDK call.
+- Use meaningful span names such as `create_organization_workflow`.
+- Record errors on spans before returning.
+- Add business identifiers as span attributes when they are safe to expose.
+- Keep baggage limited to small correlation values.
+- Use low sampling rates in production unless debugging a focused incident.

--- a/entities/access_manager_test.go
+++ b/entities/access_manager_test.go
@@ -141,6 +141,7 @@ func createMockPluginAuthConfig(pluginAuth auth.AccessManager) *mockPluginAuthCo
 		baseURLs: map[string]string{
 			"onboarding":  "http://localhost:3000/v1",
 			"transaction": "http://localhost:3001/v1",
+			"crm":         "http://localhost:3002/v1",
 		},
 		pluginAuth: pluginAuth,
 	}

--- a/entities/account_types.go
+++ b/entities/account_types.go
@@ -170,10 +170,10 @@ func (e *accountTypesEntity) buildURL(organizationID, ledgerID, accountTypeID st
 	baseURL := e.baseURLs["onboarding"]
 
 	if accountTypeID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/account-types", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/account-types", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/account-types/%s", baseURL, organizationID, ledgerID, accountTypeID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/account-types/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(accountTypeID))
 }
 
 // ListAccountTypes lists account types for a ledger with optional filters.
@@ -358,7 +358,7 @@ func (e *accountTypesEntity) DeleteAccountType(ctx context.Context, organization
 }
 
 // GetAccountTypesMetricsCount retrieves the count metrics for account types in a ledger.
-func (e *accountTypesEntity) GetAccountTypesMetricsCount(ctx context.Context, organizationID, ledgerID string) (*models.MetricsCount, error) {
+func (*accountTypesEntity) GetAccountTypesMetricsCount(_ context.Context, organizationID, ledgerID string) (*models.MetricsCount, error) {
 	const operation = "GetAccountTypesMetricsCount"
 
 	if organizationID == "" {
@@ -369,23 +369,5 @@ func (e *accountTypesEntity) GetAccountTypesMetricsCount(ctx context.Context, or
 		return nil, errors.NewMissingParameterError(operation, "ledgerID")
 	}
 
-	url := e.buildMetricsURL(organizationID, ledgerID)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.httpClient.sendRequest(req, &metrics); err != nil {
-		return nil, err
-	}
-
-	return &metrics, nil
-}
-
-// buildMetricsURL builds the URL for account types metrics API calls.
-func (e *accountTypesEntity) buildMetricsURL(organizationID, ledgerID string) string {
-	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/account-types/metrics/count", baseURL, organizationID, ledgerID)
+	return nil, errors.NewValidationError(operation, "account type count metrics are not exposed by the Midaz Ledger API", nil)
 }

--- a/entities/accounts.go
+++ b/entities/accounts.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
-	"strings"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
@@ -127,10 +125,9 @@ type AccountsService interface {
 	// Returns an error if the operation fails.
 	DeleteAccount(ctx context.Context, organizationID, ledgerID, id string) error
 
-	// GetBalance retrieves the balance for a specific account.
-	// The organizationID and ledgerID parameters specify which organization and ledger the account belongs to.
-	// The accountID parameter is the unique identifier of the account to get the balance for.
-	// Returns the balance information, or an error if the operation fails.
+	// GetBalance retrieves a single balance for a specific account.
+	// If the account has multiple balances, callers should use BalancesService.ListAccountBalances
+	// to retrieve the full set explicitly.
 	GetBalance(ctx context.Context, organizationID, ledgerID, accountID string) (*models.Balance, error)
 
 	// GetAccountsMetricsCount retrieves the count metrics for accounts in a ledger.
@@ -145,10 +142,9 @@ type AccountsService interface {
 	// Returns the external account if found, or an error if the operation fails.
 	GetExternalAccount(ctx context.Context, organizationID, ledgerID, assetCode string) (*models.Account, error)
 
-	// GetExternalAccountBalance retrieves the balance for an external account by asset code.
-	// The organizationID and ledgerID parameters specify which organization and ledger to query.
-	// The assetCode parameter is the asset code that identifies the external account (e.g., "USD", "BRL").
-	// Returns the balance information for the external account, or an error if the operation fails.
+	// GetExternalAccountBalance retrieves a single balance for an external account by asset code.
+	// If the external account has multiple balances, callers should use
+	// BalancesService.ListBalancesByExternalCode instead.
 	GetExternalAccountBalance(ctx context.Context, organizationID, ledgerID, assetCode string) (*models.Balance, error)
 
 	// GetAccountByAliasPath retrieves a specific account by its alias using the dedicated path endpoint.
@@ -311,23 +307,19 @@ func (e *accountsEntity) GetAccountByAlias(ctx context.Context, organizationID, 
 		return nil, errors.NewMissingParameterError(operation, "alias")
 	}
 
-	endpoint := fmt.Sprintf("%s?alias=%s", e.buildURL(organizationID, ledgerID, ""), alias)
+	endpoint := e.buildAliasURL(organizationID, ledgerID, alias)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	var accounts models.ListResponse[models.Account]
-	if err := e.httpClient.sendRequest(req, &accounts); err != nil {
+	var account models.Account
+	if err := e.httpClient.sendRequest(req, &account); err != nil {
 		return nil, err
 	}
 
-	if len(accounts.Items) == 0 {
-		return nil, errors.NewNotFoundError(operation, "account", alias, nil)
-	}
-
-	return &accounts.Items[0], nil
+	return &account, nil
 }
 
 // CreateAccount creates a new account in the specified ledger.
@@ -448,40 +440,19 @@ func (e *accountsEntity) GetBalance(ctx context.Context, organizationID, ledgerI
 		return nil, errors.NewMissingParameterError(operation, "accountID")
 	}
 
-	// First get the account details to get the alias
-	account, err := e.GetAccount(ctx, organizationID, ledgerID, accountID)
-	if err != nil {
-		return nil, err
-	}
-
-	if account.Alias == nil || *account.Alias == "" {
-		return nil, errors.NewValidationError(operation, "account has no alias", nil)
-	}
-
-	// Build URL with balance endpoint using alias instead of ID with proper URL encoding
-	base := e.baseURLs["transaction"]
-	// Remove trailing slash if present
-	base = strings.TrimSuffix(base, "/")
-
-	// Properly encode URL path parameters and query parameters
-	escapedOrgID := url.PathEscape(organizationID)
-	escapedLedgerID := url.PathEscape(ledgerID)
-	escapedAccountAlias := url.QueryEscape(*account.Alias)
-
-	accountsURL := fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances?account=%s",
-		base, escapedOrgID, escapedLedgerID, escapedAccountAlias)
+	accountsURL := e.buildAccountBalanceURL(organizationID, ledgerID, accountID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, accountsURL, nil)
 	if err != nil {
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	var balance models.Balance
-	if err := e.httpClient.sendRequest(req, &balance); err != nil {
+	var response models.ListResponse[models.Balance]
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		return nil, err
 	}
 
-	return &balance, nil
+	return selectSingleBalance(operation, accountID, response.Items)
 }
 
 // GetAccountsMetricsCount gets the count metrics for accounts in a ledger.
@@ -498,17 +469,12 @@ func (e *accountsEntity) GetAccountsMetricsCount(ctx context.Context, organizati
 
 	endpoint := e.buildMetricsURL(organizationID, ledgerID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	count, err := e.httpClient.doCountRequest(ctx, countRequestMethod(), endpoint, countRequestHeaders())
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.httpClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{AccountsCount: count}, nil
 }
 
 // buildURL builds the URL for accounts API calls.
@@ -516,16 +482,16 @@ func (e *accountsEntity) buildURL(organizationID, ledgerID, accountID string) st
 	baseURL := e.baseURLs["onboarding"]
 
 	if accountID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s", baseURL, organizationID, ledgerID, accountID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(accountID))
 }
 
 // buildMetricsURL builds the URL for accounts metrics API calls.
 func (e *accountsEntity) buildMetricsURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/metrics/count", baseURL, organizationID, ledgerID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/metrics/count", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }
 
 // GetExternalAccount gets an external account by asset code.
@@ -582,59 +548,50 @@ func (e *accountsEntity) GetExternalAccountBalance(ctx context.Context, organiza
 		return nil, errors.NewInternalError(operation, err)
 	}
 
-	var balance models.Balance
-	if err := e.httpClient.sendRequest(req, &balance); err != nil {
+	var response models.ListResponse[models.Balance]
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		return nil, err
 	}
 
-	return &balance, nil
+	return selectSingleBalance(operation, assetCode, response.Items)
 }
 
 // buildExternalAccountURL builds the URL for external account API calls.
 func (e *accountsEntity) buildExternalAccountURL(organizationID, ledgerID, assetCode string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s", baseURL, organizationID, ledgerID, assetCode)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(assetCode))
 }
 
 // buildExternalAccountBalanceURL builds the URL for external account balance API calls.
 func (e *accountsEntity) buildExternalAccountBalanceURL(organizationID, ledgerID, assetCode string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s/balances", baseURL, organizationID, ledgerID, assetCode)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s/balances", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(assetCode))
+}
+
+func (e *accountsEntity) buildAccountBalanceURL(organizationID, ledgerID, accountID string) string {
+	baseURL := e.baseURLs["transaction"]
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/balances", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(accountID))
 }
 
 // GetAccountByAliasPath retrieves a specific account by its alias using the dedicated path endpoint.
 func (e *accountsEntity) GetAccountByAliasPath(ctx context.Context, organizationID, ledgerID, alias string) (*models.Account, error) {
-	const operation = "GetAccountByAliasPath"
-
-	if organizationID == "" {
-		return nil, errors.NewMissingParameterError(operation, "organizationID")
-	}
-
-	if ledgerID == "" {
-		return nil, errors.NewMissingParameterError(operation, "ledgerID")
-	}
-
-	if alias == "" {
-		return nil, errors.NewMissingParameterError(operation, "alias")
-	}
-
-	endpoint := e.buildAliasURL(organizationID, ledgerID, alias)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var account models.Account
-	if err := e.httpClient.sendRequest(req, &account); err != nil {
-		return nil, err
-	}
-
-	return &account, nil
+	return e.GetAccountByAlias(ctx, organizationID, ledgerID, alias)
 }
 
 // buildAliasURL builds the URL for account alias path endpoint.
 func (e *accountsEntity) buildAliasURL(organizationID, ledgerID, alias string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/alias/%s", baseURL, organizationID, ledgerID, url.PathEscape(alias))
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/alias/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(alias))
+}
+
+func selectSingleBalance(operation, identifier string, balances []models.Balance) (*models.Balance, error) {
+	if len(balances) == 0 {
+		return nil, errors.NewNotFoundError(operation, "balance", identifier, nil)
+	}
+
+	if len(balances) > 1 {
+		return nil, errors.NewValidationError(operation, "multiple balances returned; use the balances service list methods for full results", nil)
+	}
+
+	return &balances[0], nil
 }

--- a/entities/accounts_test.go
+++ b/entities/accounts_test.go
@@ -928,23 +928,14 @@ func TestAccountsEntity_GetAccountByAlias(t *testing.T) {
 			ledgerID: "ledger-123",
 			alias:    "test-account",
 			mockResponse: `{
-				"items": [
-					{
-						"id": "acc-123",
-						"name": "Test Account",
-						"assetCode": "USD",
-						"organizationId": "org-123",
-						"ledgerId": "ledger-123",
-						"type": "LIABILITY",
-						"status": {"code": "ACTIVE"},
-						"alias": "test-account"
-					}
-				],
-				"pagination": {
-					"total": 1,
-					"limit": 10,
-					"offset": 0
-				}
+				"id": "acc-123",
+				"name": "Test Account",
+				"assetCode": "USD",
+				"organizationId": "org-123",
+				"ledgerId": "ledger-123",
+				"type": "LIABILITY",
+				"status": {"code": "ACTIVE"},
+				"alias": "test-account"
 			}`,
 			mockStatusCode: http.StatusOK,
 		},
@@ -974,8 +965,8 @@ func TestAccountsEntity_GetAccountByAlias(t *testing.T) {
 			orgID:          "org-123",
 			ledgerID:       "ledger-123",
 			alias:          "not-found",
-			mockResponse:   `{"items": [], "pagination": {"total": 0, "limit": 10, "offset": 0}}`,
-			mockStatusCode: http.StatusOK,
+			mockResponse:   `{"error":"account not found"}`,
+			mockStatusCode: http.StatusNotFound,
 			expectedError:  true,
 		},
 		{

--- a/entities/aliases.go
+++ b/entities/aliases.go
@@ -1,0 +1,221 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+)
+
+// AliasesService defines CRM alias operations.
+type AliasesService interface {
+	// ListAliases retrieves aliases for an organization.
+	ListAliases(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Alias], error)
+	// CreateAlias creates an alias for a holder.
+	CreateAlias(ctx context.Context, organizationID, holderID string, input *models.CreateAliasInput) (*models.Alias, error)
+	// GetAlias retrieves an alias by ID.
+	GetAlias(ctx context.Context, organizationID, holderID, aliasID string, includeDeleted bool) (*models.Alias, error)
+	// UpdateAlias updates an alias by ID.
+	UpdateAlias(ctx context.Context, organizationID, holderID, aliasID string, input *models.UpdateAliasInput) (*models.Alias, error)
+	// DeleteAlias deletes an alias by ID.
+	DeleteAlias(ctx context.Context, organizationID, holderID, aliasID string, hardDelete bool) error
+	// DeleteRelatedParty deletes a related party from an alias.
+	DeleteRelatedParty(ctx context.Context, organizationID, holderID, aliasID, relatedPartyID string) error
+}
+
+type aliasesEntity struct {
+	httpClient *HTTPClient
+	baseURLs   map[string]string
+}
+
+func (e *aliasesEntity) setDefaultTenantID(tenantID string) {
+	e.httpClient.SetTenantID(tenantID)
+}
+
+// NewAliasesEntity creates a new AliasesService instance.
+func NewAliasesEntity(client *http.Client, authToken string, baseURLs map[string]string) AliasesService {
+	httpClient := NewHTTPClient(client, authToken, nil)
+	if debugEnv := os.Getenv(EnvMidazDebug); debugEnv == BoolTrue {
+		httpClient.debug = true
+	}
+
+	return &aliasesEntity{httpClient: httpClient, baseURLs: baseURLs}
+}
+
+// ListAliases retrieves aliases for an organization.
+func (e *aliasesEntity) ListAliases(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Alias], error) {
+	const operation = "ListAliases"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.listURL(), nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	if opts != nil {
+		q := req.URL.Query()
+		for key, value := range opts.ToQueryParams() {
+			q.Add(key, value)
+		}
+
+		req.URL.RawQuery = q.Encode()
+	}
+
+	var response models.ListResponse[models.Alias]
+	if err := e.httpClient.doRequest(ctx, http.MethodGet, req.URL.String(), crmHeaders(organizationID), nil, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// CreateAlias creates an alias for a holder.
+func (e *aliasesEntity) CreateAlias(ctx context.Context, organizationID, holderID string, input *models.CreateAliasInput) (*models.Alias, error) {
+	const operation = "CreateAlias"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return nil, errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.NewValidationError(operation, "alias validation failed", err)
+	}
+
+	var alias models.Alias
+	if err := e.httpClient.doRequest(ctx, http.MethodPost, e.aliasURL(holderID, ""), crmHeaders(organizationID), input, &alias); err != nil {
+		return nil, err
+	}
+
+	return &alias, nil
+}
+
+// GetAlias retrieves an alias by ID.
+func (e *aliasesEntity) GetAlias(ctx context.Context, organizationID, holderID, aliasID string, includeDeleted bool) (*models.Alias, error) {
+	const operation = "GetAlias"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return nil, errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if aliasID == "" {
+		return nil, errors.NewMissingParameterError(operation, "aliasID")
+	}
+
+	endpoint := e.aliasURL(holderID, aliasID)
+	if includeDeleted {
+		endpoint += "?include_deleted=true"
+	}
+
+	var alias models.Alias
+	if err := e.httpClient.doRequest(ctx, http.MethodGet, endpoint, crmHeaders(organizationID), nil, &alias); err != nil {
+		return nil, err
+	}
+
+	return &alias, nil
+}
+
+// UpdateAlias updates an alias by ID.
+func (e *aliasesEntity) UpdateAlias(ctx context.Context, organizationID, holderID, aliasID string, input *models.UpdateAliasInput) (*models.Alias, error) {
+	const operation = "UpdateAlias"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return nil, errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if aliasID == "" {
+		return nil, errors.NewMissingParameterError(operation, "aliasID")
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.NewValidationError(operation, "alias validation failed", err)
+	}
+
+	var alias models.Alias
+	if err := e.httpClient.doRequest(ctx, http.MethodPatch, e.aliasURL(holderID, aliasID), crmHeaders(organizationID), input, &alias); err != nil {
+		return nil, err
+	}
+
+	return &alias, nil
+}
+
+// DeleteAlias deletes an alias by ID.
+func (e *aliasesEntity) DeleteAlias(ctx context.Context, organizationID, holderID, aliasID string, hardDelete bool) error {
+	const operation = "DeleteAlias"
+	if organizationID == "" {
+		return errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if aliasID == "" {
+		return errors.NewMissingParameterError(operation, "aliasID")
+	}
+
+	endpoint := e.aliasURL(holderID, aliasID)
+	if hardDelete {
+		endpoint += "?hard_delete=true"
+	}
+
+	return e.httpClient.doRequest(ctx, http.MethodDelete, endpoint, crmHeaders(organizationID), nil, nil)
+}
+
+// DeleteRelatedParty deletes a related party from an alias.
+func (e *aliasesEntity) DeleteRelatedParty(ctx context.Context, organizationID, holderID, aliasID, relatedPartyID string) error {
+	const operation = "DeleteRelatedParty"
+	if organizationID == "" {
+		return errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if aliasID == "" {
+		return errors.NewMissingParameterError(operation, "aliasID")
+	}
+
+	if relatedPartyID == "" {
+		return errors.NewMissingParameterError(operation, "relatedPartyID")
+	}
+
+	endpoint := fmt.Sprintf("%s/holders/%s/aliases/%s/related-parties/%s", e.baseURLs["crm"], pathSegment(holderID), pathSegment(aliasID), pathSegment(relatedPartyID))
+
+	return e.httpClient.doRequest(ctx, http.MethodDelete, endpoint, crmHeaders(organizationID), nil, nil)
+}
+
+func (e *aliasesEntity) listURL() string {
+	return fmt.Sprintf("%s/aliases", e.baseURLs["crm"])
+}
+
+func (e *aliasesEntity) aliasURL(holderID, aliasID string) string {
+	baseURL := e.baseURLs["crm"]
+	if aliasID == "" {
+		return fmt.Sprintf("%s/holders/%s/aliases", baseURL, pathSegment(holderID))
+	}
+
+	return fmt.Sprintf("%s/holders/%s/aliases/%s", baseURL, pathSegment(holderID), pathSegment(aliasID))
+}

--- a/entities/aliases_test.go
+++ b/entities/aliases_test.go
@@ -1,0 +1,132 @@
+package entities
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAliasesEntity_CreateAlias_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/holders/holder%2F1/aliases", r.URL.EscapedPath())
+		assert.Equal(t, "org-123", r.Header.Get("X-Organization-Id"))
+
+		var body models.CreateAliasInput
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "ledger-123", body.LedgerID)
+		assert.Equal(t, "account-123", body.AccountID)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ledgerId":"ledger-123","accountId":"account-123"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewAliasesEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*aliasesEntity)
+	alias, err := service.CreateAlias(context.Background(), "org-123", "holder/1", &models.CreateAliasInput{LedgerID: "ledger-123", AccountID: "account-123"})
+
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "ledger-123", *alias.LedgerID)
+	assert.Equal(t, "account-123", *alias.AccountID)
+}
+
+func TestAliasesEntity_UpdateAlias_OmitsNilFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/holders/holder-1/aliases/alias-1", r.URL.Path)
+
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, map[string]any{"risk": "low"}, body["metadata"])
+		assert.NotContains(t, body, "bankingDetails")
+		assert.NotContains(t, body, "regulatoryFields")
+		assert.NotContains(t, body, "relatedParties")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"ledgerId":"ledger-123","accountId":"account-123","metadata":{"risk":"low"}}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewAliasesEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*aliasesEntity)
+	alias, err := service.UpdateAlias(context.Background(), "org-123", "holder-1", "alias-1", &models.UpdateAliasInput{Metadata: map[string]any{"risk": "low"}})
+
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "low", alias.Metadata["risk"])
+}
+
+func TestAliasesEntity_ValidationErrors(t *testing.T) {
+	service := NewAliasesEntity(http.DefaultClient, "token", map[string]string{"crm": "https://crm.example.com/v1"}).(*aliasesEntity)
+
+	_, err := service.CreateAlias(context.Background(), "org-123", "holder-1", &models.CreateAliasInput{AccountID: "account-123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ledgerId is required")
+
+	_, err = service.UpdateAlias(context.Background(), "org-123", "holder-1", "alias-1", &models.UpdateAliasInput{RelatedParties: []*models.RelatedParty{{Role: "INVALID"}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "document is required")
+}
+
+func TestAliasesEntity_DeleteRelatedParty_EscapesAllIDs(t *testing.T) {
+	entity := &aliasesEntity{baseURLs: map[string]string{"crm": "https://crm.example.com/v1"}}
+	endpoint := entity.aliasURL("holder/1", "alias/2")
+
+	assert.Equal(t, "https://crm.example.com/v1/holders/holder%2F1/aliases/alias%2F2", endpoint)
+}
+
+func TestAliasesEntity_ListGetDelete_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "org-123", r.Header.Get("X-Organization-Id"))
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/aliases":
+			assert.Equal(t, "holder-123", r.URL.Query().Get("holder_id"))
+
+			_, err := w.Write([]byte(`{"items":[{"ledgerId":"ledger-123","accountId":"account-123"}],"limit":10,"page":1}`))
+			assert.NoError(t, err)
+		case r.Method == http.MethodGet && r.URL.Path == "/holders/holder-123/aliases/alias-123":
+			assert.Equal(t, "true", r.URL.Query().Get("include_deleted"))
+
+			_, err := w.Write([]byte(`{"ledgerId":"ledger-123","accountId":"account-123"}`))
+			assert.NoError(t, err)
+		case r.Method == http.MethodDelete && r.URL.Path == "/holders/holder-123/aliases/alias-123":
+			assert.Equal(t, "true", r.URL.Query().Get("hard_delete"))
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/holders/holder-123/aliases/alias-123/related-parties/party-123":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	service := NewAliasesEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*aliasesEntity)
+	list, err := service.ListAliases(context.Background(), "org-123", models.NewListOptions().WithHolderID("holder-123"))
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+
+	alias, err := service.GetAlias(context.Background(), "org-123", "holder-123", "alias-123", true)
+	require.NoError(t, err)
+	assert.Equal(t, "ledger-123", *alias.LedgerID)
+
+	require.NoError(t, service.DeleteAlias(context.Background(), "org-123", "holder-123", "alias-123", true))
+	require.NoError(t, service.DeleteRelatedParty(context.Background(), "org-123", "holder-123", "alias-123", "party-123"))
+}

--- a/entities/asset_rates.go
+++ b/entities/asset_rates.go
@@ -253,14 +253,14 @@ func (e *assetRatesEntity) buildURL(organizationID, ledgerID, externalID string)
 	baseURL := e.baseURLs["transaction"]
 
 	if externalID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates/%s", baseURL, organizationID, ledgerID, externalID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(externalID))
 }
 
 // buildFromAssetURL builds the URL for listing asset rates by source asset code.
 func (e *assetRatesEntity) buildFromAssetURL(organizationID, ledgerID, assetCode string) string {
 	baseURL := e.baseURLs["transaction"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates/from/%s", baseURL, organizationID, ledgerID, assetCode)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/asset-rates/from/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(assetCode))
 }

--- a/entities/assets.go
+++ b/entities/assets.go
@@ -414,17 +414,12 @@ func (e *assetsEntity) GetAssetsMetricsCount(ctx context.Context, organizationID
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.httpClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{AssetsCount: count}, nil
 }
 
 // buildURL builds the URL for assets API calls.
@@ -438,14 +433,14 @@ func (e *assetsEntity) buildURL(organizationID, ledgerID, assetID string) string
 	baseURL = strings.TrimSuffix(baseURL, "/")
 
 	if assetID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets/%s", baseURL, organizationID, ledgerID, assetID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(assetID))
 }
 
 // buildMetricsURL builds the URL for assets metrics API calls.
 func (e *assetsEntity) buildMetricsURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets/metrics/count", baseURL, organizationID, ledgerID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets/metrics/count", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }

--- a/entities/assets.go
+++ b/entities/assets.go
@@ -414,7 +414,7 @@ func (e *assetsEntity) GetAssetsMetricsCount(ctx context.Context, organizationID
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, url, nil)
+	count, err := e.httpClient.doCountRequest(ctx, countRequestMethod(), url, countRequestHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/entities/assets.go
+++ b/entities/assets.go
@@ -442,5 +442,7 @@ func (e *assetsEntity) buildURL(organizationID, ledgerID, assetID string) string
 // buildMetricsURL builds the URL for assets metrics API calls.
 func (e *assetsEntity) buildMetricsURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
+	baseURL = strings.TrimSuffix(baseURL, "/")
+
 	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/assets/metrics/count", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }

--- a/entities/assets_test.go
+++ b/entities/assets_test.go
@@ -1123,9 +1123,9 @@ func TestAssetsEntity_GetAssetsMetricsCount(t *testing.T) {
 			name:           "Success",
 			orgID:          "org-123",
 			ledgerID:       "ledger-123",
-			mockStatusCode: http.StatusOK,
+			mockStatusCode: http.StatusNoContent,
 			mockHeaders: map[string]string{
-				"X-Assets-Count": "42",
+				HeaderTotalCount: "42",
 			},
 			expectedCount: 42,
 		},
@@ -1197,6 +1197,7 @@ func TestAssetsEntity_GetAssetsMetricsCount(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.NotNil(t, result)
+			assert.Equal(t, tt.expectedCount, result.AssetsCount)
 		})
 	}
 }
@@ -1583,10 +1584,8 @@ func TestAssetsEntity_QueryParameters(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, receivedURL, "limit=5")
-	assert.Contains(t, receivedURL, "offset=10")
-	assert.Contains(t, receivedURL, "orderBy=name")
-	// Note: orderDirection is used instead of sortOrder in this SDK
-	assert.Contains(t, receivedURL, "orderDirection=desc")
+	assert.Contains(t, receivedURL, "page=3")
+	assert.Contains(t, receivedURL, "sort_order=desc")
 }
 
 // TestAssetsEntity_RequestHeaders tests that correct headers are sent

--- a/entities/balances.go
+++ b/entities/balances.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
@@ -196,6 +197,9 @@ type BalancesService interface {
 	// Returns the balance if found, or an error if the operation fails or the balance doesn't exist.
 	GetBalance(ctx context.Context, orgID, ledgerID, balanceID string) (*models.Balance, error)
 
+	// GetBalanceHistory retrieves the historical state of a balance at a specific point in time.
+	GetBalanceHistory(ctx context.Context, orgID, ledgerID, balanceID, date string) (*models.BalanceHistory, error)
+
 	// UpdateBalance updates an existing balance.
 	// The orgID, ledgerID, and balanceID parameters specify which organization, ledger, and balance to update.
 	// The input parameter contains the balance details to update, such as amount or metadata.
@@ -222,6 +226,9 @@ type BalancesService interface {
 	// The external code links the account to external systems.
 	// Returns a paginated list of balances, or an error if the operation fails.
 	ListBalancesByExternalCode(ctx context.Context, orgID, ledgerID, code string, opts *models.ListOptions) (*models.ListResponse[models.Balance], error)
+
+	// GetAccountBalancesHistory retrieves the historical state of all balances for an account at a specific point in time.
+	GetAccountBalancesHistory(ctx context.Context, orgID, ledgerID, accountID, date string) ([]models.BalanceHistory, error)
 }
 
 // balancesEntity implements the BalancesService interface.
@@ -424,6 +431,45 @@ func (e *balancesEntity) GetBalance(
 	return &balance, nil
 }
 
+// GetBalanceHistory retrieves the historical state of a balance at a specific point in time.
+func (e *balancesEntity) GetBalanceHistory(ctx context.Context, orgID, ledgerID, balanceID, date string) (*models.BalanceHistory, error) {
+	const operation = "GetBalanceHistory"
+
+	if orgID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if ledgerID == "" {
+		return nil, errors.NewMissingParameterError(operation, "ledgerID")
+	}
+
+	if balanceID == "" {
+		return nil, errors.NewMissingParameterError(operation, "balanceID")
+	}
+
+	if date == "" {
+		return nil, errors.NewMissingParameterError(operation, "date")
+	}
+
+	if err := validateBalanceHistoryDate(date); err != nil {
+		return nil, errors.NewValidationError(operation, "invalid date", err)
+	}
+
+	endpoint := e.buildBalanceHistoryURL(orgID, ledgerID, balanceID, date)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	var response models.BalanceHistory
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
 // UpdateBalance updates an existing balance.
 // The orgID, ledgerID, and balanceID parameters specify which organization, ledger, and balance to update.
 // The input parameter contains the balance details to update, such as amount or metadata.
@@ -522,10 +568,10 @@ func (e *balancesEntity) buildURL(organizationID, ledgerID, balanceID string) st
 	baseURL := e.baseURLs["transaction"]
 
 	if balanceID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances/%s", baseURL, organizationID, ledgerID, balanceID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(balanceID))
 }
 
 // buildAccountURL builds the URL for account balances API calls.
@@ -535,7 +581,7 @@ func (e *balancesEntity) buildURL(organizationID, ledgerID, balanceID string) st
 func (e *balancesEntity) buildAccountURL(orgID, ledgerID, accountID string) string {
 	baseURL := e.baseURLs["transaction"]
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/balances", baseURL, orgID, ledgerID, accountID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/balances", baseURL, pathSegment(orgID), pathSegment(ledgerID), pathSegment(accountID))
 }
 
 // CreateBalance creates an additional balance for an account.
@@ -668,16 +714,73 @@ func (e *balancesEntity) ListBalancesByExternalCode(ctx context.Context, orgID, 
 	return &response, nil
 }
 
+// GetAccountBalancesHistory retrieves the historical state of all balances for an account at a specific point in time.
+func (e *balancesEntity) GetAccountBalancesHistory(ctx context.Context, orgID, ledgerID, accountID, date string) ([]models.BalanceHistory, error) {
+	const operation = "GetAccountBalancesHistory"
+
+	if orgID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if ledgerID == "" {
+		return nil, errors.NewMissingParameterError(operation, "ledgerID")
+	}
+
+	if accountID == "" {
+		return nil, errors.NewMissingParameterError(operation, "accountID")
+	}
+
+	if date == "" {
+		return nil, errors.NewMissingParameterError(operation, "date")
+	}
+
+	if err := validateBalanceHistoryDate(date); err != nil {
+		return nil, errors.NewValidationError(operation, "invalid date", err)
+	}
+
+	endpoint := e.buildAccountHistoryURL(orgID, ledgerID, accountID, date)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	var response []models.BalanceHistory
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 // buildAccountAliasURL builds the URL for balance lookups by account alias.
 func (e *balancesEntity) buildAccountAliasURL(orgID, ledgerID, alias string) string {
 	baseURL := e.baseURLs["transaction"]
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/alias/%s/balances", baseURL, orgID, ledgerID, url.PathEscape(alias))
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/alias/%s/balances", baseURL, pathSegment(orgID), pathSegment(ledgerID), pathSegment(alias))
 }
 
 // buildExternalCodeURL builds the URL for balance lookups by external code.
 func (e *balancesEntity) buildExternalCodeURL(orgID, ledgerID, code string) string {
 	baseURL := e.baseURLs["transaction"]
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s/balances", baseURL, orgID, ledgerID, url.PathEscape(code))
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/external/%s/balances", baseURL, pathSegment(orgID), pathSegment(ledgerID), pathSegment(code))
+}
+
+func (e *balancesEntity) buildBalanceHistoryURL(orgID, ledgerID, balanceID, date string) string {
+	baseURL := e.baseURLs["transaction"]
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/balances/%s/history?date=%s", baseURL, pathSegment(orgID), pathSegment(ledgerID), pathSegment(balanceID), url.QueryEscape(date))
+}
+
+func (e *balancesEntity) buildAccountHistoryURL(orgID, ledgerID, accountID, date string) string {
+	baseURL := e.baseURLs["transaction"]
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/balances/history?date=%s", baseURL, pathSegment(orgID), pathSegment(ledgerID), pathSegment(accountID), url.QueryEscape(date))
+}
+
+func validateBalanceHistoryDate(date string) error {
+	if _, err := time.Parse("2006-01-02 15:04:05", date); err != nil {
+		return fmt.Errorf("date must use format yyyy-mm-dd hh:mm:ss: %w", err)
+	}
+
+	return nil
 }

--- a/entities/balances.go
+++ b/entities/balances.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -778,9 +779,17 @@ func (e *balancesEntity) buildAccountHistoryURL(orgID, ledgerID, accountID, date
 }
 
 func validateBalanceHistoryDate(date string) error {
-	if _, err := time.Parse("2006-01-02 15:04:05", date); err != nil {
-		return fmt.Errorf("date must use format yyyy-mm-dd hh:mm:ss: %w", err)
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		time.DateOnly,
 	}
 
-	return nil
+	for _, layout := range layouts {
+		if _, err := time.Parse(layout, date); err == nil {
+			return nil
+		}
+	}
+
+	return stderrors.New("date must use YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, or RFC3339")
 }

--- a/entities/balances_test.go
+++ b/entities/balances_test.go
@@ -332,7 +332,7 @@ func TestBalancesEntity_ListBalances(t *testing.T) {
 			checkRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
 				assert.Contains(t, req.URL.RawQuery, "limit=5")
-				assert.Contains(t, req.URL.RawQuery, "offset=10")
+				assert.Contains(t, req.URL.RawQuery, "page=3")
 			},
 		},
 		{
@@ -913,11 +913,11 @@ func TestBalancesEntity_UpdateBalance(t *testing.T) {
 		checkRequest   func(t *testing.T, req *http.Request)
 	}{
 		{
-			name:      "Success with metadata",
+			name:      "Success with transfer flags",
 			orgID:     "org-123",
 			ledgerID:  "ledger-456",
 			balanceID: "bal-789",
-			input:     models.NewUpdateBalanceInput().WithMetadata(map[string]any{"updated": "true", "key": "new-value"}),
+			input:     models.NewUpdateBalanceInput().WithAllowSending(false).WithAllowReceiving(true),
 			mockResponse: `{
 				"id": "bal-789",
 				"organizationId": "org-123",
@@ -927,21 +927,26 @@ func TestBalancesEntity_UpdateBalance(t *testing.T) {
 				"available": "1000000",
 				"onHold": "50000",
 				"version": 2,
-				"metadata": {"updated": "true", "key": "new-value"}
+				"allowSending": false,
+				"allowReceiving": true
 			}`,
 			mockStatusCode: http.StatusOK,
 			expectedID:     "bal-789",
 			checkRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
 				assert.Equal(t, http.MethodPatch, req.Method)
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(t, `{"allowSending":false,"allowReceiving":true}`, string(body))
+				assert.NotContains(t, string(body), "metadata")
 			},
 		},
 		{
-			name:      "Success with empty metadata",
+			name:      "Success with empty update body",
 			orgID:     "org-123",
 			ledgerID:  "ledger-456",
 			balanceID: "bal-789",
-			input:     models.NewUpdateBalanceInput().WithMetadata(map[string]any{}),
+			input:     models.NewUpdateBalanceInput().WithMetadata(map[string]any{"legacy": "ignored"}),
 			mockResponse: `{
 				"id": "bal-789",
 				"organizationId": "org-123",
@@ -950,11 +955,18 @@ func TestBalancesEntity_UpdateBalance(t *testing.T) {
 				"assetCode": "USD",
 				"available": "1000000",
 				"onHold": "50000",
-				"version": 2,
-				"metadata": {}
+				"version": 2
 			}`,
 			mockStatusCode: http.StatusOK,
 			expectedID:     "bal-789",
+			checkRequest: func(t *testing.T, req *http.Request) {
+				t.Helper()
+
+				body, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+				assert.JSONEq(t, `{}`, string(body))
+				assert.NotContains(t, string(body), "metadata")
+			},
 		},
 		{
 			name:          "Empty organization ID",
@@ -1054,6 +1066,38 @@ func TestBalancesEntity_UpdateBalance(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBalancesEntity_History_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.EscapedPath() {
+		case "/organizations/org%2F1/ledgers/ledger%2F1/balances/balance%2F1/history":
+			assert.Equal(t, "2026-01-02 03:04:05", r.URL.Query().Get("date"))
+
+			_, err := w.Write([]byte(`{}`))
+			assert.NoError(t, err)
+		case "/organizations/org%2F1/ledgers/ledger%2F1/accounts/account%2F1/balances/history":
+			assert.Equal(t, "2026-01-02 03:04:05", r.URL.Query().Get("date"))
+
+			_, err := w.Write([]byte(`[{}]`))
+			assert.NoError(t, err)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.EscapedPath())
+		}
+	}))
+	defer server.Close()
+
+	service := NewBalancesEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	history, err := service.GetBalanceHistory(context.Background(), "org/1", "ledger/1", "balance/1", "2026-01-02 03:04:05")
+	require.NoError(t, err)
+	require.NotNil(t, history)
+
+	histories, err := service.GetAccountBalancesHistory(context.Background(), "org/1", "ledger/1", "account/1", "2026-01-02 03:04:05")
+	require.NoError(t, err)
+	require.Len(t, histories, 1)
 }
 
 // TestBalancesEntity_DeleteBalance tests the DeleteBalance method
@@ -1934,7 +1978,7 @@ func TestBalancesEntity_QueryParameterEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, capturedURL, "limit=25")
-	assert.Contains(t, capturedURL, "offset=50")
+	assert.Contains(t, capturedURL, "page=3")
 }
 
 // TestBalancesEntity_JSONResponseParsing tests JSON response parsing

--- a/entities/balances_test.go
+++ b/entities/balances_test.go
@@ -942,31 +942,12 @@ func TestBalancesEntity_UpdateBalance(t *testing.T) {
 			},
 		},
 		{
-			name:      "Success with empty update body",
-			orgID:     "org-123",
-			ledgerID:  "ledger-456",
-			balanceID: "bal-789",
-			input:     models.NewUpdateBalanceInput().WithMetadata(map[string]any{"legacy": "ignored"}),
-			mockResponse: `{
-				"id": "bal-789",
-				"organizationId": "org-123",
-				"ledgerId": "ledger-456",
-				"accountId": "acc-012",
-				"assetCode": "USD",
-				"available": "1000000",
-				"onHold": "50000",
-				"version": 2
-			}`,
-			mockStatusCode: http.StatusOK,
-			expectedID:     "bal-789",
-			checkRequest: func(t *testing.T, req *http.Request) {
-				t.Helper()
-
-				body, err := io.ReadAll(req.Body)
-				require.NoError(t, err)
-				assert.JSONEq(t, `{}`, string(body))
-				assert.NotContains(t, string(body), "metadata")
-			},
+			name:          "Metadata update is rejected",
+			orgID:         "org-123",
+			ledgerID:      "ledger-456",
+			balanceID:     "bal-789",
+			input:         models.NewUpdateBalanceInput().WithMetadata(map[string]any{"legacy": "ignored"}),
+			expectedError: true,
 		},
 		{
 			name:          "Empty organization ID",
@@ -1736,7 +1717,7 @@ func TestBalancesEntity_HTTPServerIntegration(t *testing.T) {
 			"transaction": server.URL,
 		})
 
-		input := models.NewUpdateBalanceInput().WithMetadata(map[string]any{"updated": "true"})
+		input := models.NewUpdateBalanceInput().WithAllowSending(false)
 		result, err := entity.UpdateBalance(context.Background(), "org-123", "ledger-456", "bal-789", input)
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -2145,14 +2126,14 @@ func TestUpdateBalanceInput_Validation(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:          "Valid input with metadata",
+			name:          "Rejects metadata",
 			input:         models.NewUpdateBalanceInput().WithMetadata(map[string]any{"key": "value"}),
-			expectedError: false,
+			expectedError: true,
 		},
 		{
-			name:          "Valid input with empty metadata",
+			name:          "Rejects empty metadata",
 			input:         models.NewUpdateBalanceInput().WithMetadata(map[string]any{}),
-			expectedError: false,
+			expectedError: true,
 		},
 		{
 			name:          "Valid input with nil metadata",

--- a/entities/constants.go
+++ b/entities/constants.go
@@ -18,8 +18,13 @@ const (
 // Header names used in HTTP requests.
 const (
 	// HeaderTenantID is the HTTP header name used to propagate the tenant identifier.
-	// When set, the Midaz API scopes the request to the specified tenant.
+	// This is an optional compatibility header for deployments or gateways that honor
+	// explicit tenant headers. In the reference Midaz path, authenticated claims remain
+	// the primary tenant source of truth.
 	HeaderTenantID = "X-Tenant-ID"
+
+	// HeaderTotalCount is the HTTP header name used by count endpoints.
+	HeaderTotalCount = "X-Total-Count"
 )
 
 // Environment variable names used for SDK configuration.

--- a/entities/context.go
+++ b/entities/context.go
@@ -32,9 +32,10 @@ func getIdempotencyKeyFromContext(ctx context.Context) string {
 type contextKeyTenantID struct{}
 
 // WithTenantID attaches a tenant ID to the request context.
-// The HTTP client will add it as an 'X-Tenant-ID' header, which scopes the
-// API request to the specified tenant. If tenantID is empty, the context
-// is returned unchanged and no header will be set from context.
+// The HTTP client will add it as an 'X-Tenant-ID' header for deployments that
+// honor explicit tenant headers. In the reference Midaz path, authenticated claims
+// remain the primary tenant source of truth. If tenantID is empty, the context is
+// returned unchanged and no header will be set from context.
 func WithTenantID(ctx context.Context, tenantID string) context.Context {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {

--- a/entities/crm_shared.go
+++ b/entities/crm_shared.go
@@ -1,0 +1,5 @@
+package entities
+
+func crmHeaders(organizationID string) map[string]string {
+	return map[string]string{"X-Organization-Id": organizationID}
+}

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -409,6 +409,7 @@ func (e *Entity) SetAuthToken(token string) {
 	if token != "" {
 		// Set the token directly on the HTTP client
 		e.httpClient.authToken = token
+		e.propagateHTTPClientConfiguration()
 	}
 }
 
@@ -522,10 +523,6 @@ func withOptionalCRMURL(baseURLs map[string]string) map[string]string {
 	normalized := make(map[string]string, len(baseURLs)+1)
 	for service, serviceURL := range baseURLs {
 		normalized[service] = serviceURL
-	}
-
-	if _, ok := normalized["crm"]; !ok {
-		normalized["crm"] = normalized["onboarding"]
 	}
 
 	return normalized

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -137,9 +137,14 @@ func NewEntity(client *http.Client, authToken string, baseURLs map[string]string
 	// Create a new entity with the provided configuration
 	httpClient := NewHTTPClient(client, authToken, observabilityProvider)
 
+	normalizedBaseURLs, err := normalizeBaseURLs(baseURLs)
+	if err != nil {
+		return nil, err
+	}
+
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      copyBaseURLs(baseURLs),
+		baseURLs:      normalizedBaseURLs,
 		observability: observabilityProvider,
 	}
 
@@ -190,9 +195,14 @@ func NewEntityWithConfig(config Config, options ...Option) (*Entity, error) {
 	// Create a new entity with the provided configuration
 	httpClient := NewHTTPClient(config.GetHTTPClient(), authToken, config.GetObservabilityProvider())
 
+	normalizedBaseURLs, err := normalizeBaseURLs(config.GetBaseURLs())
+	if err != nil {
+		return nil, err
+	}
+
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      copyBaseURLs(config.GetBaseURLs()),
+		baseURLs:      normalizedBaseURLs,
 		observability: config.GetObservabilityProvider(),
 	}
 
@@ -490,14 +500,9 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 		return nil, errors.New("missing transaction URL in service URLs map")
 	}
 
-	normalizedBaseURLs := copyBaseURLs(serviceURLs)
-	if strings.TrimSpace(normalizedBaseURLs["crm"]) == "" {
-		crmURL := strings.TrimSpace(os.Getenv("MIDAZ_CRM_URL"))
-		if crmURL == "" {
-			return nil, errors.New("missing crm URL in service URLs map or MIDAZ_CRM_URL")
-		}
-
-		normalizedBaseURLs["crm"] = crmURL
+	normalizedBaseURLs, err := normalizeBaseURLs(serviceURLs)
+	if err != nil {
+		return nil, err
 	}
 
 	// Create a default HTTP client
@@ -538,4 +543,22 @@ func copyBaseURLs(baseURLs map[string]string) map[string]string {
 	}
 
 	return normalized
+}
+
+func normalizeBaseURLs(baseURLs map[string]string) (map[string]string, error) {
+	normalized := copyBaseURLs(baseURLs)
+	if normalized == nil {
+		return nil, errors.New("service URLs map cannot be nil")
+	}
+
+	if strings.TrimSpace(normalized["crm"]) == "" {
+		crmURL := strings.TrimSpace(os.Getenv("MIDAZ_CRM_URL"))
+		if crmURL == "" {
+			return nil, errors.New("missing crm URL in service URLs map or MIDAZ_CRM_URL")
+		}
+
+		normalized["crm"] = crmURL
+	}
+
+	return normalized, nil
 }

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	auth "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/access-manager"
@@ -137,7 +139,7 @@ func NewEntity(client *http.Client, authToken string, baseURLs map[string]string
 
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      withOptionalCRMURL(baseURLs),
+		baseURLs:      copyBaseURLs(baseURLs),
 		observability: observabilityProvider,
 	}
 
@@ -190,7 +192,7 @@ func NewEntityWithConfig(config Config, options ...Option) (*Entity, error) {
 
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      withOptionalCRMURL(config.GetBaseURLs()),
+		baseURLs:      copyBaseURLs(config.GetBaseURLs()),
 		observability: config.GetObservabilityProvider(),
 	}
 
@@ -319,7 +321,7 @@ func (e *metadataIndexesEntity) entityHTTPClient() *HTTPClient {
 }
 
 func (e *operationsEntity) entityHTTPClient() *HTTPClient {
-	return e.HTTPClient
+	return e.httpClient
 }
 
 func (e *operationRoutesEntity) entityHTTPClient() *HTTPClient {
@@ -327,15 +329,15 @@ func (e *operationRoutesEntity) entityHTTPClient() *HTTPClient {
 }
 
 func (e *organizationsEntity) entityHTTPClient() *HTTPClient {
-	return e.HTTPClient
+	return e.httpClient
 }
 
 func (e *portfoliosEntity) entityHTTPClient() *HTTPClient {
-	return e.HTTPClient
+	return e.httpClient
 }
 
 func (e *segmentsEntity) entityHTTPClient() *HTTPClient {
-	return e.HTTPClient
+	return e.httpClient
 }
 
 func (e *transactionsEntity) entityHTTPClient() *HTTPClient {
@@ -488,6 +490,16 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 		return nil, errors.New("missing transaction URL in service URLs map")
 	}
 
+	normalizedBaseURLs := copyBaseURLs(serviceURLs)
+	if strings.TrimSpace(normalizedBaseURLs["crm"]) == "" {
+		crmURL := strings.TrimSpace(os.Getenv("MIDAZ_CRM_URL"))
+		if crmURL == "" {
+			return nil, errors.New("missing crm URL in service URLs map or MIDAZ_CRM_URL")
+		}
+
+		normalizedBaseURLs["crm"] = crmURL
+	}
+
 	// Create a default HTTP client
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -499,7 +511,7 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 	// Create a new entity with the provided service URLs
 	entity := &Entity{
 		httpClient: httpClient,
-		baseURLs:   withOptionalCRMURL(serviceURLs),
+		baseURLs:   normalizedBaseURLs,
 	}
 
 	// Apply any options
@@ -515,7 +527,7 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 	return entity, nil
 }
 
-func withOptionalCRMURL(baseURLs map[string]string) map[string]string {
+func copyBaseURLs(baseURLs map[string]string) map[string]string {
 	if baseURLs == nil {
 		return nil
 	}

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -552,9 +552,13 @@ func normalizeBaseURLs(baseURLs map[string]string) (map[string]string, error) {
 	}
 
 	if strings.TrimSpace(normalized["crm"]) == "" {
-		crmURL := strings.TrimSpace(os.Getenv("MIDAZ_CRM_URL"))
+		crmURL := strings.TrimSpace(normalized["onboarding"])
 		if crmURL == "" {
-			return nil, errors.New("missing crm URL in service URLs map or MIDAZ_CRM_URL")
+			crmURL = strings.TrimSpace(os.Getenv("MIDAZ_CRM_URL"))
+		}
+
+		if crmURL == "" {
+			return nil, errors.New("missing crm URL: provide 'crm' key in service URLs map or set MIDAZ_CRM_URL environment variable")
 		}
 
 		normalized["crm"] = crmURL

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -47,7 +47,10 @@ type Entity struct {
 	Assets            AssetsService
 	AssetRates        AssetRatesService
 	Balances          BalancesService
+	Holders           HoldersService
+	Aliases           AliasesService
 	Ledgers           LedgersService
+	MetadataIndexes   MetadataIndexesService
 	Operations        OperationsService
 	OperationRoutes   OperationRoutesService
 	Organizations     OrganizationsService
@@ -134,7 +137,7 @@ func NewEntity(client *http.Client, authToken string, baseURLs map[string]string
 
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      baseURLs,
+		baseURLs:      withOptionalCRMURL(baseURLs),
 		observability: observabilityProvider,
 	}
 
@@ -187,7 +190,7 @@ func NewEntityWithConfig(config Config, options ...Option) (*Entity, error) {
 
 	entity := &Entity{
 		httpClient:    httpClient,
-		baseURLs:      config.GetBaseURLs(),
+		baseURLs:      withOptionalCRMURL(config.GetBaseURLs()),
 		observability: config.GetObservabilityProvider(),
 	}
 
@@ -213,7 +216,10 @@ func (e *Entity) initServices() {
 	e.Assets = NewAssetsEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.AssetRates = NewAssetRatesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.Balances = NewBalancesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
+	e.Holders = NewHoldersEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
+	e.Aliases = NewAliasesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.Ledgers = NewLedgersEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
+	e.MetadataIndexes = NewMetadataIndexesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.Operations = NewOperationsEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.OperationRoutes = NewOperationRoutesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.Organizations = NewOrganizationsEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
@@ -221,16 +227,19 @@ func (e *Entity) initServices() {
 	e.Segments = NewSegmentsEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 	e.TransactionRoutes = NewTransactionRoutesEntity(e.httpClient.client, e.httpClient.authToken, e.baseURLs)
 
-	// Propagate the entity-level tenant ID to each service entity's HTTP client.
-	// Each NewXxxEntity constructor creates a fresh HTTPClient with tenantID="",
-	// so we must copy the tenant ID from the parent entity after construction.
-	e.propagateTenantID()
+	// Each NewXxxEntity constructor creates a fresh HTTPClient around the shared
+	// transport. Copy the parent entity configuration across after construction.
+	e.propagateHTTPClientConfiguration()
 }
 
 // tenantSetter is implemented by service entities that can receive a tenant ID.
 // This decouples propagateTenantID from knowing every concrete service type.
 type tenantSetter interface {
 	setDefaultTenantID(tenantID string)
+}
+
+type httpClientConfigurator interface {
+	entityHTTPClient() *HTTPClient
 }
 
 // propagateTenantID copies the entity-level tenant ID to all service entity HTTP clients.
@@ -244,7 +253,7 @@ func (e *Entity) propagateTenantID() {
 
 	services := []any{
 		e.Accounts, e.AccountTypes, e.Assets, e.AssetRates,
-		e.Balances, e.Ledgers, e.Operations, e.OperationRoutes,
+		e.Aliases, e.Balances, e.Holders, e.Ledgers, e.MetadataIndexes, e.Operations, e.OperationRoutes,
 		e.Organizations, e.Portfolios, e.Segments,
 		e.Transactions, e.TransactionRoutes,
 	}
@@ -254,6 +263,87 @@ func (e *Entity) propagateTenantID() {
 			ts.setDefaultTenantID(tid)
 		}
 	}
+}
+
+func (e *Entity) propagateHTTPClientConfiguration() {
+	e.propagateTenantID()
+
+	services := []any{
+		e.Accounts, e.AccountTypes, e.Assets, e.AssetRates,
+		e.Aliases, e.Balances, e.Holders, e.Ledgers, e.MetadataIndexes, e.Operations, e.OperationRoutes,
+		e.Organizations, e.Portfolios, e.Segments,
+		e.Transactions, e.TransactionRoutes,
+	}
+
+	for _, svc := range services {
+		if configurator, ok := svc.(httpClientConfigurator); ok {
+			configurator.entityHTTPClient().applyConfigurationFrom(e.httpClient)
+		}
+	}
+}
+
+func (e *accountsEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *accountTypesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *assetsEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *assetRatesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *balancesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *holdersEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *aliasesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *ledgersEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *metadataIndexesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *operationsEntity) entityHTTPClient() *HTTPClient {
+	return e.HTTPClient
+}
+
+func (e *operationRoutesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *organizationsEntity) entityHTTPClient() *HTTPClient {
+	return e.HTTPClient
+}
+
+func (e *portfoliosEntity) entityHTTPClient() *HTTPClient {
+	return e.HTTPClient
+}
+
+func (e *segmentsEntity) entityHTTPClient() *HTTPClient {
+	return e.HTTPClient
+}
+
+func (e *transactionsEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
+}
+
+func (e *transactionRoutesEntity) entityHTTPClient() *HTTPClient {
+	return e.httpClient
 }
 
 // InitServices initializes the service interfaces for the entity.
@@ -342,6 +432,7 @@ func New(baseURL string, options ...Option) (*Entity, error) {
 	baseURLs := map[string]string{
 		"onboarding":  baseURL,
 		"transaction": baseURL,
+		"crm":         baseURL,
 	}
 
 	// Create a default HTTP client
@@ -407,7 +498,7 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 	// Create a new entity with the provided service URLs
 	entity := &Entity{
 		httpClient: httpClient,
-		baseURLs:   serviceURLs,
+		baseURLs:   withOptionalCRMURL(serviceURLs),
 	}
 
 	// Apply any options
@@ -421,4 +512,21 @@ func NewWithServiceURLs(serviceURLs map[string]string, options ...Option) (*Enti
 	entity.initServices()
 
 	return entity, nil
+}
+
+func withOptionalCRMURL(baseURLs map[string]string) map[string]string {
+	if baseURLs == nil {
+		return nil
+	}
+
+	normalized := make(map[string]string, len(baseURLs)+1)
+	for service, serviceURL := range baseURLs {
+		normalized[service] = serviceURL
+	}
+
+	if _, ok := normalized["crm"]; !ok {
+		normalized["crm"] = normalized["onboarding"]
+	}
+
+	return normalized
 }

--- a/entities/entity_test.go
+++ b/entities/entity_test.go
@@ -12,7 +12,21 @@ func TestMainFunction(_ *testing.T) {
 	// so that the testing package will execute all test files in the package.
 }
 
-func TestNewWithServiceURLs_AllowsMissingCRMURL(t *testing.T) {
+func TestNewWithServiceURLs_RequiresCRMURL(t *testing.T) {
+	t.Setenv("MIDAZ_CRM_URL", "")
+
+	entity, err := NewWithServiceURLs(map[string]string{
+		"onboarding":  "https://api.example.com/onboarding",
+		"transaction": "https://api.example.com/transaction",
+	})
+
+	require.ErrorContains(t, err, "missing crm URL")
+	require.Nil(t, entity)
+}
+
+func TestNewWithServiceURLs_UsesCRMURLFromEnvironment(t *testing.T) {
+	t.Setenv("MIDAZ_CRM_URL", "https://api.example.com/crm")
+
 	entity, err := NewWithServiceURLs(map[string]string{
 		"onboarding":  "https://api.example.com/onboarding",
 		"transaction": "https://api.example.com/transaction",
@@ -20,5 +34,5 @@ func TestNewWithServiceURLs_AllowsMissingCRMURL(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, entity)
-	require.NotContains(t, entity.baseURLs, "crm")
+	require.Equal(t, "https://api.example.com/crm", entity.baseURLs["crm"])
 }

--- a/entities/entity_test.go
+++ b/entities/entity_test.go
@@ -12,20 +12,8 @@ func TestMainFunction(_ *testing.T) {
 	// so that the testing package will execute all test files in the package.
 }
 
-func TestNewWithServiceURLs_RequiresCRMURL(t *testing.T) {
+func TestNewWithServiceURLs_FallsBackToOnboardingURLForCRM(t *testing.T) {
 	t.Setenv("MIDAZ_CRM_URL", "")
-
-	entity, err := NewWithServiceURLs(map[string]string{
-		"onboarding":  "https://api.example.com/onboarding",
-		"transaction": "https://api.example.com/transaction",
-	})
-
-	require.ErrorContains(t, err, "missing crm URL")
-	require.Nil(t, entity)
-}
-
-func TestNewWithServiceURLs_UsesCRMURLFromEnvironment(t *testing.T) {
-	t.Setenv("MIDAZ_CRM_URL", "https://api.example.com/crm")
 
 	entity, err := NewWithServiceURLs(map[string]string{
 		"onboarding":  "https://api.example.com/onboarding",
@@ -34,5 +22,16 @@ func TestNewWithServiceURLs_UsesCRMURLFromEnvironment(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, entity)
-	require.Equal(t, "https://api.example.com/crm", entity.baseURLs["crm"])
+	require.Equal(t, "https://api.example.com/onboarding", entity.baseURLs["crm"])
+}
+
+func TestNormalizeBaseURLs_UsesCRMURLFromEnvironmentWhenOnboardingMissing(t *testing.T) {
+	t.Setenv("MIDAZ_CRM_URL", "https://api.example.com/crm")
+
+	baseURLs, err := normalizeBaseURLs(map[string]string{
+		"transaction": "https://api.example.com/transaction",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "https://api.example.com/crm", baseURLs["crm"])
 }

--- a/entities/entity_test.go
+++ b/entities/entity_test.go
@@ -20,5 +20,5 @@ func TestNewWithServiceURLs_AllowsMissingCRMURL(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, entity)
-	require.Equal(t, "https://api.example.com/onboarding", entity.baseURLs["crm"])
+	require.NotContains(t, entity.baseURLs, "crm")
 }

--- a/entities/entity_test.go
+++ b/entities/entity_test.go
@@ -2,10 +2,23 @@ package entities
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestMainFunction serves as an entry point for all tests in the entities package
 func TestMainFunction(_ *testing.T) {
 	// This is an empty test function that ensures the package has at least one test
 	// so that the testing package will execute all test files in the package.
+}
+
+func TestNewWithServiceURLs_AllowsMissingCRMURL(t *testing.T) {
+	entity, err := NewWithServiceURLs(map[string]string{
+		"onboarding":  "https://api.example.com/onboarding",
+		"transaction": "https://api.example.com/transaction",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, entity)
+	require.Equal(t, "https://api.example.com/onboarding", entity.baseURLs["crm"])
 }

--- a/entities/holders.go
+++ b/entities/holders.go
@@ -1,0 +1,177 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+)
+
+// HoldersService defines CRM holder operations.
+type HoldersService interface {
+	// ListHolders retrieves holders for an organization.
+	ListHolders(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Holder], error)
+	// CreateHolder creates a holder.
+	CreateHolder(ctx context.Context, organizationID string, input *models.CreateHolderInput) (*models.Holder, error)
+	// GetHolder retrieves a holder by ID.
+	GetHolder(ctx context.Context, organizationID, holderID string, includeDeleted bool) (*models.Holder, error)
+	// UpdateHolder updates a holder by ID.
+	UpdateHolder(ctx context.Context, organizationID, holderID string, input *models.UpdateHolderInput) (*models.Holder, error)
+	// DeleteHolder deletes a holder by ID.
+	DeleteHolder(ctx context.Context, organizationID, holderID string, hardDelete bool) error
+}
+
+type holdersEntity struct {
+	httpClient *HTTPClient
+	baseURLs   map[string]string
+}
+
+func (e *holdersEntity) setDefaultTenantID(tenantID string) {
+	e.httpClient.SetTenantID(tenantID)
+}
+
+// NewHoldersEntity creates a new HoldersService instance.
+func NewHoldersEntity(client *http.Client, authToken string, baseURLs map[string]string) HoldersService {
+	httpClient := NewHTTPClient(client, authToken, nil)
+	if debugEnv := os.Getenv(EnvMidazDebug); debugEnv == BoolTrue {
+		httpClient.debug = true
+	}
+
+	return &holdersEntity{httpClient: httpClient, baseURLs: baseURLs}
+}
+
+// ListHolders retrieves holders for an organization.
+func (e *holdersEntity) ListHolders(ctx context.Context, organizationID string, opts *models.ListOptions) (*models.ListResponse[models.Holder], error) {
+	const operation = "ListHolders"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.buildURL(""), nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	if opts != nil {
+		q := req.URL.Query()
+		for key, value := range opts.ToQueryParams() {
+			q.Add(key, value)
+		}
+
+		req.URL.RawQuery = q.Encode()
+	}
+
+	var response models.ListResponse[models.Holder]
+	if err := e.httpClient.doRequest(ctx, http.MethodGet, req.URL.String(), crmHeaders(organizationID), nil, &response); err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// CreateHolder creates a holder.
+func (e *holdersEntity) CreateHolder(ctx context.Context, organizationID string, input *models.CreateHolderInput) (*models.Holder, error) {
+	const operation = "CreateHolder"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.NewValidationError(operation, "holder validation failed", err)
+	}
+
+	var holder models.Holder
+	if err := e.httpClient.doRequest(ctx, http.MethodPost, e.buildURL(""), crmHeaders(organizationID), input, &holder); err != nil {
+		return nil, err
+	}
+
+	return &holder, nil
+}
+
+// GetHolder retrieves a holder by ID.
+func (e *holdersEntity) GetHolder(ctx context.Context, organizationID, holderID string, includeDeleted bool) (*models.Holder, error) {
+	const operation = "GetHolder"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return nil, errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	endpoint := e.buildURL(holderID)
+	if includeDeleted {
+		endpoint += "?include_deleted=true"
+	}
+
+	var holder models.Holder
+	if err := e.httpClient.doRequest(ctx, http.MethodGet, endpoint, crmHeaders(organizationID), nil, &holder); err != nil {
+		return nil, err
+	}
+
+	return &holder, nil
+}
+
+// UpdateHolder updates a holder by ID.
+func (e *holdersEntity) UpdateHolder(ctx context.Context, organizationID, holderID string, input *models.UpdateHolderInput) (*models.Holder, error) {
+	const operation = "UpdateHolder"
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return nil, errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.NewValidationError(operation, "holder validation failed", err)
+	}
+
+	endpoint := e.buildURL(holderID)
+
+	var holder models.Holder
+	if err := e.httpClient.doRequest(ctx, http.MethodPatch, endpoint, crmHeaders(organizationID), input, &holder); err != nil {
+		return nil, err
+	}
+
+	return &holder, nil
+}
+
+// DeleteHolder deletes a holder by ID.
+func (e *holdersEntity) DeleteHolder(ctx context.Context, organizationID, holderID string, hardDelete bool) error {
+	const operation = "DeleteHolder"
+	if organizationID == "" {
+		return errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if holderID == "" {
+		return errors.NewMissingParameterError(operation, "holderID")
+	}
+
+	endpoint := e.buildURL(holderID)
+	if hardDelete {
+		endpoint += "?hard_delete=true"
+	}
+
+	return e.httpClient.doRequest(ctx, http.MethodDelete, endpoint, crmHeaders(organizationID), nil, nil)
+}
+
+func (e *holdersEntity) buildURL(holderID string) string {
+	baseURL := e.baseURLs["crm"]
+	if holderID == "" {
+		return fmt.Sprintf("%s/holders", baseURL)
+	}
+
+	return fmt.Sprintf("%s/holders/%s", baseURL, pathSegment(holderID))
+}

--- a/entities/holders_test.go
+++ b/entities/holders_test.go
@@ -1,0 +1,132 @@
+package entities
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHoldersEntity_CreateHolder_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/holders", r.URL.Path)
+		assert.Equal(t, "org-123", r.Header.Get("X-Organization-Id"))
+		assert.Equal(t, "Bearer token", r.Header.Get("Authorization"))
+
+		var body models.CreateHolderInput
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "Jane Doe", body.Name)
+		assert.Equal(t, "12345678900", body.Document)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"id":"550e8400-e29b-41d4-a716-446655440000","name":"Jane Doe"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewHoldersEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*holdersEntity)
+	holderType := "NATURAL_PERSON"
+	holder, err := service.CreateHolder(context.Background(), "org-123", &models.CreateHolderInput{Type: &holderType, Name: "Jane Doe", Document: "12345678900"})
+
+	require.NoError(t, err)
+	require.NotNil(t, holder)
+	assert.NotNil(t, holder.ID)
+	assert.Equal(t, "Jane Doe", *holder.Name)
+}
+
+func TestHoldersEntity_UpdateHolder_OmitsNilFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/holders/holder-123", r.URL.Path)
+
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "Jane Updated", body["name"])
+		assert.NotContains(t, body, "externalId")
+		assert.NotContains(t, body, "addresses")
+		assert.NotContains(t, body, "contact")
+		assert.NotContains(t, body, "metadata")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"id":"550e8400-e29b-41d4-a716-446655440000","name":"Jane Updated"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	name := "Jane Updated"
+	service := NewHoldersEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*holdersEntity)
+	holder, err := service.UpdateHolder(context.Background(), "org-123", "holder-123", &models.UpdateHolderInput{Name: &name})
+
+	require.NoError(t, err)
+	require.NotNil(t, holder)
+	assert.Equal(t, "Jane Updated", *holder.Name)
+}
+
+func TestHoldersEntity_ValidationErrors(t *testing.T) {
+	service := NewHoldersEntity(http.DefaultClient, "token", map[string]string{"crm": "https://crm.example.com/v1"}).(*holdersEntity)
+
+	_, err := service.CreateHolder(context.Background(), "org-123", &models.CreateHolderInput{Name: "Jane", Document: "123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "type is required")
+
+	_, err = service.UpdateHolder(context.Background(), "org-123", "holder-123", &models.UpdateHolderInput{Metadata: map[string]any{"": "bad"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid metadata")
+}
+
+func TestHoldersEntity_URLFlagsAndEscaping(t *testing.T) {
+	entity := &holdersEntity{baseURLs: map[string]string{"crm": "https://crm.example.com/v1"}}
+
+	assert.Equal(t, "https://crm.example.com/v1/holders/a%2Fb", entity.buildURL("a/b"))
+}
+
+func TestHoldersEntity_ListGetDelete_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "org-123", r.Header.Get("X-Organization-Id"))
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/holders":
+			assert.Equal(t, "external-123", r.URL.Query().Get("external_id"))
+
+			_, err := w.Write([]byte(`{"items":[{"id":"550e8400-e29b-41d4-a716-446655440000","name":"Jane Doe"}],"limit":10,"page":1}`))
+			assert.NoError(t, err)
+		case r.Method == http.MethodGet && r.URL.Path == "/holders/holder-123":
+			assert.Equal(t, "true", r.URL.Query().Get("include_deleted"))
+
+			_, err := w.Write([]byte(`{"id":"550e8400-e29b-41d4-a716-446655440000","name":"Jane Doe"}`))
+			assert.NoError(t, err)
+		case r.Method == http.MethodDelete && r.URL.Path == "/holders/holder-123":
+			assert.Equal(t, "true", r.URL.Query().Get("hard_delete"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	service := NewHoldersEntity(server.Client(), "token", map[string]string{"crm": server.URL}).(*holdersEntity)
+	list, err := service.ListHolders(context.Background(), "org-123", models.NewListOptions().WithExternalID("external-123"))
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+
+	holder, err := service.GetHolder(context.Background(), "org-123", "holder-123", true)
+	require.NoError(t, err)
+	assert.Equal(t, "Jane Doe", *holder.Name)
+
+	require.NoError(t, service.DeleteHolder(context.Background(), "org-123", "holder-123", true))
+}

--- a/entities/http.go
+++ b/entities/http.go
@@ -23,7 +23,13 @@ import (
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/security"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/version"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/propagation"
+)
+
+var (
+	errEmptyResponseBody = errors.New("empty response body")
+	errNullResponseBody  = errors.New("null response body")
 )
 
 // getUserAgent retrieves the user agent string from environment variable or uses default
@@ -45,15 +51,17 @@ func getUserAgent() string {
 // - Optimized performance with connection pooling and JSON handling
 // - Observability with tracing, metrics, and logging
 type HTTPClient struct {
-	client        *http.Client
-	authToken     string
-	userAgent     string
-	tenantID      string
-	debug         bool
-	retryOptions  *retry.Options        // Retry options for the client
-	jsonPool      *performance.JSONPool // Pool for JSON encoding/decoding
-	metrics       *observability.MetricsCollector
-	observability observability.Provider
+	client            *http.Client
+	authToken         string
+	userAgent         string
+	tenantID          string
+	debug             bool
+	retryOptions      *retry.Options        // Retry options for the client
+	jsonPool          *performance.JSONPool // Pool for JSON encoding/decoding
+	metrics           *observability.MetricsCollector
+	observability     observability.Provider
+	enableIdempotency bool
+	customRetryPolicy func(*http.Response, error) bool
 }
 
 // NewHTTPClient creates a new HTTP client with the provided configuration.
@@ -76,14 +84,15 @@ func NewHTTPClient(client *http.Client, authToken string, provider observability
 	}
 
 	return &HTTPClient{
-		client:        client,
-		authToken:     authToken,
-		userAgent:     getUserAgent(),
-		debug:         debug,
-		retryOptions:  retryOptions,
-		jsonPool:      performance.NewJSONPool(),
-		metrics:       metrics,
-		observability: provider,
+		client:            client,
+		authToken:         authToken,
+		userAgent:         getUserAgent(),
+		debug:             debug,
+		retryOptions:      retryOptions,
+		jsonPool:          performance.NewJSONPool(),
+		metrics:           metrics,
+		observability:     provider,
+		enableIdempotency: os.Getenv("MIDAZ_IDEMPOTENCY") != "false",
 	}
 }
 
@@ -134,7 +143,7 @@ func logRetryError(provider observability.Provider, format string, args ...any) 
 // WithRetryOptions sets custom retry options for the HTTP client.
 func (c *HTTPClient) WithRetryOptions(options ...retry.Option) *HTTPClient {
 	// Create a new options struct with defaults
-	retryOpts := &retry.Options{}
+	retryOpts := retry.DefaultOptions()
 
 	// Apply all options
 	for _, opt := range options {
@@ -151,12 +160,42 @@ func (c *HTTPClient) WithRetryOptions(options ...retry.Option) *HTTPClient {
 
 // WithRetryOption applies a retry option to the HTTP client.
 func (c *HTTPClient) WithRetryOption(option retry.Option) *HTTPClient {
+	if c.retryOptions == nil {
+		c.retryOptions = retry.DefaultOptions()
+	}
+
 	if err := option(c.retryOptions); err != nil {
 		// Log the error but continue with existing options
 		c.debugLog("Error applying retry option: %v", err)
 	}
 
 	return c
+}
+
+// SetEnableIdempotency enables or disables automatic idempotency header generation.
+func (c *HTTPClient) SetEnableIdempotency(enabled bool) {
+	c.enableIdempotency = enabled
+}
+
+// SetCustomRetryPolicy sets the predicate used to decide whether retries should continue.
+func (c *HTTPClient) SetCustomRetryPolicy(shouldRetry func(*http.Response, error) bool) {
+	c.customRetryPolicy = shouldRetry
+}
+
+func (c *HTTPClient) applyConfigurationFrom(source *HTTPClient) {
+	if source == nil {
+		return
+	}
+
+	c.authToken = source.authToken
+	c.userAgent = source.userAgent
+	c.tenantID = source.tenantID
+	c.debug = source.debug
+	c.observability = source.observability
+	c.metrics = source.metrics
+	c.enableIdempotency = source.enableIdempotency
+	c.customRetryPolicy = source.customRetryPolicy
+	c.retryOptions = cloneRetryOptions(source.retryOptions)
 }
 
 // WithUserAgent sets a custom user agent string for the HTTP client.
@@ -174,6 +213,8 @@ func (c *HTTPClient) WithDebug(debug bool) *HTTPClient {
 // SetTenantID sets the default tenant ID for all requests made by this HTTP client.
 // When a request is made, the tenant ID from the request context takes precedence
 // over this client-level default. If neither is set, no X-Tenant-ID header is sent.
+// This header is best-effort compatibility metadata and is not the sole tenant
+// authority for the reference Midaz path.
 //
 // SetTenantID is not safe for concurrent use with active requests. It should be
 // called during client setup, before any concurrent API calls are made. This is
@@ -246,6 +287,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, requestURL string, h
 
 	// Inject context-based headers (idempotency key, tenant ID)
 	headers = c.injectContextHeaders(ctx, headers)
+	headers = c.ensureIdempotencyHeader(method, headers)
 
 	// Setup headers
 	c.setupRequestHeaders(req, headers, body != nil)
@@ -299,7 +341,17 @@ func (c *HTTPClient) doRawRequest(ctx context.Context, method, requestURL string
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, requestURL, reader)
+	parsedURL, err := url.Parse(requestURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse request URL: %w", err)
+	}
+
+	validationReq := &http.Request{URL: parsedURL}
+	if err := security.ValidateOutboundRequest(validationReq); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, parsedURL.String(), reader) // #nosec G704 -- request URL validated via security.ValidateOutboundRequest using parsed URL
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -313,6 +365,7 @@ func (c *HTTPClient) doRawRequest(ctx context.Context, method, requestURL string
 
 	// Inject context-based headers (idempotency key, tenant ID)
 	headers = c.injectContextHeaders(ctx, headers)
+	headers = c.ensureIdempotencyHeader(method, headers)
 
 	c.setupRequestHeaders(req, headers, len(body) > 0)
 
@@ -342,20 +395,75 @@ func (c *HTTPClient) doRawRequest(ctx context.Context, method, requestURL string
 	return c.processResponse(result, responseBody)
 }
 
+func (c *HTTPClient) doCountRequest(ctx context.Context, method, requestURL string, headers map[string]string) (int, error) {
+	ctx, endSpan := c.setupObservabilityContext(ctx, method, requestURL)
+	defer endSpan()
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	headers = c.injectContextHeaders(ctx, headers)
+	c.setupRequestHeaders(req, headers, false)
+
+	if c.observability != nil && c.observability.IsEnabled() {
+		propagator := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+		propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+	}
+
+	start := time.Now()
+	resp, responseBody, err := c.executeRequestWithRetry(ctx, req, method, requestURL)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			c.closeResponseBody(resp)
+		}
+	}()
+
+	c.recordRequestMetrics(ctx, method, requestURL, resp, elapsed)
+	c.logResponseDetails(method, requestURL, resp, responseBody)
+
+	totalCount := strings.TrimSpace(resp.Header.Get(HeaderTotalCount))
+	if totalCount == "" {
+		return 0, sdkerrors.NewInternalError("CountRequest", fmt.Errorf("missing %s header", HeaderTotalCount))
+	}
+
+	count, err := strconv.Atoi(totalCount)
+	if err != nil {
+		return 0, sdkerrors.NewInternalError("CountRequest", fmt.Errorf("invalid %s header: %w", HeaderTotalCount, err))
+	}
+
+	return count, nil
+}
+
+func countRequestMethod() string {
+	return http.MethodHead
+}
+
+func countRequestHeaders() map[string]string {
+	return nil
+}
+
 // setupObservabilityContext creates tracing span if observability is enabled
 func (c *HTTPClient) setupObservabilityContext(ctx context.Context, method, requestURL string) (context.Context, func()) {
 	if c.observability == nil || !c.observability.IsEnabled() {
 		return ctx, func() {}
 	}
 
-	spanCtx, span := c.observability.Tracer().Start(ctx, fmt.Sprintf("HTTP %s %s", method, requestURL))
+	spanCtx, span := c.observability.Tracer().Start(ctx, fmt.Sprintf("HTTP %s %s", method, normalizeTelemetryURL(requestURL)))
 
 	return spanCtx, func() { span.End() }
 }
 
 // buildHTTPRequest creates the HTTP request with body handling
 func (c *HTTPClient) buildHTTPRequest(ctx context.Context, method, requestURL string, body any) (*http.Request, []byte, error) {
-	c.debugLog("Request URL: %s %s", method, requestURL)
+	c.debugLog("Request URL: %s %s", method, redactDebugURL(requestURL))
 
 	parsedURL, err := url.Parse(requestURL)
 	if err != nil {
@@ -407,7 +515,7 @@ func (c *HTTPClient) prepareRequestBody(body any) (io.Reader, []byte, error) {
 // debugLogRequestBody logs request body if debug mode is enabled
 func (c *HTTPClient) debugLogRequestBody(bodyBytes []byte) {
 	if c.debug {
-		c.debugLog("Request body: %s", string(bodyBytes))
+		c.debugLog("Request body: %s", redactDebugBody(bodyBytes))
 	}
 }
 
@@ -429,61 +537,125 @@ func (c *HTTPClient) setupRequestHeaders(req *http.Request, headers map[string]s
 
 	// Authorization header
 	if c.authToken != "" {
-		req.Header.Set("Authorization", c.authToken)
+		req.Header.Set("Authorization", formatAuthorizationHeader(c.authToken))
 	}
 }
 
 // executeRequestWithRetry handles the request execution with retry logic
 func (c *HTTPClient) executeRequestWithRetry(ctx context.Context, req *http.Request, method, requestURL string) (*http.Response, []byte, error) {
-	var resp *http.Response
+	effectiveRetryOptions := cloneRetryOptions(c.retryOptions)
+	if effectiveRetryOptions == nil {
+		effectiveRetryOptions = retry.DefaultOptions()
+	}
 
-	var responseBody []byte
+	if isUnsafeMethod(req.Method) && req.Header.Get("X-Idempotency") == "" {
+		effectiveRetryOptions.MaxRetries = 0
+	}
 
-	retryCtx := retry.WithOptionsContext(ctx, c.retryOptions)
+	retryCtx := retry.WithOptionsContext(ctx, effectiveRetryOptions)
+	execution := &retryExecution{}
 
 	err := retry.DoWithContext(retryCtx, func() error {
-		var err error
-
-		// Reset request body for retry if GetBody is available
-		if req.GetBody != nil {
-			req.Body, err = req.GetBody()
-			if err != nil {
-				return fmt.Errorf("failed to reset request body for retry: %w", err)
-			}
-		}
-
-		if err := security.ValidateOutboundRequest(req); err != nil {
-			return fmt.Errorf("invalid request URL: %w", err)
-		}
-
-		resp, err = c.client.Do(req) // #nosec G704 -- request URL validated via security.ValidateOutboundRequest
-		if err != nil {
-			c.debugLogRequestError(method, requestURL, err)
-			return fmt.Errorf("HTTP request failed: %w", err)
-		}
-
-		// Ensure response body is always closed, even on error paths
-		defer func() {
-			if resp != nil && resp.Body != nil {
-				c.closeResponseBody(resp)
-			}
-		}()
-
-		responseBody, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response body: %w", err)
-		}
-
-		if resp.StatusCode >= 400 {
-			// Extract request ID from response headers for error context
-			requestID := resp.Header.Get("X-Request-ID")
-			return c.handleErrorResponse(resp.StatusCode, responseBody, method, requestURL, requestID)
-		}
-
-		return nil
+		return c.executeRetryAttempt(req, method, requestURL, execution)
 	})
 
-	return resp, responseBody, err
+	return execution.resp, execution.responseBody, err
+}
+
+type retryExecution struct {
+	resp         *http.Response
+	responseBody []byte
+}
+
+func (c *HTTPClient) executeRetryAttempt(req *http.Request, method, requestURL string, execution *retryExecution) error {
+	if err := resetRequestBody(req); err != nil {
+		return err
+	}
+
+	if err := security.ValidateOutboundRequest(req); err != nil {
+		return fmt.Errorf("invalid request URL: %w", err)
+	}
+
+	resp, err := c.client.Do(req) // #nosec G704 -- request URL validated via security.ValidateOutboundRequest
+	if err != nil {
+		return c.handleRequestExecutionError(method, requestURL, err)
+	}
+
+	execution.resp = resp
+
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			c.closeResponseBody(resp)
+		}
+	}()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	execution.responseBody = responseBody
+
+	return c.handleRetryAttemptResponse(resp, responseBody, method, requestURL)
+}
+
+func resetRequestBody(req *http.Request) error {
+	if req.GetBody == nil {
+		return nil
+	}
+
+	body, err := req.GetBody()
+	if err != nil {
+		return fmt.Errorf("failed to reset request body for retry: %w", err)
+	}
+
+	req.Body = body
+
+	return nil
+}
+
+func (c *HTTPClient) handleRequestExecutionError(method, requestURL string, err error) error {
+	c.debugLogRequestError(method, requestURL, err)
+
+	requestErr := fmt.Errorf("HTTP request failed: %w", err)
+	if c.customRetryPolicy != nil && !c.customRetryPolicy(nil, requestErr) {
+		return retry.AsNonRetryable(requestErr)
+	}
+
+	return requestErr
+}
+
+func (c *HTTPClient) handleRetryAttemptResponse(resp *http.Response, responseBody []byte, method, requestURL string) error {
+	if resp.StatusCode < 400 {
+		return nil
+	}
+
+	requestID := resp.Header.Get("X-Request-ID")
+
+	apiErr := c.handleErrorResponse(resp.StatusCode, responseBody, method, requestURL, requestID)
+	if c.customRetryPolicy != nil && !c.customRetryPolicy(resp, apiErr) {
+		return retry.AsNonRetryable(apiErr)
+	}
+
+	return retryableHTTPError{err: apiErr, statusCode: resp.StatusCode}
+}
+
+type retryableHTTPError struct {
+	err        error
+	statusCode int
+}
+
+func (e retryableHTTPError) Error() string {
+	return e.err.Error()
+}
+
+func (e retryableHTTPError) Unwrap() error {
+	return e.err
+}
+
+// StatusCode returns the HTTP status code that made the error retryable.
+func (e retryableHTTPError) StatusCode() int {
+	return e.statusCode
 }
 
 // closeResponseBody safely closes response body with debug logging
@@ -505,7 +677,7 @@ func (c *HTTPClient) handleErrorResponse(statusCode int, responseBody []byte, me
 			c.debugLog("Request ID: %s", requestID)
 		}
 
-		c.debugLog("Error body: %s", string(responseBody))
+		c.debugLog("Error body: %s", redactDebugBody(responseBody))
 		c.debugLog("Parsed error: %v", apiErr)
 	}
 
@@ -515,14 +687,14 @@ func (c *HTTPClient) handleErrorResponse(statusCode int, responseBody []byte, me
 // debugLogRequestError logs request failures in debug mode
 func (c *HTTPClient) debugLogRequestError(method, requestURL string, err error) {
 	if c.debug {
-		c.debugLog("HTTP request failed: %s %s - %v", method, requestURL, err)
+		c.debugLog("HTTP request failed: %s %s - %v", method, redactDebugURL(requestURL), err)
 	}
 }
 
 // recordRequestMetrics records performance metrics if enabled
 func (c *HTTPClient) recordRequestMetrics(ctx context.Context, method, requestURL string, resp *http.Response, elapsed time.Duration) {
 	if c.metrics != nil {
-		c.metrics.RecordRequest(ctx, method, requestURL, resp.StatusCode, elapsed)
+		c.metrics.RecordRequest(ctx, method, normalizeTelemetryURL(requestURL), resp.StatusCode, elapsed)
 	}
 }
 
@@ -532,16 +704,24 @@ func (c *HTTPClient) logResponseDetails(method, requestURL string, resp *http.Re
 		return
 	}
 
-	c.debugLog("Response from: %s %s", method, requestURL)
+	c.debugLog("Response from: %s %s", method, redactDebugURL(requestURL))
 	c.debugLog("Response status: %d", resp.StatusCode)
-	c.debugLog("Response headers: %v", resp.Header)
-	c.debugLog("Response body: %s", string(responseBody))
+	c.debugLog("Response headers: %v", redactHeaders(resp.Header))
+	c.debugLog("Response body: %s", redactDebugBody(responseBody))
 }
 
 // processResponse handles JSON unmarshaling of the response
 func (c *HTTPClient) processResponse(result any, responseBody []byte) error {
-	if result == nil || len(responseBody) == 0 {
+	if result == nil {
 		return nil
+	}
+
+	if len(responseBody) == 0 {
+		return errEmptyResponseBody
+	}
+
+	if bytes.Equal(bytes.TrimSpace(responseBody), []byte("null")) {
+		return errNullResponseBody
 	}
 
 	if err := c.jsonPool.Unmarshal(responseBody, result); err != nil {
@@ -566,23 +746,96 @@ func (c *HTTPClient) sendRequest(req *http.Request, v any) error {
 		}
 	}
 
-	// Extract body from the request
+	// Extract the raw body from the request so we can preserve the original payload
+	// without forcing a JSON decode/re-encode cycle.
 	body, err := c.extractRequestBody(req)
 	if err != nil {
 		return err
 	}
 
+	if len(body) > 0 && strings.TrimSpace(headers["Content-Type"]) == "" {
+		headers["Content-Type"] = "application/json"
+	}
+
 	// Use the context from the request
 	ctx := req.Context()
 
-	// Call the new doRequest method
-	return c.doRequest(ctx, method, requestURL, headers, body, v)
+	// Reuse the raw-request path to preserve the original body bytes.
+	return c.doRawRequest(ctx, method, requestURL, headers, body, v)
 }
 
-// extractRequestBody reads and parses the request body.
-func (c *HTTPClient) extractRequestBody(req *http.Request) (any, error) {
+func cloneRetryOptions(options *retry.Options) *retry.Options {
+	if options == nil {
+		return nil
+	}
+
+	cloned := *options
+
+	return &cloned
+}
+
+func formatAuthorizationHeader(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return token
+	}
+
+	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
+		return token
+	}
+
+	return "Bearer " + token
+}
+
+func isUnsafeMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *HTTPClient) ensureIdempotencyHeader(method string, headers map[string]string) map[string]string {
+	defer func() {
+		if headers != nil {
+			delete(headers, "X-Midaz-Auto-Idempotency")
+		}
+	}()
+
+	if !c.enableIdempotency || !isUnsafeMethod(method) {
+		return headers
+	}
+
+	if headers != nil && strings.TrimSpace(headers["X-Idempotency"]) != "" {
+		return headers
+	}
+
+	if !supportsAutomaticIdempotency(headers) {
+		return headers
+	}
+
+	if headers == nil {
+		headers = map[string]string{}
+	}
+
+	headers["X-Idempotency"] = uuid.NewString()
+
+	return headers
+}
+
+func supportsAutomaticIdempotency(headers map[string]string) bool {
+	if headers == nil {
+		return false
+	}
+
+	return headers["X-Midaz-Auto-Idempotency"] == "true"
+}
+
+// extractRequestBody reads and returns the raw request body bytes.
+func (c *HTTPClient) extractRequestBody(req *http.Request) ([]byte, error) {
 	if req.Body == nil {
-		return nil, nil //nolint:nilnil // nil body with no error is valid
+		return nil, nil
 	}
 
 	bodyBytes, err := io.ReadAll(req.Body)
@@ -595,15 +848,10 @@ func (c *HTTPClient) extractRequestBody(req *http.Request) (any, error) {
 	}
 
 	if len(bodyBytes) == 0 {
-		return nil, nil //nolint:nilnil // empty body with no error is valid
+		return nil, nil
 	}
 
-	var body any
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		return nil, err
-	}
-
-	return body, nil
+	return bodyBytes, nil
 }
 
 // sanitizeLogInput removes control characters from strings to prevent log injection attacks.
@@ -620,6 +868,115 @@ func sanitizeLogInput(input string) string {
 	}
 
 	return input
+}
+
+func redactHeaders(headers http.Header) map[string][]string {
+	redacted := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		switch strings.ToLower(key) {
+		case "authorization", "cookie", "set-cookie", "x-idempotency", strings.ToLower(HeaderTenantID):
+			redacted[key] = []string{"[REDACTED]"}
+		default:
+			copied := make([]string, len(values))
+			copy(copied, values)
+			redacted[key] = copied
+		}
+	}
+
+	return redacted
+}
+
+func redactDebugBody(body []byte) string {
+	if len(body) == 0 {
+		return "[empty]"
+	}
+
+	return fmt.Sprintf("[REDACTED len=%d]", len(body))
+}
+
+func normalizeTelemetryURL(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+
+	segments := strings.Split(parsedURL.Path, "/")
+	for i, segment := range segments {
+		if segment == "" {
+			continue
+		}
+
+		if isLikelyTelemetryIdentifier(segment) {
+			segments[i] = ":id"
+		}
+	}
+
+	parsedURL.Path = strings.Join(segments, "/")
+
+	return parsedURL.String()
+}
+
+func redactDebugURL(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	query := parsedURL.Query()
+	for key := range query {
+		if isSensitiveQueryKey(key) {
+			query.Set(key, "[REDACTED]")
+		}
+	}
+
+	parsedURL.RawQuery = query.Encode()
+	parsedURL.Fragment = ""
+
+	return parsedURL.String()
+}
+
+func isSensitiveQueryKey(key string) bool {
+	normalized := strings.ToLower(key)
+	if strings.Contains(normalized, "document") || strings.Contains(normalized, "metadata") {
+		return true
+	}
+
+	switch normalized {
+	case "banking_details_account", "banking_details_iban", "external_id":
+		return true
+	default:
+		return false
+	}
+}
+
+func isLikelyTelemetryIdentifier(segment string) bool {
+	if len(segment) == 36 && strings.Count(segment, "-") == 4 {
+		return true
+	}
+
+	allDigits := true
+	hasDigit := false
+
+	for _, r := range segment {
+		if r < '0' || r > '9' {
+			allDigits = false
+		} else {
+			hasDigit = true
+		}
+	}
+
+	if allDigits && len(segment) > 3 {
+		return true
+	}
+
+	if len(segment) >= 16 && hasDigit {
+		return true
+	}
+
+	return false
 }
 
 // sanitizeLogArgs sanitizes all string arguments to prevent log injection.
@@ -682,8 +1039,8 @@ func (*HTTPClient) parseErrorResponse(statusCode int, body []byte, requestID str
 	}
 
 	if err := json.Unmarshal(body, &apiError); err != nil {
-		// If we can't parse the JSON, return the raw body as the error message
-		return sdkerrors.ErrorFromHTTPResponse(statusCode, requestID, string(body), "", "", "")
+		message := fmt.Sprintf("API returned non-JSON error response with status code %d and body length %d", statusCode, len(body))
+		return sdkerrors.ErrorFromHTTPResponse(statusCode, requestID, message, "", "", "")
 	}
 
 	// Use the message if available, otherwise use the error field
@@ -759,7 +1116,7 @@ func (c *HTTPClient) NewRequest(method, requestURL string, body any) (*http.Requ
 
 	// Add authorization if there's a token
 	if c.authToken != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+		req.Header.Set("Authorization", formatAuthorizationHeader(c.authToken))
 	}
 
 	return req, nil

--- a/entities/http_idempotency_test.go
+++ b/entities/http_idempotency_test.go
@@ -99,7 +99,20 @@ func TestUnsafeMethodRetriesOnlyWithIdempotency(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var calls atomic.Int32
 
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			var generatedKey string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.expectedSuccess {
+					key := r.Header.Get("X-Idempotency")
+					assert.NotEmpty(t, key)
+
+					if generatedKey == "" {
+						generatedKey = key
+					} else {
+						assert.Equal(t, generatedKey, key)
+					}
+				}
+
 				if calls.Add(1) == 1 {
 					w.WriteHeader(http.StatusInternalServerError)
 

--- a/entities/http_idempotency_test.go
+++ b/entities/http_idempotency_test.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIdempotencyHeaderInjection(t *testing.T) {
@@ -13,7 +19,9 @@ func TestIdempotencyHeaderInjection(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seen = r.Header.Get("X-Idempotency")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{}`))
+
+		_, err := w.Write([]byte(`{}`))
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 
@@ -23,11 +31,109 @@ func TestIdempotencyHeaderInjection(t *testing.T) {
 	ctx := WithIdempotencyKey(context.Background(), "abc123")
 
 	var out map[string]any
-	if err := c.doRequest(ctx, http.MethodGet, srv.URL, nil, nil, &out); err != nil {
-		t.Fatalf("doRequest failed: %v", err)
+
+	err := c.doRequest(ctx, http.MethodGet, srv.URL, nil, nil, &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "abc123", seen)
+}
+
+func TestRedactDebugURLMasksSensitiveQueryValues(t *testing.T) {
+	redacted := redactDebugURL("https://api.example.com/holders?document=12345678900&external_id=ext-1&limit=10&metadata.email=a@example.com")
+
+	require.NotEmpty(t, redacted)
+
+	for _, leaked := range []string{"12345678900", "ext-1", "a@example.com"} {
+		assert.NotContains(t, redacted, leaked)
 	}
 
-	if seen != "abc123" {
-		t.Fatalf("expected X-Idempotency header 'abc123', got '%s'", seen)
+	assert.Contains(t, redacted, "limit=10")
+}
+
+func TestAutomaticIdempotencyHeaderForUnsafeMethods(t *testing.T) {
+	var seen, autoHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("X-Idempotency")
+		autoHeader = r.Header.Get("X-Midaz-Auto-Idempotency")
+		w.Header().Set("Content-Type", "application/json")
+
+		_, err := w.Write([]byte(`{}`))
+		assert.NoError(t, err)
+	}))
+	defer srv.Close()
+
+	c := NewHTTPClient(srv.Client(), "", nil)
+
+	var out map[string]any
+
+	err := c.doRequest(context.Background(), http.MethodPost, srv.URL, map[string]string{"X-Midaz-Auto-Idempotency": "true"}, map[string]string{"ok": "true"}, &out)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, seen)
+	assert.Empty(t, autoHeader)
+}
+
+func TestUnsafeMethodRetriesOnlyWithIdempotency(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         map[string]string
+		expectedCalls   int32
+		expectedSuccess bool
+	}{
+		{
+			name:            "no idempotency disables retry",
+			headers:         nil,
+			expectedCalls:   1,
+			expectedSuccess: false,
+		},
+		{
+			name:            "generated idempotency allows retry",
+			headers:         map[string]string{"X-Midaz-Auto-Idempotency": "true"},
+			expectedCalls:   2,
+			expectedSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if calls.Add(1) == 1 {
+					w.WriteHeader(http.StatusInternalServerError)
+
+					_, err := w.Write([]byte(`{"error":"temporary"}`))
+					assert.NoError(t, err)
+
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+
+				_, err := w.Write([]byte(`{}`))
+				assert.NoError(t, err)
+			}))
+			defer srv.Close()
+
+			c := NewHTTPClient(srv.Client(), "", nil)
+			c.WithRetryOptions(
+				retry.WithMaxRetries(1),
+				retry.WithInitialDelay(time.Millisecond),
+				retry.WithMaxDelay(time.Millisecond),
+			)
+
+			var out map[string]any
+
+			err := c.doRequest(context.Background(), http.MethodPost, srv.URL, tt.headers, map[string]string{"ok": "true"}, &out)
+
+			if tt.expectedSuccess {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			assert.Equal(t, tt.expectedCalls, calls.Load())
+		})
 	}
 }

--- a/entities/http_idempotency_test.go
+++ b/entities/http_idempotency_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/retry"
 )
 
 func TestIdempotencyHeaderInjection(t *testing.T) {
@@ -42,12 +44,20 @@ func TestRedactDebugURLMasksSensitiveQueryValues(t *testing.T) {
 	redacted := redactDebugURL("https://api.example.com/holders?document=12345678900&external_id=ext-1&limit=10&metadata.email=a@example.com")
 
 	require.NotEmpty(t, redacted)
+	redactedURL, err := url.Parse(redacted)
+	require.NoError(t, err)
 
-	for _, leaked := range []string{"12345678900", "ext-1", "a@example.com"} {
-		assert.NotContains(t, redacted, leaked)
+	query := redactedURL.Query()
+	for key, original := range map[string]string{
+		"document":       "12345678900",
+		"external_id":    "ext-1",
+		"metadata.email": "a@example.com",
+	} {
+		assert.NotEqual(t, original, query.Get(key))
+		assert.NotEqual(t, url.QueryEscape(original), query.Get(key))
 	}
 
-	assert.Contains(t, redacted, "limit=10")
+	assert.Equal(t, "10", query.Get("limit"))
 }
 
 func TestAutomaticIdempotencyHeaderForUnsafeMethods(t *testing.T) {

--- a/entities/ledgers.go
+++ b/entities/ledgers.go
@@ -103,6 +103,12 @@ type LedgersService interface {
 	// Returns the updated ledger, or an error if the operation fails.
 	UpdateLedger(ctx context.Context, organizationID, id string, input *models.UpdateLedgerInput) (*models.Ledger, error)
 
+	// GetLedgerSettings retrieves the settings for a ledger.
+	GetLedgerSettings(ctx context.Context, organizationID, id string) (*models.LedgerSettings, error)
+
+	// UpdateLedgerSettings partially updates the settings for a ledger.
+	UpdateLedgerSettings(ctx context.Context, organizationID, id string, input *models.UpdateLedgerSettingsInput) (*models.LedgerSettings, error)
+
 	// DeleteLedger deletes a ledger.
 	// The organizationID parameter specifies which organization the ledger belongs to.
 	// The id parameter is the unique identifier of the ledger to delete.
@@ -334,6 +340,69 @@ func (e *ledgersEntity) UpdateLedger(
 	return &ledger, nil
 }
 
+// GetLedgerSettings retrieves the settings for a ledger.
+func (e *ledgersEntity) GetLedgerSettings(ctx context.Context, organizationID, id string) (*models.LedgerSettings, error) {
+	const operation = "GetLedgerSettings"
+
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if id == "" {
+		return nil, errors.NewMissingParameterError(operation, "id")
+	}
+
+	url := e.buildSettingsURL(organizationID, id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	var settings models.LedgerSettings
+	if err := e.httpClient.sendRequest(req, &settings); err != nil {
+		return nil, err
+	}
+
+	return &settings, nil
+}
+
+// UpdateLedgerSettings partially updates the settings for a ledger.
+func (e *ledgersEntity) UpdateLedgerSettings(ctx context.Context, organizationID, id string, input *models.UpdateLedgerSettingsInput) (*models.LedgerSettings, error) {
+	const operation = "UpdateLedgerSettings"
+
+	if organizationID == "" {
+		return nil, errors.NewMissingParameterError(operation, "organizationID")
+	}
+
+	if id == "" {
+		return nil, errors.NewMissingParameterError(operation, "id")
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	url := e.buildSettingsURL(organizationID, id)
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	var settings models.LedgerSettings
+	if err := e.httpClient.sendRequest(req, &settings); err != nil {
+		return nil, err
+	}
+
+	return &settings, nil
+}
+
 // DeleteLedger deletes a ledger.
 // The organizationID parameter specifies which organization the ledger belongs to.
 // The id parameter is the unique identifier of the ledger to delete.
@@ -372,17 +441,12 @@ func (e *ledgersEntity) GetLedgersMetricsCount(ctx context.Context, organization
 
 	url := e.buildMetricsURL(organizationID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.httpClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{LedgersCount: count}, nil
 }
 
 // buildURL builds the URL for ledgers API calls.
@@ -390,14 +454,19 @@ func (e *ledgersEntity) buildURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
 
 	if ledgerID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers", baseURL, organizationID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers", baseURL, pathSegment(organizationID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s", baseURL, organizationID, ledgerID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }
 
 // buildMetricsURL builds the URL for ledgers metrics API calls.
 func (e *ledgersEntity) buildMetricsURL(organizationID string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/metrics/count", baseURL, organizationID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/metrics/count", baseURL, pathSegment(organizationID))
+}
+
+func (e *ledgersEntity) buildSettingsURL(organizationID, ledgerID string) string {
+	baseURL := e.baseURLs["onboarding"]
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/settings", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }

--- a/entities/ledgers_test.go
+++ b/entities/ledgers_test.go
@@ -131,6 +131,53 @@ func TestLedgersEntity_Settings_RequestConstruction(t *testing.T) {
 	assert.True(t, settings.Accounting.ValidateAccountType)
 }
 
+func TestLedgersEntity_Settings_Validation(t *testing.T) {
+	service := NewLedgersEntity(http.DefaultClient, "token", map[string]string{"onboarding": "https://api.example.com"})
+
+	tests := []struct {
+		name string
+		call func() (*models.LedgerSettings, error)
+	}{
+		{
+			name: "get missing organizationID",
+			call: func() (*models.LedgerSettings, error) {
+				return service.GetLedgerSettings(context.Background(), "", "ledger-1")
+			},
+		},
+		{
+			name: "get missing id",
+			call: func() (*models.LedgerSettings, error) {
+				return service.GetLedgerSettings(context.Background(), "org-1", "")
+			},
+		},
+		{
+			name: "update missing organizationID",
+			call: func() (*models.LedgerSettings, error) {
+				return service.UpdateLedgerSettings(context.Background(), "", "ledger-1", models.NewUpdateLedgerSettingsInput())
+			},
+		},
+		{
+			name: "update missing id",
+			call: func() (*models.LedgerSettings, error) {
+				return service.UpdateLedgerSettings(context.Background(), "org-1", "", models.NewUpdateLedgerSettingsInput())
+			},
+		},
+		{
+			name: "update missing input",
+			call: func() (*models.LedgerSettings, error) {
+				return service.UpdateLedgerSettings(context.Background(), "org-1", "ledger-1", nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.call()
+			require.Error(t, err)
+		})
+	}
+}
+
 // \1 performs an operation
 func TestGetLedger(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/entities/ledgers_test.go
+++ b/entities/ledgers_test.go
@@ -2,7 +2,10 @@ package entities
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/entities/mocks"
@@ -90,6 +93,42 @@ func TestListLedgers(t *testing.T) {
 	_, err = mockService.ListLedgers(ctx, "", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "organization ID is required")
+}
+
+func TestLedgersEntity_Settings_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodGet:
+			assert.Equal(t, "/organizations/org%2F1/ledgers/ledger%2F1/settings", r.URL.EscapedPath())
+		case http.MethodPatch:
+			assert.Equal(t, "/organizations/org%2F1/ledgers/ledger%2F1/settings", r.URL.EscapedPath())
+
+			var body map[string]any
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+				http.Error(w, "invalid request body", http.StatusBadRequest)
+				return
+			}
+
+			assert.Contains(t, body, "accounting")
+		default:
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+
+		_, err := w.Write([]byte(`{"accounting":{"validateAccountType":true,"validateRoutes":false}}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewLedgersEntity(server.Client(), "token", map[string]string{"onboarding": server.URL})
+	settings, err := service.GetLedgerSettings(context.Background(), "org/1", "ledger/1")
+	require.NoError(t, err)
+	assert.True(t, settings.Accounting.ValidateAccountType)
+
+	settings, err = service.UpdateLedgerSettings(context.Background(), "org/1", "ledger/1", models.NewUpdateLedgerSettingsInput().WithValidateAccountType(true))
+	require.NoError(t, err)
+	assert.True(t, settings.Accounting.ValidateAccountType)
 }
 
 // \1 performs an operation

--- a/entities/metadata_indexes.go
+++ b/entities/metadata_indexes.go
@@ -1,0 +1,135 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
+)
+
+// MetadataIndexesService defines the service for Ledger metadata-index endpoints.
+type MetadataIndexesService interface {
+	// ListMetadataIndexes lists metadata indexes, optionally filtered by entity name.
+	ListMetadataIndexes(ctx context.Context, entityName string) ([]models.MetadataIndex, error)
+	// CreateMetadataIndex creates a metadata index for an entity type.
+	CreateMetadataIndex(ctx context.Context, entityName string, input *models.CreateMetadataIndexInput) (*models.MetadataIndex, error)
+	// DeleteMetadataIndex deletes a metadata index by entity name and metadata key.
+	DeleteMetadataIndex(ctx context.Context, entityName, metadataKey string) error
+}
+
+type metadataIndexesEntity struct {
+	httpClient *HTTPClient
+	baseURLs   map[string]string
+}
+
+func (e *metadataIndexesEntity) setDefaultTenantID(tenantID string) {
+	e.httpClient.SetTenantID(tenantID)
+}
+
+// NewMetadataIndexesEntity creates a new MetadataIndexesService instance.
+func NewMetadataIndexesEntity(client *http.Client, authToken string, baseURLs map[string]string) MetadataIndexesService {
+	httpClient := NewHTTPClient(client, authToken, nil)
+
+	if debugEnv := os.Getenv(EnvMidazDebug); debugEnv == BoolTrue {
+		httpClient.debug = true
+	}
+
+	return &metadataIndexesEntity{
+		httpClient: httpClient,
+		baseURLs:   baseURLs,
+	}
+}
+
+func (e *metadataIndexesEntity) buildBaseURL() string {
+	return fmt.Sprintf("%s/settings/metadata-indexes", e.baseURLs["transaction"])
+}
+
+// ListMetadataIndexes lists metadata indexes, optionally filtered by entity name.
+func (e *metadataIndexesEntity) ListMetadataIndexes(ctx context.Context, entityName string) ([]models.MetadataIndex, error) {
+	const operation = "ListMetadataIndexes"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.buildBaseURL(), nil)
+	if err != nil {
+		return nil, errors.NewInternalError(operation, err)
+	}
+
+	if entityName != "" {
+		if !models.IsValidMetadataIndexEntity(entityName) {
+			return nil, errors.NewValidationError(operation, "invalid entityName", fmt.Errorf("unsupported metadata index entity %q", entityName))
+		}
+
+		q := req.URL.Query()
+		q.Set("entity_name", entityName)
+		req.URL.RawQuery = q.Encode()
+	}
+
+	var result []models.MetadataIndex
+	if err := e.httpClient.sendRequest(req, &result); err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		result = []models.MetadataIndex{}
+	}
+
+	return result, nil
+}
+
+// CreateMetadataIndex creates a metadata index for an entity type.
+func (e *metadataIndexesEntity) CreateMetadataIndex(ctx context.Context, entityName string, input *models.CreateMetadataIndexInput) (*models.MetadataIndex, error) {
+	const operation = "CreateMetadataIndex"
+
+	if entityName == "" {
+		return nil, errors.NewMissingParameterError(operation, "entityName")
+	}
+
+	if !models.IsValidMetadataIndexEntity(entityName) {
+		return nil, errors.NewValidationError(operation, "invalid entityName", fmt.Errorf("unsupported metadata index entity %q", entityName))
+	}
+
+	if input == nil {
+		return nil, errors.NewMissingParameterError(operation, "input")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, errors.NewValidationError(operation, "metadata index validation failed", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/entities/%s", e.buildBaseURL(), pathSegment(entityName))
+
+	var result models.MetadataIndex
+	if err := e.httpClient.doRequest(ctx, http.MethodPost, endpoint, nil, input, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// DeleteMetadataIndex deletes a metadata index by entity name and metadata key.
+func (e *metadataIndexesEntity) DeleteMetadataIndex(ctx context.Context, entityName, metadataKey string) error {
+	const operation = "DeleteMetadataIndex"
+
+	if entityName == "" {
+		return errors.NewMissingParameterError(operation, "entityName")
+	}
+
+	if !models.IsValidMetadataIndexEntity(entityName) {
+		return errors.NewValidationError(operation, "invalid entityName", fmt.Errorf("unsupported metadata index entity %q", entityName))
+	}
+
+	if metadataKey == "" {
+		return errors.NewMissingParameterError(operation, "metadataKey")
+	}
+
+	endpoint := fmt.Sprintf("%s/entities/%s/key/%s", e.buildBaseURL(), pathSegment(entityName), pathSegment(metadataKey))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return errors.NewInternalError(operation, err)
+	}
+
+	return e.httpClient.sendRequest(req, nil)
+}

--- a/entities/metadata_indexes.go
+++ b/entities/metadata_indexes.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
@@ -32,10 +31,6 @@ func (e *metadataIndexesEntity) setDefaultTenantID(tenantID string) {
 // NewMetadataIndexesEntity creates a new MetadataIndexesService instance.
 func NewMetadataIndexesEntity(client *http.Client, authToken string, baseURLs map[string]string) MetadataIndexesService {
 	httpClient := NewHTTPClient(client, authToken, nil)
-
-	if debugEnv := os.Getenv(EnvMidazDebug); debugEnv == BoolTrue {
-		httpClient.debug = true
-	}
 
 	return &metadataIndexesEntity{
 		httpClient: httpClient,

--- a/entities/metadata_indexes_test.go
+++ b/entities/metadata_indexes_test.go
@@ -1,0 +1,92 @@
+package entities
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataIndexesEntity_CreateMetadataIndex_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/settings/metadata-indexes/entities/transaction", r.URL.Path)
+
+		var body models.CreateMetadataIndexInput
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "externalId", body.MetadataKey)
+
+		if !assert.NotNil(t, body.Sparse) {
+			http.Error(w, "missing sparse", http.StatusBadRequest)
+			return
+		}
+
+		assert.True(t, *body.Sparse)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"indexName":"metadata.externalId_1","entityName":"transaction","metadataKey":"externalId","sparse":true}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewMetadataIndexesEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	result, err := service.CreateMetadataIndex(context.Background(), "transaction", models.NewCreateMetadataIndexInput("externalId"))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "externalId", result.MetadataKey)
+}
+
+func TestMetadataIndexValidation(t *testing.T) {
+	require.NoError(t, models.NewCreateMetadataIndexInput("valid_key1").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput("1bad").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput("bad.key").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput("bad-key").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput("bad key").Validate())
+	require.Error(t, (*models.CreateMetadataIndexInput)(nil).Validate())
+	assert.Nil(t, (*models.CreateMetadataIndexInput)(nil).WithUnique(true))
+}
+
+func TestMetadataIndexesEntity_RejectsInvalidEntityName(t *testing.T) {
+	service := NewMetadataIndexesEntity(http.DefaultClient, "token", map[string]string{"transaction": "https://ledger.example.com/v1"})
+	_, err := service.CreateMetadataIndex(context.Background(), "invalid_entity", models.NewCreateMetadataIndexInput("tier"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid entityName")
+}
+
+func TestMetadataIndexesEntity_ListAndDelete_RequestConstruction(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/settings/metadata-indexes":
+			assert.Equal(t, "transaction", r.URL.Query().Get("entity_name"))
+
+			_, err := w.Write([]byte(`[{"indexName":"metadata.tier_1","entityName":"transaction","metadataKey":"tier"}]`))
+			assert.NoError(t, err)
+		case r.Method == http.MethodDelete && r.URL.Path == "/settings/metadata-indexes/entities/transaction/key/tier":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	service := NewMetadataIndexesEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	indexes, err := service.ListMetadataIndexes(context.Background(), "transaction")
+	require.NoError(t, err)
+	require.Len(t, indexes, 1)
+	assert.Equal(t, "tier", indexes[0].MetadataKey)
+
+	require.NoError(t, service.DeleteMetadataIndex(context.Background(), "transaction", "tier"))
+}

--- a/entities/metadata_indexes_test.go
+++ b/entities/metadata_indexes_test.go
@@ -39,11 +39,18 @@ func TestMetadataIndexesEntity_CreateMetadataIndex_RequestConstruction(t *testin
 	defer server.Close()
 
 	service := NewMetadataIndexesEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
-	result, err := service.CreateMetadataIndex(context.Background(), "transaction", models.NewCreateMetadataIndexInput("externalId"))
+	result, err := service.CreateMetadataIndex(context.Background(), "transaction", models.NewCreateMetadataIndexInput("externalId").WithSparse(true))
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "externalId", result.MetadataKey)
+}
+
+func TestCreateMetadataIndexInput_OmitsSparseWhenUnset(t *testing.T) {
+	body, err := json.Marshal(models.NewCreateMetadataIndexInput("externalId"))
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "sparse")
 }
 
 func TestMetadataIndexValidation(t *testing.T) {

--- a/entities/metadata_indexes_test.go
+++ b/entities/metadata_indexes_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
@@ -55,6 +56,8 @@ func TestCreateMetadataIndexInput_OmitsSparseWhenUnset(t *testing.T) {
 
 func TestMetadataIndexValidation(t *testing.T) {
 	require.NoError(t, models.NewCreateMetadataIndexInput("valid_key1").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput("").Validate())
+	require.Error(t, models.NewCreateMetadataIndexInput(strings.Repeat("a", 101)).Validate())
 	require.Error(t, models.NewCreateMetadataIndexInput("1bad").Validate())
 	require.Error(t, models.NewCreateMetadataIndexInput("bad.key").Validate())
 	require.Error(t, models.NewCreateMetadataIndexInput("bad-key").Validate())

--- a/entities/mocks/mock_operations.go
+++ b/entities/mocks/mock_operations.go
@@ -95,9 +95,9 @@ func (mr *MockOperationsServiceMockRecorder) GetOperation(ctx, orgID, ledgerID, 
 }
 
 // UpdateOperation mocks base method.
-func (m *MockOperationsService) UpdateOperation(ctx context.Context, orgID, ledgerID, transactionID, operationID string, input any) (*models.Operation, error) {
+func (m *MockOperationsService) UpdateOperation(ctx context.Context, orgID, ledgerID, accountID, operationID string, input any) (*models.Operation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateOperation", ctx, orgID, ledgerID, transactionID, operationID, input)
+	ret := m.ctrl.Call(m, "UpdateOperation", ctx, orgID, ledgerID, accountID, operationID, input)
 
 	var ret0 *models.Operation
 	if ret[0] != nil {
@@ -113,7 +113,31 @@ func (m *MockOperationsService) UpdateOperation(ctx context.Context, orgID, ledg
 }
 
 // UpdateOperation indicates an expected call of UpdateOperation.
-func (mr *MockOperationsServiceMockRecorder) UpdateOperation(ctx, orgID, ledgerID, transactionID, operationID, input any) *gomock.Call {
+func (mr *MockOperationsServiceMockRecorder) UpdateOperation(ctx, orgID, ledgerID, accountID, operationID, input any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOperation", reflect.TypeOf((*MockOperationsService)(nil).UpdateOperation), ctx, orgID, ledgerID, transactionID, operationID, input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOperation", reflect.TypeOf((*MockOperationsService)(nil).UpdateOperation), ctx, orgID, ledgerID, accountID, operationID, input)
+}
+
+// UpdateTransactionOperation mocks base method.
+func (m *MockOperationsService) UpdateTransactionOperation(ctx context.Context, orgID, ledgerID, transactionID, operationID string, input any) (*models.Operation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTransactionOperation", ctx, orgID, ledgerID, transactionID, operationID, input)
+
+	var ret0 *models.Operation
+	if ret[0] != nil {
+		ret0, _ = ret[0].(*models.Operation) //nolint:errcheck // Type guaranteed by mock setup
+	}
+
+	var ret1 error
+	if ret[1] != nil {
+		ret1, _ = ret[1].(error) //nolint:errcheck // Type guaranteed by mock setup
+	}
+
+	return ret0, ret1
+}
+
+// UpdateTransactionOperation indicates an expected call of UpdateTransactionOperation.
+func (mr *MockOperationsServiceMockRecorder) UpdateTransactionOperation(ctx, orgID, ledgerID, transactionID, operationID, input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTransactionOperation", reflect.TypeOf((*MockOperationsService)(nil).UpdateTransactionOperation), ctx, orgID, ledgerID, transactionID, operationID, input)
 }

--- a/entities/mocks/mock_transactions.go
+++ b/entities/mocks/mock_transactions.go
@@ -243,6 +243,30 @@ func (mr *MockTransactionsServiceMockRecorder) CancelTransaction(ctx, orgID, led
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelTransaction", reflect.TypeOf((*MockTransactionsService)(nil).CancelTransaction), ctx, orgID, ledgerID, transactionID)
 }
 
+// CancelTransactionWithResponse mocks base method.
+func (m *MockTransactionsService) CancelTransactionWithResponse(ctx context.Context, orgID, ledgerID, transactionID string) (*models.Transaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelTransactionWithResponse", ctx, orgID, ledgerID, transactionID)
+
+	var ret0 *models.Transaction
+	if ret[0] != nil {
+		ret0, _ = ret[0].(*models.Transaction) //nolint:errcheck // Type guaranteed by mock setup
+	}
+
+	var ret1 error
+	if len(ret) > 1 && ret[1] != nil {
+		ret1, _ = ret[1].(error) //nolint:errcheck // Type guaranteed by mock setup
+	}
+
+	return ret0, ret1
+}
+
+// CancelTransactionWithResponse indicates an expected call of CancelTransactionWithResponse.
+func (mr *MockTransactionsServiceMockRecorder) CancelTransactionWithResponse(ctx, orgID, ledgerID, transactionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelTransactionWithResponse", reflect.TypeOf((*MockTransactionsService)(nil).CancelTransactionWithResponse), ctx, orgID, ledgerID, transactionID)
+}
+
 // CreateInflowTransaction mocks base method.
 func (m *MockTransactionsService) CreateInflowTransaction(ctx context.Context, orgID, ledgerID string, input *models.CreateInflowInput) (*models.Transaction, error) {
 	m.ctrl.T.Helper()

--- a/entities/operation_routes.go
+++ b/entities/operation_routes.go
@@ -133,10 +133,10 @@ func (e *operationRoutesEntity) buildURL(organizationID, ledgerID, operationRout
 	baseURL := e.baseURLs["transaction"]
 
 	if operationRouteID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/operation-routes", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/operation-routes", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/operation-routes/%s", baseURL, organizationID, ledgerID, operationRouteID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/operation-routes/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(operationRouteID))
 }
 
 // ListOperationRoutes retrieves a paginated list of operation routes
@@ -228,7 +228,7 @@ func (e *operationRoutesEntity) CreateOperationRoute(ctx context.Context, organi
 
 	url := e.buildURL(organizationID, ledgerID, "")
 
-	e.httpClient.debugLog("[%s]: Creating operation route with input: %+v", operation, input)
+	e.httpClient.debugLog("[%s]: Creating operation route", operation)
 
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -274,7 +274,7 @@ func (e *operationRoutesEntity) UpdateOperationRoute(ctx context.Context, organi
 
 	url := e.buildURL(organizationID, ledgerID, operationRouteID)
 
-	e.httpClient.debugLog("[%s]: Updating operation route %s with input: %+v", operation, operationRouteID, input)
+	e.httpClient.debugLog("[%s]: Updating operation route %s", operation, operationRouteID)
 
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/entities/operations.go
+++ b/entities/operations.go
@@ -393,7 +393,7 @@ func (*operationsEntity) UpdateOperation(_ context.Context, _, _, _, _ string, _
 
 // UpdateTransactionOperation updates an operation.
 func (e *operationsEntity) UpdateTransactionOperation(ctx context.Context, orgID, ledgerID, transactionID, operationID string, input any) (*models.Operation, error) {
-	const operation = "UpdateOperation"
+	const operation = "UpdateTransactionOperation"
 
 	if orgID == "" {
 		return nil, errors.NewMissingParameterError(operation, "organizationID")

--- a/entities/operations.go
+++ b/entities/operations.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -168,11 +169,17 @@ type OperationsService interface {
 
 	GetOperation(ctx context.Context, orgID, ledgerID, accountID, operationID string, transactionID ...string) (*models.Operation, error)
 
-	// UpdateOperation updates an existing operation.
-	// The orgID, ledgerID, and accountID parameters specify which organization, ledger, and account the operation belongs to.
+	// UpdateTransactionOperation updates an existing operation by transaction scope.
+	// The orgID, ledgerID, and transactionID parameters specify which organization, ledger,
+	// and transaction the operation belongs to.
 	// The operationID parameter is the unique identifier of the operation to update.
 	// The input parameter contains the operation details to update.
 	// Returns the updated operation, or an error if the operation fails.
+	UpdateTransactionOperation(ctx context.Context, orgID, ledgerID, transactionID, operationID string, input any) (*models.Operation, error)
+
+	// UpdateOperation is retained for source compatibility with the former account-scoped
+	// signature. Midaz now updates operations through the transaction-scoped endpoint.
+	// Deprecated: use UpdateTransactionOperation with a transactionID.
 	UpdateOperation(ctx context.Context, orgID, ledgerID, accountID, operationID string, input any) (*models.Operation, error)
 }
 
@@ -377,8 +384,15 @@ func (e *operationsEntity) GetOperation(ctx context.Context, orgID, ledgerID, ac
 	return &operationModel, nil
 }
 
-// UpdateOperation updates an operation.
-func (e *operationsEntity) UpdateOperation(ctx context.Context, orgID, ledgerID, accountID, operationID string, input any) (*models.Operation, error) {
+// UpdateOperation rejects the former account-scoped update path so callers do not
+// silently route an accountID into Midaz's transaction-scoped endpoint.
+// Deprecated: use UpdateTransactionOperation with a transactionID.
+func (*operationsEntity) UpdateOperation(_ context.Context, _, _, _, _ string, _ any) (*models.Operation, error) {
+	return nil, errors.NewValidationError("UpdateOperation", "operation updates are transaction-scoped", stderrors.New("use UpdateTransactionOperation(ctx, orgID, ledgerID, transactionID, operationID, input)"))
+}
+
+// UpdateTransactionOperation updates an operation.
+func (e *operationsEntity) UpdateTransactionOperation(ctx context.Context, orgID, ledgerID, transactionID, operationID string, input any) (*models.Operation, error) {
 	const operation = "UpdateOperation"
 
 	if orgID == "" {
@@ -389,8 +403,8 @@ func (e *operationsEntity) UpdateOperation(ctx context.Context, orgID, ledgerID,
 		return nil, errors.NewMissingParameterError(operation, "ledgerID")
 	}
 
-	if accountID == "" {
-		return nil, errors.NewMissingParameterError(operation, "accountID")
+	if transactionID == "" {
+		return nil, errors.NewMissingParameterError(operation, "transactionID")
 	}
 
 	if operationID == "" {
@@ -401,7 +415,7 @@ func (e *operationsEntity) UpdateOperation(ctx context.Context, orgID, ledgerID,
 		return nil, errors.NewMissingParameterError(operation, "input")
 	}
 
-	url := fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/operations/%s", e.baseURLs["transaction"], orgID, ledgerID, accountID, operationID)
+	url := fmt.Sprintf("%s/organizations/%s/ledgers/%s/transactions/%s/operations/%s", e.baseURLs["transaction"], pathSegment(orgID), pathSegment(ledgerID), pathSegment(transactionID), pathSegment(operationID))
 
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -430,8 +444,8 @@ func (e *operationsEntity) buildURL(orgID, ledgerID, accountID, operationID stri
 	base = strings.TrimSuffix(base, "/")
 
 	if operationID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/operations", base, orgID, ledgerID, accountID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/operations", base, pathSegment(orgID), pathSegment(ledgerID), pathSegment(accountID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/operations/%s", base, orgID, ledgerID, accountID, operationID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/accounts/%s/operations/%s", base, pathSegment(orgID), pathSegment(ledgerID), pathSegment(accountID), pathSegment(operationID))
 }

--- a/entities/operations.go
+++ b/entities/operations.go
@@ -186,12 +186,12 @@ type OperationsService interface {
 // operationsEntity implements the OperationsService interface.
 // It handles the communication with the Midaz API for operation-related operations.
 type operationsEntity struct {
-	HTTPClient *HTTPClient
+	httpClient *HTTPClient
 	baseURLs   map[string]string
 }
 
 func (e *operationsEntity) setDefaultTenantID(tenantID string) {
-	e.HTTPClient.SetTenantID(tenantID)
+	e.httpClient.SetTenantID(tenantID)
 }
 
 // NewOperationsEntity creates a new operations entity.
@@ -241,7 +241,7 @@ func NewOperationsEntity(client *http.Client, authToken string, baseURLs map[str
 	}
 
 	return &operationsEntity{
-		HTTPClient: httpClient,
+		httpClient: httpClient,
 		baseURLs:   baseURLs,
 	}
 }
@@ -281,7 +281,7 @@ func (e *operationsEntity) ListOperations(ctx context.Context, orgID, ledgerID, 
 	}
 
 	var response models.ListResponse[models.Operation]
-	if err := e.HTTPClient.sendRequest(req, &response); err != nil {
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (e *operationsEntity) GetOperation(ctx context.Context, orgID, ledgerID, ac
 	}
 
 	var operationModel models.Operation
-	if err := e.HTTPClient.sendRequest(req, &operationModel); err != nil {
+	if err := e.httpClient.sendRequest(req, &operationModel); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (e *operationsEntity) UpdateTransactionOperation(ctx context.Context, orgID
 	}
 
 	var operationModel models.Operation
-	if err := e.HTTPClient.sendRequest(req, &operationModel); err != nil {
+	if err := e.httpClient.sendRequest(req, &operationModel); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}

--- a/entities/operations_test.go
+++ b/entities/operations_test.go
@@ -83,7 +83,7 @@ func createTestOperationsEntity(serverURL string) *operationsEntity {
 	}
 
 	return &operationsEntity{
-		HTTPClient: httpClient,
+		httpClient: httpClient,
 		baseURLs: map[string]string{
 			"transaction": serverURL,
 			"onboarding":  serverURL,
@@ -135,7 +135,7 @@ func TestNewOperationsEntity(t *testing.T) {
 
 			entity, ok := service.(*operationsEntity)
 			require.True(t, ok, "service should be *operationsEntity")
-			assert.NotNil(t, entity.HTTPClient)
+			assert.NotNil(t, entity.httpClient)
 			assert.Equal(t, tt.baseURLs, entity.baseURLs)
 		})
 	}
@@ -1248,7 +1248,7 @@ func TestOperationsEntity_AuthorizationHeader(t *testing.T) {
 	defer server.Close()
 
 	entity := createTestOperationsEntity(server.URL)
-	entity.HTTPClient.authToken = "test-bearer-token"
+	entity.httpClient.authToken = "test-bearer-token"
 
 	_, err := entity.GetOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID)
 	require.NoError(t, err)
@@ -1371,7 +1371,7 @@ func TestMockHTTPClientForOperations(t *testing.T) {
 	}
 
 	entity := &operationsEntity{
-		HTTPClient: httpClient,
+		httpClient: httpClient,
 		baseURLs:   map[string]string{"transaction": "http://localhost:8080"},
 	}
 

--- a/entities/operations_test.go
+++ b/entities/operations_test.go
@@ -422,7 +422,7 @@ func TestOperationsEntity_ListOperations_QueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, capturedURL, "limit=25")
-	assert.Contains(t, capturedURL, "offset=50")
+	assert.Contains(t, capturedURL, "page=3")
 }
 
 // TestOperationsEntity_GetOperation tests GetOperation method
@@ -551,6 +551,7 @@ func TestOperationsEntity_GetOperation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/accounts/")
 				assert.Contains(t, r.URL.Path, "/operations/")
 
 				w.Header().Set("Content-Type", "application/json")
@@ -630,13 +631,13 @@ func TestOperationsEntity_GetOperation_ResponseFields(t *testing.T) {
 	assert.Equal(t, "value", result.Metadata["key"])
 }
 
-// TestOperationsEntity_UpdateOperation tests UpdateOperation method
-func TestOperationsEntity_UpdateOperation(t *testing.T) {
+// TestOperationsEntity_UpdateTransactionOperation tests UpdateTransactionOperation method.
+func TestOperationsEntity_UpdateTransactionOperation(t *testing.T) {
 	tests := []struct {
 		name           string
 		orgID          string
 		ledgerID       string
-		accountID      string
+		transactionID  string
 		operationID    string
 		input          any
 		mockResponse   any
@@ -645,11 +646,11 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 		errorContains  string
 	}{
 		{
-			name:        "success with description update",
-			orgID:       opTestOrgID,
-			ledgerID:    opTestLedgerID,
-			accountID:   opTestAccountID,
-			operationID: opTestOperationID,
+			name:          "success with description update",
+			orgID:         opTestOrgID,
+			ledgerID:      opTestLedgerID,
+			transactionID: opTestTransactionID,
+			operationID:   opTestOperationID,
 			input: models.UpdateOperationInput{
 				Description: "Updated description",
 			},
@@ -657,11 +658,11 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			mockStatusCode: http.StatusOK,
 		},
 		{
-			name:        "success with metadata update",
-			orgID:       opTestOrgID,
-			ledgerID:    opTestLedgerID,
-			accountID:   opTestAccountID,
-			operationID: opTestOperationID,
+			name:          "success with metadata update",
+			orgID:         opTestOrgID,
+			ledgerID:      opTestLedgerID,
+			transactionID: opTestTransactionID,
+			operationID:   opTestOperationID,
 			input: models.UpdateOperationInput{
 				Metadata: map[string]any{"newKey": "newValue"},
 			},
@@ -669,11 +670,11 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			mockStatusCode: http.StatusOK,
 		},
 		{
-			name:        "success with full update",
-			orgID:       opTestOrgID,
-			ledgerID:    opTestLedgerID,
-			accountID:   opTestAccountID,
-			operationID: opTestOperationID,
+			name:          "success with full update",
+			orgID:         opTestOrgID,
+			ledgerID:      opTestLedgerID,
+			transactionID: opTestTransactionID,
+			operationID:   opTestOperationID,
 			input: models.UpdateOperationInput{
 				Description: "Full update",
 				Metadata:    map[string]any{"key1": "value1", "key2": "value2"},
@@ -685,7 +686,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:          "empty organization ID",
 			orgID:         "",
 			ledgerID:      opTestLedgerID,
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   opTestOperationID,
 			input:         models.UpdateOperationInput{Description: "test"},
 			expectError:   true,
@@ -695,27 +696,27 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:          "empty ledger ID",
 			orgID:         opTestOrgID,
 			ledgerID:      "",
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   opTestOperationID,
 			input:         models.UpdateOperationInput{Description: "test"},
 			expectError:   true,
 			errorContains: "ledgerID",
 		},
 		{
-			name:          "empty account ID",
+			name:          "empty transaction ID",
 			orgID:         opTestOrgID,
 			ledgerID:      opTestLedgerID,
-			accountID:     "",
+			transactionID: "",
 			operationID:   opTestOperationID,
 			input:         models.UpdateOperationInput{Description: "test"},
 			expectError:   true,
-			errorContains: "accountID",
+			errorContains: "transactionID",
 		},
 		{
 			name:          "empty operation ID",
 			orgID:         opTestOrgID,
 			ledgerID:      opTestLedgerID,
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   "",
 			input:         models.UpdateOperationInput{Description: "test"},
 			expectError:   true,
@@ -725,7 +726,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:          "nil input",
 			orgID:         opTestOrgID,
 			ledgerID:      opTestLedgerID,
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   opTestOperationID,
 			input:         nil,
 			expectError:   true,
@@ -735,7 +736,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:           "not found 404",
 			orgID:          opTestOrgID,
 			ledgerID:       opTestLedgerID,
-			accountID:      opTestAccountID,
+			transactionID:  opTestTransactionID,
 			operationID:    "nonexistent",
 			input:          models.UpdateOperationInput{Description: "test"},
 			mockResponse:   map[string]string{"error": "Operation not found"},
@@ -746,7 +747,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:           "unauthorized 401",
 			orgID:          opTestOrgID,
 			ledgerID:       opTestLedgerID,
-			accountID:      opTestAccountID,
+			transactionID:  opTestTransactionID,
 			operationID:    opTestOperationID,
 			input:          models.UpdateOperationInput{Description: "test"},
 			mockResponse:   map[string]string{"error": "Unauthorized"},
@@ -757,7 +758,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:           "forbidden 403",
 			orgID:          opTestOrgID,
 			ledgerID:       opTestLedgerID,
-			accountID:      opTestAccountID,
+			transactionID:  opTestTransactionID,
 			operationID:    opTestOperationID,
 			input:          models.UpdateOperationInput{Description: "test"},
 			mockResponse:   map[string]string{"error": "Forbidden"},
@@ -768,7 +769,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:           "server error 500",
 			orgID:          opTestOrgID,
 			ledgerID:       opTestLedgerID,
-			accountID:      opTestAccountID,
+			transactionID:  opTestTransactionID,
 			operationID:    opTestOperationID,
 			input:          models.UpdateOperationInput{Description: "test"},
 			mockResponse:   map[string]string{"error": "Internal server error"},
@@ -779,7 +780,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 			name:           "bad request 400",
 			orgID:          opTestOrgID,
 			ledgerID:       opTestLedgerID,
-			accountID:      opTestAccountID,
+			transactionID:  opTestTransactionID,
 			operationID:    opTestOperationID,
 			input:          models.UpdateOperationInput{Description: "test"},
 			mockResponse:   map[string]string{"error": "Bad request"},
@@ -812,7 +813,7 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 
 			entity := createTestOperationsEntity(server.URL)
 
-			result, err := entity.UpdateOperation(context.Background(), tt.orgID, tt.ledgerID, tt.accountID, tt.operationID, tt.input)
+			result, err := entity.UpdateTransactionOperation(context.Background(), tt.orgID, tt.ledgerID, tt.transactionID, tt.operationID, tt.input)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -831,8 +832,8 @@ func TestOperationsEntity_UpdateOperation(t *testing.T) {
 	}
 }
 
-// TestOperationsEntity_UpdateOperation_RequestBody verifies request body is properly serialized
-func TestOperationsEntity_UpdateOperation_RequestBody(t *testing.T) {
+// TestOperationsEntity_UpdateTransactionOperation_RequestBody verifies request body is properly serialized.
+func TestOperationsEntity_UpdateTransactionOperation_RequestBody(t *testing.T) {
 	var capturedBody map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -854,13 +855,21 @@ func TestOperationsEntity_UpdateOperation_RequestBody(t *testing.T) {
 		Metadata:    map[string]any{"testKey": "testValue"},
 	}
 
-	_, err := entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, input)
+	_, err := entity.UpdateTransactionOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestTransactionID, opTestOperationID, input)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Test description", capturedBody["description"])
 	metadata, ok := capturedBody["metadata"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "testValue", metadata["testKey"])
+}
+
+func TestOperationsEntity_UpdateOperation_DeprecatedAccountScopedMethodFailsLoudly(t *testing.T) {
+	entity := createTestOperationsEntity("https://ledger.example.com/v1")
+
+	_, err := entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, models.UpdateOperationInput{Description: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "UpdateTransactionOperation")
 }
 
 // TestOperationsEntity_ContextCancellation tests that context cancellation is respected
@@ -892,6 +901,7 @@ func TestOperationsEntity_ValidationEdgeCases(t *testing.T) {
 		orgID         string
 		ledgerID      string
 		accountID     string
+		transactionID string
 		operationID   string
 		input         any
 		expectError   bool
@@ -972,7 +982,7 @@ func TestOperationsEntity_ValidationEdgeCases(t *testing.T) {
 			method:        "UpdateOperation",
 			orgID:         opTestOrgID,
 			ledgerID:      opTestLedgerID,
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   opTestOperationID,
 			input:         nil,
 			expectError:   true,
@@ -983,7 +993,7 @@ func TestOperationsEntity_ValidationEdgeCases(t *testing.T) {
 			method:        "UpdateOperation",
 			orgID:         "",
 			ledgerID:      opTestLedgerID,
-			accountID:     opTestAccountID,
+			transactionID: opTestTransactionID,
 			operationID:   opTestOperationID,
 			input:         models.UpdateOperationInput{Description: "test"},
 			expectError:   true,
@@ -1003,7 +1013,7 @@ func TestOperationsEntity_ValidationEdgeCases(t *testing.T) {
 			case "GetOperation":
 				_, err = entity.GetOperation(ctx, tt.orgID, tt.ledgerID, tt.accountID, tt.operationID)
 			case "UpdateOperation":
-				_, err = entity.UpdateOperation(ctx, tt.orgID, tt.ledgerID, tt.accountID, tt.operationID, tt.input)
+				_, err = entity.UpdateTransactionOperation(ctx, tt.orgID, tt.ledgerID, tt.transactionID, tt.operationID, tt.input)
 			}
 
 			if tt.expectError {
@@ -1059,8 +1069,8 @@ func TestOperationsEntity_HTTPErrorCodes(t *testing.T) {
 			_, err = entity.GetOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID)
 			require.Error(t, err)
 
-			// Test UpdateOperation
-			_, err = entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, models.UpdateOperationInput{})
+			// Test UpdateTransactionOperation
+			_, err = entity.UpdateTransactionOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestTransactionID, opTestOperationID, models.UpdateOperationInput{})
 			require.Error(t, err)
 		})
 	}
@@ -1264,13 +1274,13 @@ func TestOperationsEntity_ContentTypeHeader(t *testing.T) {
 	entity := createTestOperationsEntity(server.URL)
 
 	input := models.UpdateOperationInput{Description: "test"}
-	_, err := entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, input)
+	_, err := entity.UpdateTransactionOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestTransactionID, opTestOperationID, input)
 	require.NoError(t, err)
 
 	assert.Equal(t, "application/json", capturedHeaders.Get("Content-Type"))
 }
 
-// TestOperationsEntity_UpdateWithMapInput tests UpdateOperation with map input type
+// TestOperationsEntity_UpdateWithMapInput tests UpdateTransactionOperation with map input type.
 func TestOperationsEntity_UpdateWithMapInput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1287,7 +1297,7 @@ func TestOperationsEntity_UpdateWithMapInput(t *testing.T) {
 		"metadata":    map[string]any{"key": "value"},
 	}
 
-	result, err := entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, input)
+	result, err := entity.UpdateTransactionOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestTransactionID, opTestOperationID, input)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
@@ -1326,7 +1336,7 @@ func TestOperationsEntity_ListWithAllFilters(t *testing.T) {
 
 	// Verify query parameters
 	assert.Contains(t, capturedQuery, "limit=20")
-	assert.Contains(t, capturedQuery, "offset=40")
+	assert.Contains(t, capturedQuery, "page=3")
 }
 
 // TestMockHTTPClientForOperations tests using the MockHTTPClient pattern
@@ -1391,7 +1401,7 @@ func TestOperationsEntity_URLPathConstruction(t *testing.T) {
 		{
 			name:         "UpdateOperation path",
 			method:       "UpdateOperation",
-			expectedPath: "/organizations/org-123/ledgers/ledger-456/accounts/acc-789/operations/op-abc",
+			expectedPath: "/organizations/org-123/ledgers/ledger-456/transactions/tx-xyz/operations/op-abc",
 		},
 	}
 
@@ -1425,7 +1435,7 @@ func TestOperationsEntity_URLPathConstruction(t *testing.T) {
 			case "GetOperation":
 				entity.GetOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID)
 			case "UpdateOperation":
-				entity.UpdateOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestAccountID, opTestOperationID, models.UpdateOperationInput{})
+				entity.UpdateTransactionOperation(context.Background(), opTestOrgID, opTestLedgerID, opTestTransactionID, opTestOperationID, models.UpdateOperationInput{})
 			}
 
 			assert.Equal(t, tt.expectedPath, capturedPath)

--- a/entities/organizations.go
+++ b/entities/organizations.go
@@ -312,6 +312,10 @@ func redactedOrgPayloadForLog(payload any) any {
 		redacted["legalDocument"] = "<redacted>"
 	}
 
+	if _, ok := redacted["legal_document"]; ok {
+		redacted["legal_document"] = "<redacted>"
+	}
+
 	return redacted
 }
 

--- a/entities/organizations.go
+++ b/entities/organizations.go
@@ -349,21 +349,14 @@ func (e *organizationsEntity) DeleteOrganization(ctx context.Context, id string)
 
 // GetOrganizationsMetricsCount gets the count metrics for organizations.
 func (e *organizationsEntity) GetOrganizationsMetricsCount(ctx context.Context) (*models.MetricsCount, error) {
-	const operation = "GetOrganizationsMetricsCount"
-
 	url := e.buildMetricsURL()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	count, err := e.HTTPClient.doCountRequest(ctx, countRequestMethod(), url, countRequestHeaders())
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.HTTPClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{OrganizationsCount: count}, nil
 }
 
 // buildURL builds the URL for organizations API calls.
@@ -374,7 +367,7 @@ func (e *organizationsEntity) buildURL(id string) string {
 		return fmt.Sprintf("%s/organizations", baseURL)
 	}
 
-	return fmt.Sprintf("%s/organizations/%s", baseURL, id)
+	return fmt.Sprintf("%s/organizations/%s", baseURL, pathSegment(id))
 }
 
 // buildMetricsURL builds the URL for organizations metrics API calls.

--- a/entities/organizations.go
+++ b/entities/organizations.go
@@ -271,8 +271,8 @@ func (e *organizationsEntity) CreateOrganization(ctx context.Context, input *mod
 	mmodelInput := input.ToMmodelCreateOrganizationInput()
 
 	e.httpClient.debugLog("[%s]: Converting SDK input to backend format", operation)
-	e.httpClient.debugLog("[%s]: Original: %+v", operation, input)
-	e.httpClient.debugLog("[%s]: Converted: %+v", operation, mmodelInput)
+	e.httpClient.debugLog("[%s]: Original: %+v", operation, redactedOrgPayloadForLog(input))
+	e.httpClient.debugLog("[%s]: Converted: %+v", operation, redactedOrgPayloadForLog(mmodelInput))
 
 	// Marshal the input to JSON
 	body, err := json.Marshal(mmodelInput)
@@ -291,6 +291,28 @@ func (e *organizationsEntity) CreateOrganization(ctx context.Context, input *mod
 	}
 
 	return &organization, nil
+}
+
+func redactedOrgPayloadForLog(payload any) any {
+	if payload == nil {
+		return nil
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return map[string]any{"redacted": true, "reason": "payload marshal failed"}
+	}
+
+	redacted := map[string]any{}
+	if err := json.Unmarshal(body, &redacted); err != nil {
+		return map[string]any{"redacted": true, "reason": "payload unmarshal failed"}
+	}
+
+	if _, ok := redacted["legalDocument"]; ok {
+		redacted["legalDocument"] = "<redacted>"
+	}
+
+	return redacted
 }
 
 // UpdateOrganization updates an existing organization.

--- a/entities/organizations.go
+++ b/entities/organizations.go
@@ -135,12 +135,12 @@ type OrganizationsService interface {
 // organizationsEntity implements the OrganizationsService interface.
 // It handles the communication with the Midaz API for organization-related operations.
 type organizationsEntity struct {
-	HTTPClient *HTTPClient
+	httpClient *HTTPClient
 	baseURLs   map[string]string
 }
 
 func (e *organizationsEntity) setDefaultTenantID(tenantID string) {
-	e.HTTPClient.SetTenantID(tenantID)
+	e.httpClient.SetTenantID(tenantID)
 }
 
 // NewOrganizationsEntity creates a new organizations entity.
@@ -187,7 +187,7 @@ func NewOrganizationsEntity(client *http.Client, authToken string, baseURLs map[
 	}
 
 	return &organizationsEntity{
-		HTTPClient: httpClient,
+		httpClient: httpClient,
 		baseURLs:   baseURLs,
 	}
 }
@@ -215,7 +215,7 @@ func (e *organizationsEntity) ListOrganizations(ctx context.Context, opts *model
 	}
 
 	var response models.ListResponse[models.Organization]
-	if err := e.HTTPClient.sendRequest(req, &response); err != nil {
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		return nil, err
 	}
 
@@ -238,7 +238,7 @@ func (e *organizationsEntity) GetOrganization(ctx context.Context, id string) (*
 	}
 
 	var organization models.Organization
-	if err := e.HTTPClient.sendRequest(req, &organization); err != nil {
+	if err := e.httpClient.sendRequest(req, &organization); err != nil {
 		return nil, err
 	}
 
@@ -270,9 +270,9 @@ func (e *organizationsEntity) CreateOrganization(ctx context.Context, input *mod
 	// Convert the input to the mmodel format using our utility
 	mmodelInput := input.ToMmodelCreateOrganizationInput()
 
-	e.HTTPClient.debugLog("[%s]: Converting SDK input to backend format", operation)
-	e.HTTPClient.debugLog("[%s]: Original: %+v", operation, input)
-	e.HTTPClient.debugLog("[%s]: Converted: %+v", operation, mmodelInput)
+	e.httpClient.debugLog("[%s]: Converting SDK input to backend format", operation)
+	e.httpClient.debugLog("[%s]: Original: %+v", operation, input)
+	e.httpClient.debugLog("[%s]: Converted: %+v", operation, mmodelInput)
 
 	// Marshal the input to JSON
 	body, err := json.Marshal(mmodelInput)
@@ -286,7 +286,7 @@ func (e *organizationsEntity) CreateOrganization(ctx context.Context, input *mod
 	}
 
 	var organization models.Organization
-	if err := e.HTTPClient.sendRequest(req, &organization); err != nil {
+	if err := e.httpClient.sendRequest(req, &organization); err != nil {
 		return nil, err
 	}
 
@@ -322,7 +322,7 @@ func (e *organizationsEntity) UpdateOrganization(ctx context.Context, id string,
 	}
 
 	var organization models.Organization
-	if err := e.HTTPClient.sendRequest(req, &organization); err != nil {
+	if err := e.httpClient.sendRequest(req, &organization); err != nil {
 		return nil, err
 	}
 
@@ -344,14 +344,14 @@ func (e *organizationsEntity) DeleteOrganization(ctx context.Context, id string)
 		return errors.NewInternalError(operation, err)
 	}
 
-	return e.HTTPClient.sendRequest(req, nil)
+	return e.httpClient.sendRequest(req, nil)
 }
 
 // GetOrganizationsMetricsCount gets the count metrics for organizations.
 func (e *organizationsEntity) GetOrganizationsMetricsCount(ctx context.Context) (*models.MetricsCount, error) {
 	url := e.buildMetricsURL()
 
-	count, err := e.HTTPClient.doCountRequest(ctx, countRequestMethod(), url, countRequestHeaders())
+	count, err := e.httpClient.doCountRequest(ctx, countRequestMethod(), url, countRequestHeaders())
 	if err != nil {
 		return nil, err
 	}

--- a/entities/organizations_test.go
+++ b/entities/organizations_test.go
@@ -145,7 +145,7 @@ func TestCreateOrganization(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test input
-	input := models.NewCreateOrganizationInput("New Org").
+	input := models.NewCreateOrganizationInput("New Org", "123456789012345").
 		WithLegalDocument("987654321").
 		WithStatus(models.NewStatus("ACTIVE")).
 		WithMetadata(map[string]any{

--- a/entities/organizations_test.go
+++ b/entities/organizations_test.go
@@ -145,8 +145,7 @@ func TestCreateOrganization(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test input
-	input := models.NewCreateOrganizationInput("New Org", "123456789012345").
-		WithLegalDocument("987654321").
+	input := models.NewCreateOrganizationInput("New Org", "987654321").
 		WithStatus(models.NewStatus("ACTIVE")).
 		WithMetadata(map[string]any{
 			"key": "value",

--- a/entities/portfolios.go
+++ b/entities/portfolios.go
@@ -135,12 +135,12 @@ type PortfoliosService interface {
 // portfoliosEntity implements the PortfoliosService interface.
 // It provides methods for creating, retrieving, updating, and deleting portfolios.
 type portfoliosEntity struct {
-	HTTPClient *HTTPClient
+	httpClient *HTTPClient
 	baseURLs   map[string]string
 }
 
 func (e *portfoliosEntity) setDefaultTenantID(tenantID string) {
-	e.HTTPClient.SetTenantID(tenantID)
+	e.httpClient.SetTenantID(tenantID)
 }
 
 // NewPortfoliosEntity creates a new portfolios entity.
@@ -155,7 +155,7 @@ func NewPortfoliosEntity(client *http.Client, authToken string, baseURLs map[str
 	}
 
 	return &portfoliosEntity{
-		HTTPClient: httpClient,
+		httpClient: httpClient,
 		baseURLs:   baseURLs,
 	}
 }
@@ -191,7 +191,7 @@ func (e *portfoliosEntity) ListPortfolios(ctx context.Context, organizationID, l
 	}
 
 	var response models.ListResponse[models.Portfolio]
-	if err := e.HTTPClient.sendRequest(req, &response); err != nil {
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		return nil, err
 	}
 
@@ -222,7 +222,7 @@ func (e *portfoliosEntity) GetPortfolio(ctx context.Context, organizationID, led
 	}
 
 	var portfolio models.Portfolio
-	if err := e.HTTPClient.sendRequest(req, &portfolio); err != nil {
+	if err := e.httpClient.sendRequest(req, &portfolio); err != nil {
 		return nil, err
 	}
 
@@ -258,7 +258,7 @@ func (e *portfoliosEntity) CreatePortfolio(ctx context.Context, organizationID, 
 	}
 
 	var portfolio models.Portfolio
-	if err := e.HTTPClient.sendRequest(req, &portfolio); err != nil {
+	if err := e.httpClient.sendRequest(req, &portfolio); err != nil {
 		return nil, err
 	}
 
@@ -298,7 +298,7 @@ func (e *portfoliosEntity) UpdatePortfolio(ctx context.Context, organizationID, 
 	}
 
 	var portfolio models.Portfolio
-	if err := e.HTTPClient.sendRequest(req, &portfolio); err != nil {
+	if err := e.httpClient.sendRequest(req, &portfolio); err != nil {
 		return nil, err
 	}
 
@@ -328,7 +328,7 @@ func (e *portfoliosEntity) DeletePortfolio(ctx context.Context, organizationID, 
 		return errors.NewInternalError(operation, err)
 	}
 
-	return e.HTTPClient.sendRequest(req, nil)
+	return e.httpClient.sendRequest(req, nil)
 }
 
 // GetPortfoliosMetricsCount gets the count metrics for portfolios in a ledger.
@@ -345,7 +345,7 @@ func (e *portfoliosEntity) GetPortfoliosMetricsCount(ctx context.Context, organi
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	count, err := e.HTTPClient.doCountRequest(ctx, http.MethodHead, url, nil)
+	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/entities/portfolios.go
+++ b/entities/portfolios.go
@@ -345,17 +345,12 @@ func (e *portfoliosEntity) GetPortfoliosMetricsCount(ctx context.Context, organi
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	count, err := e.HTTPClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.HTTPClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{PortfoliosCount: count}, nil
 }
 
 // buildURL builds the URL for portfolios API calls.
@@ -363,14 +358,14 @@ func (e *portfoliosEntity) buildURL(organizationID, ledgerID, portfolioID string
 	baseURL := e.baseURLs["onboarding"]
 
 	if portfolioID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios/%s", baseURL, organizationID, ledgerID, portfolioID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(portfolioID))
 }
 
 // buildMetricsURL builds the URL for portfolios metrics API calls.
 func (e *portfoliosEntity) buildMetricsURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios/metrics/count", baseURL, organizationID, ledgerID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/portfolios/metrics/count", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }

--- a/entities/segments.go
+++ b/entities/segments.go
@@ -353,17 +353,12 @@ func (e *segmentsEntity) GetSegmentsMetricsCount(ctx context.Context, organizati
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	count, err := e.HTTPClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
-		return nil, errors.NewInternalError(operation, err)
-	}
-
-	var metrics models.MetricsCount
-	if err := e.HTTPClient.sendRequest(req, &metrics); err != nil {
 		return nil, err
 	}
 
-	return &metrics, nil
+	return &models.MetricsCount{SegmentsCount: count}, nil
 }
 
 // buildURL builds the URL for segments API calls.
@@ -372,14 +367,14 @@ func (e *segmentsEntity) buildURL(organizationID, ledgerID, segmentID string) st
 
 	// Segments are directly under ledgers in the API, not under portfolios
 	if segmentID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments/%s", baseURL, organizationID, ledgerID, segmentID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(segmentID))
 }
 
 // buildMetricsURL builds the URL for segments metrics API calls.
 func (e *segmentsEntity) buildMetricsURL(organizationID, ledgerID string) string {
 	baseURL := e.baseURLs["onboarding"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments/metrics/count", baseURL, organizationID, ledgerID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/segments/metrics/count", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 }

--- a/entities/segments.go
+++ b/entities/segments.go
@@ -122,19 +122,19 @@ type SegmentsService interface {
 // segmentsEntity implements the SegmentsService interface.
 // It provides methods for creating, retrieving, updating, and deleting segments.
 type segmentsEntity struct {
-	HTTPClient *HTTPClient
+	httpClient *HTTPClient
 	baseURLs   map[string]string
 }
 
 func (e *segmentsEntity) setDefaultTenantID(tenantID string) {
-	e.HTTPClient.SetTenantID(tenantID)
+	e.httpClient.SetTenantID(tenantID)
 }
 
 // NewSegmentsEntity creates a new segments entity.
 // It initializes the HTTP client and base URLs for API requests.
 func NewSegmentsEntity(client *http.Client, authToken string, baseURLs map[string]string) SegmentsService {
 	return &segmentsEntity{
-		HTTPClient: NewHTTPClient(client, authToken, nil),
+		httpClient: NewHTTPClient(client, authToken, nil),
 		baseURLs:   baseURLs,
 	}
 }
@@ -174,7 +174,7 @@ func (e *segmentsEntity) ListSegments(
 	}
 
 	var response models.ListResponse[models.Segment]
-	if err := e.HTTPClient.sendRequest(req, &response); err != nil {
+	if err := e.httpClient.sendRequest(req, &response); err != nil {
 		return nil, err
 	}
 
@@ -208,7 +208,7 @@ func (e *segmentsEntity) GetSegment(
 	}
 
 	var segment models.Segment
-	if err := e.HTTPClient.sendRequest(req, &segment); err != nil {
+	if err := e.httpClient.sendRequest(req, &segment); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (e *segmentsEntity) CreateSegment(
 	}
 
 	var segment models.Segment
-	if err := e.HTTPClient.sendRequest(req, &segment); err != nil {
+	if err := e.httpClient.sendRequest(req, &segment); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (e *segmentsEntity) UpdateSegment(
 	}
 
 	var segment models.Segment
-	if err := e.HTTPClient.sendRequest(req, &segment); err != nil {
+	if err := e.httpClient.sendRequest(req, &segment); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (e *segmentsEntity) DeleteSegment(
 		return errors.NewInternalError(operation, err)
 	}
 
-	if err := e.HTTPClient.sendRequest(req, nil); err != nil {
+	if err := e.httpClient.sendRequest(req, nil); err != nil {
 		// HTTPClient.DoRequest already returns proper error types
 		return err
 	}
@@ -353,7 +353,7 @@ func (e *segmentsEntity) GetSegmentsMetricsCount(ctx context.Context, organizati
 
 	url := e.buildMetricsURL(organizationID, ledgerID)
 
-	count, err := e.HTTPClient.doCountRequest(ctx, http.MethodHead, url, nil)
+	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/entities/segments_test.go
+++ b/entities/segments_test.go
@@ -87,7 +87,7 @@ func TestNewSegmentsEntity(t *testing.T) {
 
 			entity, ok := service.(*segmentsEntity)
 			require.True(t, ok, "expected *segmentsEntity type")
-			assert.NotNil(t, entity.HTTPClient)
+			assert.NotNil(t, entity.httpClient)
 			assert.Equal(t, tt.baseURLs, entity.baseURLs)
 		})
 	}
@@ -315,7 +315,7 @@ func TestSegmentsEntity_ListSegments(t *testing.T) {
 			}
 
 			entity := &segmentsEntity{
-				HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+				httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 				baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 			}
 
@@ -356,7 +356,7 @@ func TestSegmentsEntity_ListSegments_QueryParams(t *testing.T) {
 	}
 
 	entity := &segmentsEntity{
-		HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+		httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 		baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 	}
 
@@ -512,7 +512,7 @@ func TestSegmentsEntity_GetSegment(t *testing.T) {
 			}
 
 			entity := &segmentsEntity{
-				HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+				httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 				baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 			}
 
@@ -712,7 +712,7 @@ func createSegmentEntityWithMock(t *testing.T, mockError error, statusCode int, 
 	}
 
 	return &segmentsEntity{
-		HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+		httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 		baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 	}
 }
@@ -933,7 +933,7 @@ func TestSegmentsEntity_UpdateSegment(t *testing.T) {
 			}
 
 			entity := &segmentsEntity{
-				HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+				httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 				baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 			}
 
@@ -1087,7 +1087,7 @@ func TestSegmentsEntity_DeleteSegment(t *testing.T) {
 			}
 
 			entity := &segmentsEntity{
-				HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+				httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 				baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 			}
 
@@ -1197,7 +1197,7 @@ func TestSegmentsEntity_GetSegmentsMetricsCount(t *testing.T) {
 			}
 
 			entity := &segmentsEntity{
-				HTTPClient: newMockSegmentsHTTPClientAdapter(mockClient),
+				httpClient: newMockSegmentsHTTPClientAdapter(mockClient),
 				baseURLs:   map[string]string{"onboarding": "https://api.example.com"},
 			}
 
@@ -1223,7 +1223,7 @@ func TestSegmentsEntity_GetSegmentsMetricsCount(t *testing.T) {
 // newValidationTestEntity creates a segment entity for validation testing
 func newValidationTestEntity() *segmentsEntity {
 	return &segmentsEntity{
-		HTTPClient: newMockSegmentsHTTPClientAdapter(&MockHTTPClient{
+		httpClient: newMockSegmentsHTTPClientAdapter(&MockHTTPClient{
 			DoFunc: func(_ *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,

--- a/entities/segments_test.go
+++ b/entities/segments_test.go
@@ -372,7 +372,7 @@ func TestSegmentsEntity_ListSegments_QueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, capturedURL, "limit=20")
-	assert.Contains(t, capturedURL, "page=1")
+	assert.Contains(t, capturedURL, "offset=5")
 	assert.Contains(t, capturedURL, "sort_order=desc")
 	assert.Contains(t, capturedURL, "status=ACTIVE")
 }

--- a/entities/segments_test.go
+++ b/entities/segments_test.go
@@ -372,8 +372,8 @@ func TestSegmentsEntity_ListSegments_QueryParams(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Contains(t, capturedURL, "limit=20")
-	assert.Contains(t, capturedURL, "offset=5")
-	assert.Contains(t, capturedURL, "orderBy=createdAt")
+	assert.Contains(t, capturedURL, "page=1")
+	assert.Contains(t, capturedURL, "sort_order=desc")
 	assert.Contains(t, capturedURL, "status=ACTIVE")
 }
 
@@ -1123,8 +1123,8 @@ func TestSegmentsEntity_GetSegmentsMetricsCount(t *testing.T) {
 			name:           "success",
 			orgID:          testOrgID,
 			ledgerID:       testLedgerID,
-			mockStatusCode: http.StatusOK,
-			mockResponse:   `{"count": 42}`,
+			mockStatusCode: http.StatusNoContent,
+			mockResponse:   ``,
 		},
 		{
 			name:          "empty organization ID",
@@ -1190,6 +1190,7 @@ func TestSegmentsEntity_GetSegmentsMetricsCount(t *testing.T) {
 
 					return &http.Response{
 						StatusCode: statusCode,
+						Header:     http.Header{HeaderTotalCount: []string{"42"}},
 						Body:       io.NopCloser(strings.NewReader(tt.mockResponse)),
 					}, nil
 				},
@@ -1214,6 +1215,7 @@ func TestSegmentsEntity_GetSegmentsMetricsCount(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
+			assert.Equal(t, 42, result.SegmentsCount)
 		})
 	}
 }
@@ -1619,7 +1621,7 @@ func TestSegmentsEntity_RequestURLConstruction(t *testing.T) {
 
 	require.Len(t, capturedRequests, 1)
 	assert.Contains(t, capturedRequests[0].URL, "limit=25")
-	assert.Contains(t, capturedRequests[0].URL, "offset=50")
+	assert.Contains(t, capturedRequests[0].URL, "page=3")
 }
 
 func TestSegmentsEntity_ResponseParsing(t *testing.T) {

--- a/entities/transaction_routes.go
+++ b/entities/transaction_routes.go
@@ -134,10 +134,10 @@ func (e *transactionRoutesEntity) buildURL(organizationID, ledgerID, transaction
 	baseURL := e.baseURLs["transaction"]
 
 	if transactionRouteID == "" {
-		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transaction-routes", baseURL, organizationID, ledgerID)
+		return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transaction-routes", baseURL, pathSegment(organizationID), pathSegment(ledgerID))
 	}
 
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transaction-routes/%s", baseURL, organizationID, ledgerID, transactionRouteID)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transaction-routes/%s", baseURL, pathSegment(organizationID), pathSegment(ledgerID), pathSegment(transactionRouteID))
 }
 
 // ListTransactionRoutes retrieves a paginated list of transaction routes
@@ -229,7 +229,7 @@ func (e *transactionRoutesEntity) CreateTransactionRoute(ctx context.Context, or
 
 	url := e.buildURL(organizationID, ledgerID, "")
 
-	e.httpClient.debugLog("[%s]: Creating transaction route with input: %+v", operation, input)
+	e.httpClient.debugLog("[%s]: Creating transaction route", operation)
 
 	body, err := json.Marshal(input)
 	if err != nil {
@@ -275,7 +275,7 @@ func (e *transactionRoutesEntity) UpdateTransactionRoute(ctx context.Context, or
 
 	url := e.buildURL(organizationID, ledgerID, transactionRouteID)
 
-	e.httpClient.debugLog("[%s]: Updating transaction route %s with input: %+v", operation, transactionRouteID, input)
+	e.httpClient.debugLog("[%s]: Updating transaction route %s", operation, transactionRouteID)
 
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/entities/transactions.go
+++ b/entities/transactions.go
@@ -952,7 +952,7 @@ func (e *transactionsEntity) CancelTransactionWithResponse(ctx context.Context, 
 	var transaction models.Transaction
 	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
 		if errors.Is(err, errEmptyResponseBody) || errors.Is(err, errNullResponseBody) {
-			return nil, nil //nolint:nilnil // successful cancel endpoints may be bodyless
+			return &models.Transaction{ID: transactionID}, nil
 		}
 
 		return nil, err

--- a/entities/transactions.go
+++ b/entities/transactions.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
 	sdkerrors "github.com/LerianStudio/midaz-sdk-golang/v2/pkg/errors"
 )
@@ -391,26 +393,17 @@ func (e *transactionsEntity) setTransactionOperations(transaction *models.Transa
 }
 
 func (*transactionsEntity) parseOperation(operationMap map[string]any) models.Operation {
-	var operation models.Operation
-
-	encoded, err := json.Marshal(operationMap)
-	if err == nil {
-		if err := json.Unmarshal(encoded, &operation); err == nil {
-			if operation.Metadata == nil {
-				operation.Metadata = map[string]any{}
-			}
-
-			return operation
-		}
-	}
-
-	return models.Operation{
+	operation := models.Operation{
 		ID:               getString(operationMap, "id"),
 		TransactionID:    getString(operationMap, "transactionId"),
 		Description:      getString(operationMap, "description"),
 		Type:             getString(operationMap, "type"),
 		AssetCode:        getString(operationMap, "assetCode"),
 		ChartOfAccounts:  getString(operationMap, "chartOfAccounts"),
+		Amount:           operationAmountFromMap(operationMap),
+		Balance:          operationBalanceFromMap(operationMap, "balance"),
+		BalanceAfter:     operationBalanceFromMap(operationMap, "balanceAfter"),
+		Status:           operationStatusFromMap(operationMap),
 		AccountID:        getString(operationMap, "accountId"),
 		AccountAlias:     getString(operationMap, "accountAlias"),
 		BalanceID:        getString(operationMap, "balanceId"),
@@ -423,6 +416,87 @@ func (*transactionsEntity) parseOperation(operationMap map[string]any) models.Op
 		RouteDescription: getString(operationMap, "routeDescription"),
 		Direction:        getString(operationMap, "direction"),
 	}
+	if metadata, ok := operationMap["metadata"].(map[string]any); ok {
+		operation.Metadata = metadata
+	} else {
+		operation.Metadata = map[string]any{}
+	}
+
+	if balanceAffected, ok := boolFromAny(operationMap["balanceAffected"]); ok {
+		operation.BalanceAffected = &balanceAffected
+	}
+
+	return operation
+}
+
+func operationAmountFromMap(operationMap map[string]any) models.Amount {
+	amountMap, ok := operationMap["amount"].(map[string]any)
+	if !ok {
+		return models.Amount{}
+	}
+
+	return models.Amount{Value: decimalPtrFromAny(amountMap["value"])}
+}
+
+func operationBalanceFromMap(operationMap map[string]any, key string) models.OperationBalance {
+	balanceMap, ok := operationMap[key].(map[string]any)
+	if !ok {
+		return models.OperationBalance{}
+	}
+
+	return models.OperationBalance{
+		Available: decimalPtrFromAny(balanceMap["available"]),
+		OnHold:    decimalPtrFromAny(balanceMap["onHold"]),
+	}
+}
+
+func operationStatusFromMap(operationMap map[string]any) models.Status {
+	statusMap, ok := operationMap["status"].(map[string]any)
+	if !ok {
+		return models.Status{}
+	}
+
+	return models.Status{Code: getString(statusMap, "code")}
+}
+
+func decimalPtrFromAny(value any) *decimal.Decimal {
+	switch v := value.(type) {
+	case nil:
+		return nil
+	case string:
+		parsed, err := decimal.NewFromString(strings.TrimSpace(v))
+		if err != nil {
+			return nil
+		}
+
+		return &parsed
+	case json.Number:
+		parsed, err := decimal.NewFromString(v.String())
+		if err != nil {
+			return nil
+		}
+
+		return &parsed
+	case int:
+		parsed := decimal.NewFromInt(int64(v))
+		return &parsed
+	case int64:
+		parsed := decimal.NewFromInt(v)
+		return &parsed
+	case float64:
+		parsed := decimal.NewFromFloat(v)
+		return &parsed
+	default:
+		return nil
+	}
+}
+
+func boolFromAny(value any) (result bool, ok bool) {
+	if v, ok := value.(bool); ok {
+		return v, true
+	}
+
+	return false, false
 }
 
 // CreateTransactionWithDSL creates a new transaction using the DSL format.

--- a/entities/transactions.go
+++ b/entities/transactions.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -52,6 +54,9 @@ type TransactionsService interface {
 	// Returns a ListResponse containing the transactions and pagination information, or an error if the operation fails.
 	ListTransactions(ctx context.Context, orgID, ledgerID string, opts *models.ListOptions) (*models.ListResponse[models.Transaction], error)
 
+	// GetTransactionsMetricsCount retrieves the count of transactions that match the supplied filters.
+	GetTransactionsMetricsCount(ctx context.Context, orgID, ledgerID string, opts *models.ListOptions) (*models.MetricsCount, error)
+
 	// UpdateTransaction updates an existing transaction.
 	// The orgID and ledgerID parameters specify which organization and ledger the transaction belongs to.
 	// The transactionID parameter is the unique identifier of the transaction to update.
@@ -76,6 +81,9 @@ type TransactionsService interface {
 	// The transactionID parameter is the unique identifier of the transaction to cancel.
 	// Returns an error if the operation fails.
 	CancelTransaction(ctx context.Context, orgID, ledgerID, transactionID string) error
+
+	// CancelTransactionWithResponse cancels a pending transaction and returns the cancelled transaction.
+	CancelTransactionWithResponse(ctx context.Context, orgID, ledgerID, transactionID string) (*models.Transaction, error)
 
 	// CreateInflowTransaction creates an inflow transaction (funds entering the system).
 	// Inflow transactions have no source - they represent deposits or funding operations.
@@ -193,10 +201,6 @@ func (*transactionsEntity) validateCreateTransactionInput(operation, orgID, ledg
 		return sdkerrors.NewValidationError(operation, "transaction validation failed", err)
 	}
 
-	if input.Send == nil && len(input.Operations) == 0 {
-		return sdkerrors.NewValidationError(operation, "transaction must have at least one operation", nil)
-	}
-
 	return nil
 }
 
@@ -205,7 +209,13 @@ func (e *transactionsEntity) sendCreateTransactionRequest(ctx context.Context, o
 	txMap := input.ToLibTransaction()
 
 	var responseMap map[string]any
-	if err := e.httpClient.doRequest(ctx, http.MethodPost, e.buildURL(orgID, ledgerID, "/json"), nil, txMap, &responseMap); err != nil {
+
+	headers := map[string]string{"X-Midaz-Auto-Idempotency": "true"}
+	if key := strings.TrimSpace(input.IdempotencyKey); key != "" {
+		headers["X-Idempotency"] = key
+	}
+
+	if err := e.httpClient.doRequest(ctx, http.MethodPost, e.buildURL(orgID, ledgerID, "/json"), headers, txMap, &responseMap); err != nil {
 		return nil, err
 	}
 
@@ -226,16 +236,16 @@ func (e *transactionsEntity) parseTransactionResponse(responseMap map[string]any
 	e.setTransactionStatus(transaction, responseMap)
 	e.setTransactionTimestamps(transaction, responseMap)
 	e.setTransactionMetadata(transaction, responseMap)
+	e.setTransactionOperations(transaction, responseMap)
+	e.normalizeTransaction(transaction)
 
 	return transaction
 }
 
 // setTransactionAmount sets the amount field from various response formats
 func (*transactionsEntity) setTransactionAmount(transaction *models.Transaction, responseMap map[string]any) {
-	if amount, ok := responseMap["amount"].(string); ok {
-		transaction.Amount = amount
-	} else if amount, ok := responseMap["amount"].(float64); ok {
-		transaction.Amount = fmt.Sprintf("%.2f", amount)
+	if amount, ok := responseMap["amount"]; ok {
+		transaction.Amount = models.DecimalStringFromAny(amount)
 	}
 }
 
@@ -244,6 +254,8 @@ func (*transactionsEntity) setTransactionIDs(transaction *models.Transaction, re
 	transaction.OrganizationID = getString(responseMap, "organizationId")
 	transaction.LedgerID = getString(responseMap, "ledgerId")
 	transaction.Route = getString(responseMap, "route")
+	transaction.RouteID = getString(responseMap, "routeId")
+	transaction.ParentTransactionID = getString(responseMap, "parentTransactionId")
 	transaction.ChartOfAccountsGroupName = getString(responseMap, "chartOfAccountsGroupName")
 
 	if pending, ok := responseMap["pending"].(bool); ok {
@@ -302,12 +314,114 @@ func (*transactionsEntity) setTransactionTimestamps(transaction *models.Transact
 	if updatedAt, err := time.Parse(time.RFC3339, getString(responseMap, "updatedAt")); err == nil {
 		transaction.UpdatedAt = updatedAt
 	}
+
+	if deletedAt := getString(responseMap, "deletedAt"); deletedAt != "" {
+		if parsedDeletedAt, err := time.Parse(time.RFC3339, deletedAt); err == nil {
+			transaction.DeletedAt = &parsedDeletedAt
+		}
+	}
 }
 
 // setTransactionMetadata sets the metadata from response map
 func (*transactionsEntity) setTransactionMetadata(transaction *models.Transaction, responseMap map[string]any) {
 	if metadata, ok := responseMap["metadata"].(map[string]any); ok {
 		transaction.Metadata = metadata
+	}
+}
+
+func (*transactionsEntity) normalizeTransaction(transaction *models.Transaction) {
+	if transaction == nil {
+		return
+	}
+
+	if transaction.Source == nil {
+		transaction.Source = []string{}
+	}
+
+	if transaction.Destination == nil {
+		transaction.Destination = []string{}
+	}
+
+	if transaction.Operations == nil {
+		transaction.Operations = []models.Operation{}
+	}
+
+	if transaction.Metadata == nil {
+		transaction.Metadata = map[string]any{}
+	}
+
+	for i := range transaction.Operations {
+		if transaction.Operations[i].Metadata == nil {
+			transaction.Operations[i].Metadata = map[string]any{}
+		}
+	}
+}
+
+func (e *transactionsEntity) normalizeTransactionListResponse(response *models.ListResponse[models.Transaction]) {
+	if response == nil {
+		return
+	}
+
+	if response.Items == nil {
+		response.Items = []models.Transaction{}
+	}
+
+	for i := range response.Items {
+		e.normalizeTransaction(&response.Items[i])
+	}
+}
+
+func (e *transactionsEntity) setTransactionOperations(transaction *models.Transaction, responseMap map[string]any) {
+	operations, ok := responseMap["operations"].([]any)
+	if !ok {
+		return
+	}
+
+	parsedOperations := make([]models.Operation, 0, len(operations))
+	for _, item := range operations {
+		operationMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		parsedOperations = append(parsedOperations, e.parseOperation(operationMap))
+	}
+
+	transaction.Operations = parsedOperations
+}
+
+func (*transactionsEntity) parseOperation(operationMap map[string]any) models.Operation {
+	var operation models.Operation
+
+	encoded, err := json.Marshal(operationMap)
+	if err == nil {
+		if err := json.Unmarshal(encoded, &operation); err == nil {
+			if operation.Metadata == nil {
+				operation.Metadata = map[string]any{}
+			}
+
+			return operation
+		}
+	}
+
+	return models.Operation{
+		ID:               getString(operationMap, "id"),
+		TransactionID:    getString(operationMap, "transactionId"),
+		Description:      getString(operationMap, "description"),
+		Type:             getString(operationMap, "type"),
+		AssetCode:        getString(operationMap, "assetCode"),
+		ChartOfAccounts:  getString(operationMap, "chartOfAccounts"),
+		AccountID:        getString(operationMap, "accountId"),
+		AccountAlias:     getString(operationMap, "accountAlias"),
+		BalanceID:        getString(operationMap, "balanceId"),
+		BalanceKey:       getString(operationMap, "balanceKey"),
+		OrganizationID:   getString(operationMap, "organizationId"),
+		LedgerID:         getString(operationMap, "ledgerId"),
+		Route:            getString(operationMap, "route"),
+		RouteID:          getString(operationMap, "routeId"),
+		RouteCode:        getString(operationMap, "routeCode"),
+		RouteDescription: getString(operationMap, "routeDescription"),
+		Direction:        getString(operationMap, "direction"),
 	}
 }
 
@@ -353,29 +467,12 @@ func (e *transactionsEntity) CreateTransactionWithDSL(ctx context.Context, orgID
 		return nil, sdkerrors.NewMissingParameterError(operation, "ledger ID")
 	}
 
-	// Convert the DSL input to map format before sending to API
-	// Use the strongly-typed converter to include send/source/distribute, share, rate, etc.
-	transactionMap := input.ToTransactionMap()
-
-	// Use the correct endpoint for DSL transactions
-	url := e.buildURL(orgID, ledgerID, "/dsl")
-
-	body, err := json.Marshal(transactionMap)
+	dslContent, err := input.RenderDSL()
 	if err != nil {
-		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to marshal request body: %w", err))
+		return nil, sdkerrors.NewValidationError(operation, "failed to render DSL input", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
-	if err != nil {
-		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to create request: %w", err))
-	}
-
-	var transaction models.Transaction
-	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
-		return nil, err
-	}
-
-	return &transaction, nil
+	return e.CreateTransactionWithDSLFile(ctx, orgID, ledgerID, dslContent)
 }
 
 // CreateTransactionWithDSLFile creates a new transaction using a DSL file.
@@ -395,16 +492,33 @@ func (e *transactionsEntity) CreateTransactionWithDSLFile(ctx context.Context, o
 	}
 
 	// Use DSL endpoint with raw body payload
-	url := e.buildURL(orgID, ledgerID, "/dsl")
+	endpointURL := e.buildURL(orgID, ledgerID, "/dsl")
 
-	headers := map[string]string{"Content-Type": "text/plain"}
+	var body bytes.Buffer
 
-	var transaction models.Transaction
-	if err := e.httpClient.doRawRequest(ctx, http.MethodPost, url, headers, dslContent, &transaction); err != nil {
+	writer := multipart.NewWriter(&body)
+
+	part, err := writer.CreateFormFile("transaction", "transaction.dsl")
+	if err != nil {
+		return nil, sdkerrors.NewInternalError("CreateTransactionWithDSLFile", fmt.Errorf("failed to create multipart body: %w", err))
+	}
+
+	if _, err := part.Write(dslContent); err != nil {
+		return nil, sdkerrors.NewInternalError("CreateTransactionWithDSLFile", fmt.Errorf("failed to write multipart body: %w", err))
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, sdkerrors.NewInternalError("CreateTransactionWithDSLFile", fmt.Errorf("failed to finalize multipart body: %w", err))
+	}
+
+	headers := map[string]string{"Content-Type": writer.FormDataContentType()}
+
+	var responseMap map[string]any
+	if err := e.httpClient.doRawRequest(ctx, http.MethodPost, endpointURL, headers, body.Bytes(), &responseMap); err != nil {
 		return nil, err
 	}
 
-	return &transaction, nil
+	return e.parseTransactionResponse(responseMap), nil
 }
 
 func validateDSLContent(dslContent []byte) error {
@@ -414,11 +528,6 @@ func validateDSLContent(dslContent []byte) error {
 
 	if !utf8.Valid(dslContent) {
 		return errors.New("DSL content must be valid UTF-8")
-	}
-
-	content := strings.ToLower(string(dslContent))
-	if !strings.Contains(content, "send") || !strings.Contains(content, "distribute") {
-		return errors.New("DSL content missing required sections")
 	}
 
 	return nil
@@ -465,9 +574,9 @@ func (e *transactionsEntity) GetTransaction(ctx context.Context, orgID, ledgerID
 	}
 
 	// Build the URL for the transaction
-	url := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s", transactionID))
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s", transactionID))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointURL, nil)
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to create request: %w", err))
 	}
@@ -477,14 +586,15 @@ func (e *transactionsEntity) GetTransaction(ctx context.Context, orgID, ledgerID
 		return nil, err
 	}
 
+	e.normalizeTransaction(&transaction)
+
 	return &transaction, nil
 }
 
 // ListTransactions retrieves a paginated list of transactions for a ledger with optional filters.
 //
 // This method fetches a list of transactions from the specified organization and ledger,
-// with support for pagination, sorting, and filtering. The results are returned as a paginated
-// list that includes the total count and links to navigate between pages.
+// with support for cursor pagination, sorting, and filtering.
 //
 // Parameters:
 //   - ctx: Context for the request, which can be used for cancellation and timeout.
@@ -492,8 +602,8 @@ func (e *transactionsEntity) GetTransaction(ctx context.Context, orgID, ledgerID
 //   - ledgerID: The ID of the ledger to query. Must be a valid ledger ID.
 //   - opts: Optional parameters for pagination, sorting, and filtering. Can be nil for default behavior.
 //     Supported options include:
-//   - Page: The page number to retrieve (starting from 1)
-//   - PageSize: The number of items per page (default is 20)
+//   - Cursor: The cursor returned by the previous transaction list response
+//   - Limit: The number of items per page (default is 20)
 //   - Sort: The field to sort by (e.g., "created_at")
 //   - Order: The sort order ("asc" or "desc")
 //   - Filter: Additional filtering criteria as key-value pairs
@@ -523,9 +633,9 @@ func (e *transactionsEntity) ListTransactions(ctx context.Context, orgID, ledger
 	}
 
 	// Build the URL for the transactions
-	url := e.buildURL(orgID, ledgerID, "")
+	endpointURL := e.buildURL(orgID, ledgerID, "")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpointURL, nil)
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to create request: %w", err))
 	}
@@ -534,7 +644,7 @@ func (e *transactionsEntity) ListTransactions(ctx context.Context, orgID, ledger
 	if opts != nil {
 		q := req.URL.Query()
 
-		for key, value := range opts.ToQueryParams() {
+		for key, value := range transactionListQueryParams(opts) {
 			q.Add(key, value)
 		}
 
@@ -546,7 +656,56 @@ func (e *transactionsEntity) ListTransactions(ctx context.Context, orgID, ledger
 		return nil, err
 	}
 
+	e.normalizeTransactionListResponse(&response)
+
 	return &response, nil
+}
+
+func transactionListQueryParams(opts *models.ListOptions) map[string]string {
+	params := opts.ToQueryParams()
+	delete(params, models.QueryParamPage)
+
+	if opts.Cursor != "" {
+		params[models.QueryParamCursor] = opts.Cursor
+	}
+
+	return params
+}
+
+// GetTransactionsMetricsCount retrieves the count of transactions that match the supplied filters.
+func (e *transactionsEntity) GetTransactionsMetricsCount(ctx context.Context, orgID, ledgerID string, opts *models.ListOptions) (*models.MetricsCount, error) {
+	const operation = "GetTransactionsMetricsCount"
+
+	if orgID == "" {
+		return nil, sdkerrors.NewMissingParameterError(operation, "organization ID")
+	}
+
+	if ledgerID == "" {
+		return nil, sdkerrors.NewMissingParameterError(operation, "ledger ID")
+	}
+
+	endpointURL := e.buildMetricsURL(orgID, ledgerID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpointURL, nil)
+	if err != nil {
+		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to create request: %w", err))
+	}
+
+	if opts != nil {
+		q := req.URL.Query()
+		for key, value := range opts.ToQueryParams() {
+			q.Add(key, value)
+		}
+
+		req.URL.RawQuery = q.Encode()
+	}
+
+	count, err := e.httpClient.doCountRequest(ctx, http.MethodHead, req.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.MetricsCount{TransactionsCount: count}, nil
 }
 
 // UpdateTransaction updates an existing transaction.
@@ -572,14 +731,14 @@ func (e *transactionsEntity) UpdateTransaction(ctx context.Context, orgID, ledge
 	}
 
 	// Build the URL for the transaction
-	url := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s", transactionID))
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s", transactionID))
 
 	body, err := json.Marshal(input)
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to marshal request body: %w", err))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpointURL, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, fmt.Errorf("failed to create request: %w", err))
 	}
@@ -588,6 +747,8 @@ func (e *transactionsEntity) UpdateTransaction(ctx context.Context, orgID, ledge
 	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
 		return nil, err
 	}
+
+	e.normalizeTransaction(&transaction)
 
 	return &transaction, nil
 }
@@ -608,9 +769,9 @@ func (e *transactionsEntity) RevertTransaction(ctx context.Context, orgID, ledge
 		return nil, sdkerrors.NewMissingParameterError(operation, "transaction ID")
 	}
 
-	url := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/revert", transactionID))
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/revert", transactionID))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, nil)
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
@@ -619,6 +780,8 @@ func (e *transactionsEntity) RevertTransaction(ctx context.Context, orgID, ledge
 	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
 		return nil, err
 	}
+
+	e.normalizeTransaction(&transaction)
 
 	return &transaction, nil
 }
@@ -639,9 +802,9 @@ func (e *transactionsEntity) CommitTransaction(ctx context.Context, orgID, ledge
 		return nil, sdkerrors.NewMissingParameterError(operation, "transaction ID")
 	}
 
-	url := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/commit", transactionID))
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/commit", transactionID))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, nil)
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
@@ -650,6 +813,8 @@ func (e *transactionsEntity) CommitTransaction(ctx context.Context, orgID, ledge
 	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
 		return nil, err
 	}
+
+	e.normalizeTransaction(&transaction)
 
 	return &transaction, nil
 }
@@ -670,14 +835,46 @@ func (e *transactionsEntity) CancelTransaction(ctx context.Context, orgID, ledge
 		return sdkerrors.NewMissingParameterError(operation, "transaction ID")
 	}
 
-	url := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/cancel", transactionID))
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/cancel", transactionID))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
-	if err != nil {
-		return sdkerrors.NewInternalError(operation, err)
+	return e.httpClient.doRawRequest(ctx, http.MethodPost, endpointURL, nil, nil, nil)
+}
+
+// CancelTransactionWithResponse cancels a pending transaction and returns the cancelled transaction.
+func (e *transactionsEntity) CancelTransactionWithResponse(ctx context.Context, orgID, ledgerID, transactionID string) (*models.Transaction, error) {
+	const operation = "CancelTransaction"
+
+	if orgID == "" {
+		return nil, sdkerrors.NewMissingParameterError(operation, "organization ID")
 	}
 
-	return e.httpClient.sendRequest(req, nil)
+	if ledgerID == "" {
+		return nil, sdkerrors.NewMissingParameterError(operation, "ledger ID")
+	}
+
+	if transactionID == "" {
+		return nil, sdkerrors.NewMissingParameterError(operation, "transaction ID")
+	}
+
+	endpointURL := e.buildURL(orgID, ledgerID, fmt.Sprintf("/%s/cancel", transactionID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, nil)
+	if err != nil {
+		return nil, sdkerrors.NewInternalError(operation, err)
+	}
+
+	var transaction models.Transaction
+	if err := e.httpClient.sendRequest(req, &transaction); err != nil {
+		if errors.Is(err, errEmptyResponseBody) || errors.Is(err, errNullResponseBody) {
+			return nil, nil //nolint:nilnil // successful cancel endpoints may be bodyless
+		}
+
+		return nil, err
+	}
+
+	e.normalizeTransaction(&transaction)
+
+	return &transaction, nil
 }
 
 // CreateInflowTransaction creates an inflow transaction (funds entering the system).
@@ -700,14 +897,14 @@ func (e *transactionsEntity) CreateInflowTransaction(ctx context.Context, orgID,
 		return nil, sdkerrors.NewValidationError(operation, "invalid input", err)
 	}
 
-	url := e.buildURL(orgID, ledgerID, "/inflow")
+	endpointURL := e.buildURL(orgID, ledgerID, "/inflow")
 
-	body, err := json.Marshal(input)
+	body, err := json.Marshal(input.ToMap())
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
@@ -742,14 +939,14 @@ func (e *transactionsEntity) CreateOutflowTransaction(ctx context.Context, orgID
 		return nil, sdkerrors.NewValidationError(operation, "invalid input", err)
 	}
 
-	url := e.buildURL(orgID, ledgerID, "/outflow")
+	endpointURL := e.buildURL(orgID, ledgerID, "/outflow")
 
-	body, err := json.Marshal(input)
+	body, err := json.Marshal(input.ToMap())
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
@@ -784,14 +981,14 @@ func (e *transactionsEntity) CreateAnnotationTransaction(ctx context.Context, or
 		return nil, sdkerrors.NewValidationError(operation, "invalid input", err)
 	}
 
-	url := e.buildURL(orgID, ledgerID, "/annotation")
+	endpointURL := e.buildURL(orgID, ledgerID, "/annotation")
 
-	body, err := json.Marshal(input)
+	body, err := json.Marshal(input.ToLibTransaction())
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, sdkerrors.NewInternalError(operation, err)
 	}
@@ -809,7 +1006,25 @@ func (e *transactionsEntity) CreateAnnotationTransaction(ctx context.Context, or
 // buildURL builds the URL for transactions API calls with the specified suffix.
 func (e *transactionsEntity) buildURL(orgID, ledgerID, suffix string) string {
 	base := e.baseURLs["transaction"]
-	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transactions%s", base, orgID, ledgerID, suffix)
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transactions%s", base, pathSegment(orgID), pathSegment(ledgerID), escapeTransactionSuffix(suffix))
+}
+
+func (e *transactionsEntity) buildMetricsURL(orgID, ledgerID string) string {
+	base := e.baseURLs["transaction"]
+	return fmt.Sprintf("%s/organizations/%s/ledgers/%s/transactions/metrics/count", base, pathSegment(orgID), pathSegment(ledgerID))
+}
+
+func escapeTransactionSuffix(suffix string) string {
+	if suffix == "" {
+		return ""
+	}
+
+	parts := strings.Split(strings.TrimPrefix(suffix, "/"), "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+
+	return "/" + strings.Join(parts, "/")
 }
 
 // getString safely extracts a string value from a map

--- a/entities/transactions.go
+++ b/entities/transactions.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -740,9 +739,9 @@ func (e *transactionsEntity) ListTransactions(ctx context.Context, orgID, ledger
 
 func transactionListQueryParams(opts *models.ListOptions) map[string]string {
 	params := opts.ToQueryParams()
-	delete(params, models.QueryParamPage)
 
 	if opts.Cursor != "" {
+		delete(params, models.QueryParamPage)
 		params[models.QueryParamCursor] = opts.Cursor
 	}
 
@@ -1111,7 +1110,7 @@ func escapeTransactionSuffix(suffix string) string {
 
 	parts := strings.Split(strings.TrimPrefix(suffix, "/"), "/")
 	for i, part := range parts {
-		parts[i] = url.PathEscape(part)
+		parts[i] = pathSegment(part)
 	}
 
 	return "/" + strings.Join(parts, "/")

--- a/entities/transactions.go
+++ b/entities/transactions.go
@@ -511,7 +511,10 @@ func (e *transactionsEntity) CreateTransactionWithDSLFile(ctx context.Context, o
 		return nil, sdkerrors.NewInternalError("CreateTransactionWithDSLFile", fmt.Errorf("failed to finalize multipart body: %w", err))
 	}
 
-	headers := map[string]string{"Content-Type": writer.FormDataContentType()}
+	headers := map[string]string{
+		"Content-Type":             writer.FormDataContentType(),
+		"X-Midaz-Auto-Idempotency": "true",
+	}
 
 	var responseMap map[string]any
 	if err := e.httpClient.doRawRequest(ctx, http.MethodPost, endpointURL, headers, body.Bytes(), &responseMap); err != nil {
@@ -693,7 +696,7 @@ func (e *transactionsEntity) GetTransactionsMetricsCount(ctx context.Context, or
 
 	if opts != nil {
 		q := req.URL.Query()
-		for key, value := range opts.ToQueryParams() {
+		for key, value := range transactionMetricsCountQueryParams(opts) {
 			q.Add(key, value)
 		}
 
@@ -706,6 +709,16 @@ func (e *transactionsEntity) GetTransactionsMetricsCount(ctx context.Context, or
 	}
 
 	return &models.MetricsCount{TransactionsCount: count}, nil
+}
+
+func transactionMetricsCountQueryParams(opts *models.ListOptions) map[string]string {
+	params := opts.ToQueryParams()
+	delete(params, models.QueryParamPage)
+	delete(params, models.QueryParamCursor)
+	delete(params, models.QueryParamLimit)
+	delete(params, models.QueryParamOffset)
+
+	return params
 }
 
 // UpdateTransaction updates an existing transaction.
@@ -910,6 +923,7 @@ func (e *transactionsEntity) CreateInflowTransaction(ctx context.Context, orgID,
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Midaz-Auto-Idempotency", "true")
 
 	var result map[string]any
 	if err := e.httpClient.sendRequest(req, &result); err != nil {
@@ -952,6 +966,7 @@ func (e *transactionsEntity) CreateOutflowTransaction(ctx context.Context, orgID
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Midaz-Auto-Idempotency", "true")
 
 	var result map[string]any
 	if err := e.httpClient.sendRequest(req, &result); err != nil {
@@ -994,6 +1009,7 @@ func (e *transactionsEntity) CreateAnnotationTransaction(ctx context.Context, or
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Midaz-Auto-Idempotency", "true")
 
 	var result map[string]any
 	if err := e.httpClient.sendRequest(req, &result); err != nil {

--- a/entities/transactions_http_test.go
+++ b/entities/transactions_http_test.go
@@ -320,7 +320,8 @@ func TestTransactionsEntity_CancelTransaction_AllowsEmptySuccessBody(t *testing.
 
 	result, err := service.CancelTransactionWithResponse(context.Background(), "org-1", "ledger-1", "tx-1")
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	require.NotNil(t, result)
+	assert.Equal(t, "tx-1", result.ID)
 }
 
 func TestTransactionsEntity_CancelTransactionWithResponse_HTTP(t *testing.T) {

--- a/entities/transactions_http_test.go
+++ b/entities/transactions_http_test.go
@@ -1,0 +1,341 @@
+package entities
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionsEntity_CreateTransaction_HTTPRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/organizations/org%2F1/ledgers/ledger%2F1/transactions/json", r.URL.EscapedPath())
+		assert.Equal(t, "caller-key-123", r.Header.Get("X-Idempotency"))
+		assert.Empty(t, r.Header.Get("X-Midaz-Auto-Idempotency"))
+
+		var body map[string]any
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		send, ok := body["send"].(map[string]any)
+		if !assert.True(t, ok) {
+			http.Error(w, "missing send", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "100.50", send["value"])
+
+		source, ok := send["source"].(map[string]any)
+		if !assert.True(t, ok) {
+			http.Error(w, "missing source", http.StatusBadRequest)
+			return
+		}
+
+		fromItems, ok := source["from"].([]any)
+		if !assert.True(t, ok) || !assert.NotEmpty(t, fromItems) {
+			http.Error(w, "missing from", http.StatusBadRequest)
+			return
+		}
+
+		from, ok := fromItems[0].(map[string]any)
+		if !assert.True(t, ok) {
+			http.Error(w, "invalid from", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "customer:1", from["accountAlias"])
+		assert.Equal(t, "route-legacy", from["route"])
+		assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", from["routeId"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"id":"tx-1","amount":"100.50","assetCode":"USD"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	routeID := "550e8400-e29b-41d4-a716-446655440000"
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	result, err := service.CreateTransaction(context.Background(), "org/1", "ledger/1", &models.CreateTransactionInput{
+		Send: &models.SendInput{
+			Asset: "USD",
+			Value: "100.50",
+			Source: &models.SourceInput{From: []models.FromToInput{{
+				Account:      "customer:1",
+				AccountAlias: "customer:1",
+				Route:        "route-legacy",
+				RouteID:      &routeID,
+				Amount:       models.AmountInput{Asset: "USD", Value: "100.50"},
+			}}},
+			Distribute: &models.DistributeInput{To: []models.FromToInput{{
+				Account: "merchant:1",
+				Amount:  models.AmountInput{Asset: "USD", Value: "100.50"},
+			}}},
+		},
+		IdempotencyKey: "caller-key-123",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "100.50", result.Amount)
+}
+
+func TestTransactionsEntity_ListTransactions_UsesCursorPagination(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.URL.Query().Get("page"))
+		assert.Equal(t, "cursor-123", r.URL.Query().Get("cursor"))
+		assert.Equal(t, "25", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"items":[],"pagination":{"limit":25}}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	_, err := service.ListTransactions(context.Background(), "org-1", "ledger-1", models.NewListOptions().WithPage(3).WithCursor("cursor-123").WithLimit(25))
+	require.NoError(t, err)
+}
+
+func TestTransactionsEntity_CreateSpecializedTransactions_HTTPWireShape(t *testing.T) {
+	tests := []struct {
+		name          string
+		path          string
+		call          func(TransactionsService) (*models.Transaction, error)
+		assertPayload func(*testing.T, map[string]any)
+	}{
+		{
+			name: "inflow uses accountAlias in distribute",
+			path: "/organizations/org-1/ledgers/ledger-1/transactions/inflow",
+			call: func(service TransactionsService) (*models.Transaction, error) {
+				return service.CreateInflowTransaction(context.Background(), "org-1", "ledger-1", models.NewCreateInflowInput("USD", 100, &models.DistributeInput{To: []models.FromToInput{{
+					Account: "dest-account", Amount: models.AmountInput{Asset: "USD", Value: 100},
+				}}}))
+			},
+			assertPayload: func(t *testing.T, body map[string]any) {
+				t.Helper()
+
+				send, ok := body["send"].(map[string]any)
+				require.True(t, ok)
+				distribute, ok := send["distribute"].(map[string]any)
+				require.True(t, ok)
+				toItems, ok := distribute["to"].([]any)
+				require.True(t, ok)
+				require.NotEmpty(t, toItems)
+				to, ok := toItems[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "dest-account", to["accountAlias"])
+				assert.NotContains(t, to, "account")
+			},
+		},
+		{
+			name: "outflow uses accountAlias in source",
+			path: "/organizations/org-1/ledgers/ledger-1/transactions/outflow",
+			call: func(service TransactionsService) (*models.Transaction, error) {
+				return service.CreateOutflowTransaction(context.Background(), "org-1", "ledger-1", models.NewCreateOutflowInput("USD", 100, &models.SourceInput{From: []models.FromToInput{{
+					Account: "source-account", Amount: models.AmountInput{Asset: "USD", Value: 100},
+				}}}))
+			},
+			assertPayload: func(t *testing.T, body map[string]any) {
+				t.Helper()
+
+				send, ok := body["send"].(map[string]any)
+				require.True(t, ok)
+				source, ok := send["source"].(map[string]any)
+				require.True(t, ok)
+				fromItems, ok := source["from"].([]any)
+				require.True(t, ok)
+				require.NotEmpty(t, fromItems)
+				from, ok := fromItems[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "source-account", from["accountAlias"])
+				assert.NotContains(t, from, "account")
+			},
+		},
+		{
+			name: "annotation uses canonical transaction mapping",
+			path: "/organizations/org-1/ledgers/ledger-1/transactions/annotation",
+			call: func(service TransactionsService) (*models.Transaction, error) {
+				return service.CreateAnnotationTransaction(context.Background(), "org-1", "ledger-1", models.NewCreateAnnotationInput("note", &models.SendInput{
+					Asset: "USD", Value: 1,
+					Source:     &models.SourceInput{From: []models.FromToInput{{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: 1}}}},
+					Distribute: &models.DistributeInput{To: []models.FromToInput{{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: 1}}}},
+				}))
+			},
+			assertPayload: func(t *testing.T, body map[string]any) {
+				t.Helper()
+
+				send, ok := body["send"].(map[string]any)
+				require.True(t, ok)
+				source, ok := send["source"].(map[string]any)
+				require.True(t, ok)
+				fromItems, ok := source["from"].([]any)
+				require.True(t, ok)
+				require.NotEmpty(t, fromItems)
+				from, ok := fromItems[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "source", from["accountAlias"])
+				assert.NotContains(t, from, "account")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.path, r.URL.EscapedPath())
+
+				var body map[string]any
+				if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&body)) {
+					http.Error(w, "invalid request body", http.StatusBadRequest)
+					return
+				}
+
+				tt.assertPayload(t, body)
+				w.Header().Set("Content-Type", "application/json")
+				_, err := w.Write([]byte(`{"id":"tx-1","amount":"100","assetCode":"USD"}`))
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+
+			service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+			result, err := tt.call(service)
+			require.NoError(t, err)
+			assert.Equal(t, "tx-1", result.ID)
+		})
+	}
+}
+
+func TestTransactionsEntity_CreateTransaction_ParsesOperationFinancialFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"id":"tx-1",
+			"amount":"100",
+			"assetCode":"USD",
+			"operations":[{
+				"id":"op-1",
+				"type":"debit",
+				"assetCode":"USD",
+				"amount":{"value":"100"},
+				"balance":{"available":"900","onHold":"0"},
+				"balanceAfter":{"available":"800","onHold":"0"},
+				"status":{"code":"APPROVED"}
+			}]
+		}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	result, err := service.CreateTransaction(context.Background(), "org-1", "ledger-1", &models.CreateTransactionInput{
+		Send: &models.SendInput{
+			Asset: "USD", Value: 100,
+			Source:     &models.SourceInput{From: []models.FromToInput{{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: 100}}}},
+			Distribute: &models.DistributeInput{To: []models.FromToInput{{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: 100}}}},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Operations, 1)
+	require.NotNil(t, result.Operations[0].Amount.Value)
+	require.NotNil(t, result.Operations[0].Balance.Available)
+	require.NotNil(t, result.Operations[0].BalanceAfter.Available)
+	assert.Equal(t, "100", result.Operations[0].Amount.Value.String())
+	assert.Equal(t, "900", result.Operations[0].Balance.Available.String())
+	assert.Equal(t, "800", result.Operations[0].BalanceAfter.Available.String())
+	assert.Equal(t, "APPROVED", result.Operations[0].Status.Code)
+}
+
+func TestTransactionsEntity_CreateTransactionWithDSLFile_HTTPMultipart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/organizations/org-1/ledgers/ledger-1/transactions/dsl", r.URL.EscapedPath())
+
+		mediaType := r.Header.Get("Content-Type")
+		if !assert.True(t, strings.HasPrefix(mediaType, "multipart/form-data; boundary=")) {
+			http.Error(w, "invalid content type", http.StatusBadRequest)
+			return
+		}
+
+		reader, err := r.MultipartReader()
+		if !assert.NoError(t, err) {
+			http.Error(w, "invalid multipart", http.StatusBadRequest)
+			return
+		}
+
+		part, err := reader.NextPart()
+		if !assert.NoError(t, err) {
+			http.Error(w, "missing multipart part", http.StatusBadRequest)
+			return
+		}
+
+		defer func() {
+			assert.NoError(t, part.Close())
+		}()
+
+		assert.Equal(t, "transaction", part.FormName())
+		assert.Equal(t, "transaction.dsl", part.FileName())
+
+		payload, err := io.ReadAll(part)
+		if !assert.NoError(t, err) {
+			http.Error(w, "invalid multipart payload", http.StatusBadRequest)
+			return
+		}
+
+		assert.Equal(t, "(transaction V1)", string(payload))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"id":"tx-dsl","amount":"1","assetCode":"USD"}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	result, err := service.CreateTransactionWithDSLFile(context.Background(), "org-1", "ledger-1", []byte("(transaction V1)"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "tx-dsl", result.ID)
+}
+
+func TestTransactionsEntity_CancelTransaction_AllowsEmptySuccessBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/organizations/org-1/ledgers/ledger-1/transactions/tx-1/cancel", r.URL.EscapedPath())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	err := service.CancelTransaction(context.Background(), "org-1", "ledger-1", "tx-1")
+	require.NoError(t, err)
+
+	result, err := service.CancelTransactionWithResponse(context.Background(), "org-1", "ledger-1", "tx-1")
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestTransactionsEntity_CancelTransactionWithResponse_HTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/organizations/org-1/ledgers/ledger-1/transactions/tx-1/cancel", r.URL.EscapedPath())
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"id":"tx-1","amount":"100","assetCode":"USD","status":{"code":"CANCELED"}}`))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	service := NewTransactionsEntity(server.Client(), "token", map[string]string{"transaction": server.URL})
+	result, err := service.CancelTransactionWithResponse(context.Background(), "org-1", "ledger-1", "tx-1")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "tx-1", result.ID)
+	assert.Equal(t, "CANCELED", result.Status.Code)
+}

--- a/entities/transactions_http_test.go
+++ b/entities/transactions_http_test.go
@@ -91,6 +91,7 @@ func TestTransactionsEntity_CreateTransaction_HTTPRequest(t *testing.T) {
 func TestTransactionsEntity_ListTransactions_UsesCursorPagination(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(t, r.URL.Query().Get("page"))
+		assert.Empty(t, r.URL.Query().Get("offset"))
 		assert.Equal(t, "cursor-123", r.URL.Query().Get("cursor"))
 		assert.Equal(t, "25", r.URL.Query().Get("limit"))
 		w.Header().Set("Content-Type", "application/json")

--- a/entities/transactions_test.go
+++ b/entities/transactions_test.go
@@ -1027,11 +1027,10 @@ func TestTransactionInputValidation(t *testing.T) {
 	})
 
 	t.Run("CreateAnnotationInput validation", func(t *testing.T) {
-		// Test empty description
+		// Annotation-only transactions do not require send details.
 		input := &models.CreateAnnotationInput{Description: ""}
 		err := input.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "send is required")
+		require.NoError(t, err)
 
 		// Test valid input
 		input = models.NewCreateAnnotationInput("Test annotation", createValidSendInput("USD", 1))
@@ -1094,7 +1093,7 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 		}
 		err := input.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "value must be greater than 0")
+		assert.Contains(t, err.Error(), "value must be greater than zero")
 	})
 
 	t.Run("Missing source", func(t *testing.T) {

--- a/entities/transactions_test.go
+++ b/entities/transactions_test.go
@@ -15,6 +15,21 @@ import (
 
 // ========== Test Data Helpers ==========
 
+func createValidSendInput(asset string, value float64) *models.SendInput {
+	return &models.SendInput{
+		Asset: asset,
+		Value: value,
+		Source: &models.SourceInput{From: []models.FromToInput{{
+			Account: "source-account",
+			Amount:  models.AmountInput{Asset: asset, Value: value},
+		}}},
+		Distribute: &models.DistributeInput{To: []models.FromToInput{{
+			Account: "dest-account",
+			Amount:  models.AmountInput{Asset: asset, Value: value},
+		}}},
+	}
+}
+
 func createTestTransaction(id, orgID, ledgerID, assetCode, amount, statusCode string) *models.Transaction {
 	return &models.Transaction{
 		ID:             id,
@@ -54,20 +69,18 @@ func createTestTransactionList(orgID, ledgerID string) *models.ListResponse[mode
 
 func createTestTransactionInput() *models.CreateTransactionInput {
 	return &models.CreateTransactionInput{
-		AssetCode:   "USD",
-		Amount:      "100",
 		Description: "Test payment",
 		Send: &models.SendInput{
 			Asset: "USD",
-			Value: "100",
+			Value: 100,
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
-					{Account: "source-account", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "source-account", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
-					{Account: "dest-account", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "dest-account", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 		},
@@ -79,7 +92,7 @@ func createTestDSLInput() *models.TransactionDSLInput {
 		Description: "DSL Transaction",
 		Send: &models.DSLSend{
 			Asset: "USD",
-			Value: "100",
+			Value: 100,
 			Source: &models.DSLSource{
 				From: []models.DSLFromTo{{Account: "source-account"}},
 			},
@@ -582,6 +595,14 @@ func TestCancelTransaction(t *testing.T) {
 	err := mockService.CancelTransaction(ctx, orgID, ledgerID, transactionID)
 	require.NoError(t, err)
 
+	mockService.EXPECT().
+		CancelTransactionWithResponse(gomock.Any(), orgID, ledgerID, transactionID).
+		Return(&models.Transaction{ID: transactionID}, nil)
+
+	transaction, err := mockService.CancelTransactionWithResponse(ctx, orgID, ledgerID, transactionID)
+	require.NoError(t, err)
+	require.NotNil(t, transaction)
+
 	// Test empty organization ID
 	mockService.EXPECT().
 		CancelTransaction(gomock.Any(), "", ledgerID, transactionID).
@@ -712,9 +733,9 @@ func TestCreateInflowTransaction(t *testing.T) {
 	orgID := "org-123"
 	ledgerID := "ledger-456"
 
-	input := models.NewCreateInflowInput("USD", "100", &models.DistributeInput{
+	input := models.NewCreateInflowInput("USD", 100, &models.DistributeInput{
 		To: []models.FromToInput{
-			{Account: "dest-account", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "dest-account", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 		},
 	}).WithDescription("Deposit")
 
@@ -771,9 +792,9 @@ func TestCreateOutflowTransaction(t *testing.T) {
 	orgID := "org-123"
 	ledgerID := "ledger-456"
 
-	input := models.NewCreateOutflowInput("USD", "100", &models.SourceInput{
+	input := models.NewCreateOutflowInput("USD", 100, &models.SourceInput{
 		From: []models.FromToInput{
-			{Account: "source-account", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "source-account", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 		},
 	}).WithDescription("Withdrawal")
 
@@ -830,7 +851,7 @@ func TestCreateAnnotationTransaction(t *testing.T) {
 	orgID := "org-123"
 	ledgerID := "ledger-456"
 
-	input := models.NewCreateAnnotationInput("Annotation note").
+	input := models.NewCreateAnnotationInput("Annotation note", createValidSendInput("USD", 1)).
 		WithCode("ANN-001").
 		WithMetadata(map[string]any{"type": "note"})
 
@@ -875,56 +896,34 @@ func TestCreateAnnotationTransaction(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "input is required")
 
-	// Test empty description validation
+	// Test current CreateTransactionInput validation reused by annotations.
 	invalidInput := &models.CreateAnnotationInput{Description: ""}
 	mockService.EXPECT().
 		CreateAnnotationTransaction(gomock.Any(), orgID, ledgerID, invalidInput).
-		Return(nil, errors.New("description is required"))
+		Return(nil, errors.New("send is required"))
 
 	_, err = mockService.CreateAnnotationTransaction(ctx, orgID, ledgerID, invalidInput)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "description is required")
+	assert.Contains(t, err.Error(), "send is required")
 }
 
 // ========== TestTransactionInputValidation ==========
 
 func TestTransactionInputValidation(t *testing.T) {
 	t.Run("CreateTransactionInput validation", func(t *testing.T) {
-		// Test empty amount
-		input := &models.CreateTransactionInput{
-			AssetCode: "USD",
-			Amount:    "",
-		}
+		// Test missing send
+		input := &models.CreateTransactionInput{}
 		err := input.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "amount")
+		assert.Contains(t, err.Error(), "send is required")
 
-		// Test zero amount
+		// Test invalid send
 		input = &models.CreateTransactionInput{
-			AssetCode: "USD",
-			Amount:    "0",
+			Send: &models.SendInput{Asset: "USD"},
 		}
 		err = input.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "amount")
-
-		// Test empty asset code
-		input = &models.CreateTransactionInput{
-			AssetCode: "",
-			Amount:    "100",
-		}
-		err = input.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "assetCode")
-
-		// Test missing operations and send
-		input = &models.CreateTransactionInput{
-			AssetCode: "USD",
-			Amount:    "100",
-		}
-		err = input.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "operations or send")
+		assert.Contains(t, err.Error(), "invalid send")
 	})
 
 	t.Run("UpdateTransactionInput validation", func(t *testing.T) {
@@ -957,7 +956,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		// Test empty asset
 		input = &models.CreateInflowInput{
 			Send: &models.SendInflowInput{
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err = input.Validate()
@@ -968,7 +967,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		input = &models.CreateInflowInput{
 			Send: &models.SendInflowInput{
 				Asset: "USD",
-				Value: "0",
+				Value: 0,
 			},
 		}
 		err = input.Validate()
@@ -979,7 +978,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		input = &models.CreateInflowInput{
 			Send: &models.SendInflowInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err = input.Validate()
@@ -997,7 +996,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		// Test empty asset
 		input = &models.CreateOutflowInput{
 			Send: &models.SendOutflowInput{
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err = input.Validate()
@@ -1008,7 +1007,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		input = &models.CreateOutflowInput{
 			Send: &models.SendOutflowInput{
 				Asset: "USD",
-				Value: "0",
+				Value: 0,
 			},
 		}
 		err = input.Validate()
@@ -1019,7 +1018,7 @@ func TestTransactionInputValidation(t *testing.T) {
 		input = &models.CreateOutflowInput{
 			Send: &models.SendOutflowInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err = input.Validate()
@@ -1032,10 +1031,10 @@ func TestTransactionInputValidation(t *testing.T) {
 		input := &models.CreateAnnotationInput{Description: ""}
 		err := input.Validate()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "description is required")
+		assert.Contains(t, err.Error(), "send is required")
 
 		// Test valid input
-		input = models.NewCreateAnnotationInput("Test annotation")
+		input = models.NewCreateAnnotationInput("Test annotation", createValidSendInput("USD", 1))
 		err = input.Validate()
 		require.NoError(t, err)
 	})
@@ -1046,10 +1045,11 @@ func TestTransactionInputValidation(t *testing.T) {
 func TestTransactionDSLInputValidation(t *testing.T) {
 	t.Run("Valid DSL input", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
-			Description: "Test DSL transaction",
+			ChartOfAccountsGroupName: "TRANSFERS",
+			Description:              "Test DSL transaction",
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.DSLSource{
 					From: []models.DSLFromTo{{Account: "source"}},
 				},
@@ -1064,7 +1064,8 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Nil send", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
-			Description: "Test",
+			ChartOfAccountsGroupName: "TRANSFERS",
+			Description:              "Test",
 		}
 		err := input.Validate()
 		require.Error(t, err)
@@ -1073,8 +1074,9 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Empty asset", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
+			ChartOfAccountsGroupName: "TRANSFERS",
 			Send: &models.DSLSend{
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err := input.Validate()
@@ -1084,9 +1086,10 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Zero value", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
+			ChartOfAccountsGroupName: "TRANSFERS",
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "0",
+				Value: 0,
 			},
 		}
 		err := input.Validate()
@@ -1096,9 +1099,10 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Missing source", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
+			ChartOfAccountsGroupName: "TRANSFERS",
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 			},
 		}
 		err := input.Validate()
@@ -1108,9 +1112,10 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Empty source from", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
+			ChartOfAccountsGroupName: "TRANSFERS",
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.DSLSource{
 					From: []models.DSLFromTo{},
 				},
@@ -1123,9 +1128,10 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 
 	t.Run("Missing distribute", func(t *testing.T) {
 		input := &models.TransactionDSLInput{
+			ChartOfAccountsGroupName: "TRANSFERS",
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.DSLSource{
 					From: []models.DSLFromTo{{Account: "source"}},
 				},
@@ -1143,10 +1149,11 @@ func TestTransactionDSLInputValidation(t *testing.T) {
 		}
 
 		input := &models.TransactionDSLInput{
-			Description: longDesc,
+			ChartOfAccountsGroupName: "TRANSFERS",
+			Description:              longDesc,
 			Send: &models.DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.DSLSource{
 					From: []models.DSLFromTo{{Account: "source"}},
 				},
@@ -1173,15 +1180,15 @@ func TestTransactionMapConversion(t *testing.T) {
 			Metadata:                 map[string]any{"key": "value"},
 			Send: &models.SendInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{
-						{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+						{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 					},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{
-						{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: "100"}},
+						{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: 100}},
 					},
 				},
 			},
@@ -1206,7 +1213,7 @@ func TestTransactionMapConversion(t *testing.T) {
 			Metadata:                 map[string]any{"type": "transfer"},
 			Send: &models.DSLSend{
 				Asset: "EUR",
-				Value: "500",
+				Value: 500,
 				Source: &models.DSLSource{
 					From: []models.DSLFromTo{{Account: "source-acc"}},
 				},
@@ -1242,23 +1249,23 @@ func TestTransactionMapConversion(t *testing.T) {
 
 func TestTransactionBuilderMethods(t *testing.T) {
 	t.Run("CreateTransactionInput builder", func(t *testing.T) {
-		input := models.NewCreateTransactionInput("USD", "100").
+		input := models.NewCreateTransactionInput("USD", 100).
 			WithDescription("Test payment").
 			WithMetadata(map[string]any{"key": "value"}).
 			WithExternalID("ext-123").
 			WithSend(&models.SendInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &models.SourceInput{
-					From: []models.FromToInput{{Account: "src", Amount: models.AmountInput{Asset: "USD", Value: "100"}}},
+					From: []models.FromToInput{{Account: "src", Amount: models.AmountInput{Asset: "USD", Value: 100}}},
 				},
 				Distribute: &models.DistributeInput{
-					To: []models.FromToInput{{Account: "dst", Amount: models.AmountInput{Asset: "USD", Value: "100"}}},
+					To: []models.FromToInput{{Account: "dst", Amount: models.AmountInput{Asset: "USD", Value: 100}}},
 				},
 			})
 
-		assert.Equal(t, "USD", input.AssetCode)
-		assert.Equal(t, "100", input.Amount)
+		assert.Equal(t, "USD", input.Send.Asset)
+		assert.Equal(t, 100, input.Send.Value)
 		assert.Equal(t, "Test payment", input.Description)
 		assert.Equal(t, "ext-123", input.ExternalID)
 		assert.NotNil(t, input.Metadata)
@@ -1277,8 +1284,8 @@ func TestTransactionBuilderMethods(t *testing.T) {
 	})
 
 	t.Run("CreateInflowInput builder", func(t *testing.T) {
-		input := models.NewCreateInflowInput("USD", "100", &models.DistributeInput{
-			To: []models.FromToInput{{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: "100"}}},
+		input := models.NewCreateInflowInput("USD", 100, &models.DistributeInput{
+			To: []models.FromToInput{{Account: "dest", Amount: models.AmountInput{Asset: "USD", Value: 100}}},
 		}).
 			WithDescription("Deposit").
 			WithCode("DEP-001").
@@ -1294,8 +1301,8 @@ func TestTransactionBuilderMethods(t *testing.T) {
 	})
 
 	t.Run("CreateOutflowInput builder", func(t *testing.T) {
-		input := models.NewCreateOutflowInput("USD", "100", &models.SourceInput{
-			From: []models.FromToInput{{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: "100"}}},
+		input := models.NewCreateOutflowInput("USD", 100, &models.SourceInput{
+			From: []models.FromToInput{{Account: "source", Amount: models.AmountInput{Asset: "USD", Value: 100}}},
 		}).
 			WithDescription("Withdrawal").
 			WithCode("WTH-001").
@@ -1311,10 +1318,10 @@ func TestTransactionBuilderMethods(t *testing.T) {
 	})
 
 	t.Run("CreateAnnotationInput builder", func(t *testing.T) {
-		input := models.NewCreateAnnotationInput("Note").
+		input := models.NewCreateAnnotationInput("Note", createValidSendInput("USD", 1)).
 			WithCode("NOTE-001").
-			WithMetadata(map[string]any{"type": "comment"}).
-			WithChartOfAccountsGroupName("annotations")
+			WithMetadata(map[string]any{"type": "comment"})
+		input.ChartOfAccountsGroupName = "annotations"
 
 		assert.Equal(t, "Note", input.Description)
 		assert.Equal(t, "NOTE-001", input.Code)

--- a/entities/url.go
+++ b/entities/url.go
@@ -1,0 +1,14 @@
+package entities
+
+import "net/url"
+
+func pathSegment(value string) string {
+	switch value {
+	case ".":
+		return "%2E"
+	case "..":
+		return "%2E%2E"
+	}
+
+	return url.PathEscape(value)
+}

--- a/examples/access-manager-example/main.go
+++ b/examples/access-manager-example/main.go
@@ -85,8 +85,7 @@ func buildOrganizationInput() *models.CreateOrganizationInput {
 	description := "Ledger Test"
 	line2 := "CJ 203"
 
-	return models.NewCreateOrganizationInput("Acme Corporation", "123456789012345").
-		WithLegalDocument("78425230000190").
+	return models.NewCreateOrganizationInput("Acme Corporation", "78425230000190").
 		WithDoingBusinessAs("The ledger.io").
 		WithStatus(models.Status{
 			Code:        "ACTIVE",

--- a/examples/access-manager-example/main.go
+++ b/examples/access-manager-example/main.go
@@ -85,7 +85,7 @@ func buildOrganizationInput() *models.CreateOrganizationInput {
 	description := "Ledger Test"
 	line2 := "CJ 203"
 
-	return models.NewCreateOrganizationInput("Acme Corporation").
+	return models.NewCreateOrganizationInput("Acme Corporation", "123456789012345").
 		WithLegalDocument("78425230000190").
 		WithDoingBusinessAs("The ledger.io").
 		WithStatus(models.Status{

--- a/examples/clean-transaction/main.go
+++ b/examples/clean-transaction/main.go
@@ -32,8 +32,6 @@ func main() {
 	c, err := client.New(
 		client.WithEnvironment(config.EnvironmentLocal),
 		client.WithObservabilityProvider(observabilityProvider),
-		client.WithOnboardingURL("http://localhost:3000/v1"),
-		client.WithTransactionURL("http://localhost:3001/v1"),
 		client.UseAllAPIs(),
 	)
 	if err != nil {
@@ -64,14 +62,14 @@ func createDSLTransaction(ctx context.Context, txService entities.TransactionsSe
 		},
 		Send: &models.DSLSend{
 			Asset: "USD",
-			Value: "100.00", // $100.00
+			Value: 100.00, // $100.00
 			Source: &models.DSLSource{
 				From: []models.DSLFromTo{
 					{
 						Account: "account123",
 						Amount: &models.DSLAmount{
 							Asset: "USD",
-							Value: "100.00", // $100.00
+							Value: 100.00, // $100.00
 						},
 					},
 				},
@@ -82,7 +80,7 @@ func createDSLTransaction(ctx context.Context, txService entities.TransactionsSe
 						Account: "account456",
 						Amount: &models.DSLAmount{
 							Asset: "USD",
-							Value: "100.00", // $100.00
+							Value: 100.00, // $100.00
 						},
 					},
 				},

--- a/examples/mass-demo-generator/main.go
+++ b/examples/mass-demo-generator/main.go
@@ -637,10 +637,14 @@ func processAccountTransactions(ctx context.Context, c *client.Client, state *wo
 	}
 
 	if state.demoConfig.txPerAccountVal > 0 {
-		fmt.Printf("Previewing first transaction for ledger %s\n", ledger.ID)
-		if payloadData, err := json.MarshalIndent(inputs[0].ToLibTransaction(), "", "  "); err == nil {
-			fmt.Println(string(payloadData))
-		}
+		first := inputs[0]
+		fmt.Printf("Previewing first transaction for ledger %s: asset=%s amount=%v sources=%d destinations=%d\n",
+			ledger.ID,
+			first.Send.Asset,
+			first.Send.Value,
+			len(first.Send.Source.From),
+			len(first.Send.Distribute.To),
+		)
 	}
 
 	options := txpkg.DefaultBatchOptions()
@@ -698,8 +702,6 @@ func buildAccountTransactions(state *workflowState, accounts []*models.Account, 
 
 			tx := &models.CreateTransactionInput{
 				Description:              fmt.Sprintf("Demo funding for %s #%d", alias, sequence),
-				Amount:                   amountStr,
-				AssetCode:                state.demoConfig.assetCodeVal,
 				ChartOfAccountsGroupName: state.demoConfig.chartGroupVal,
 				IdempotencyKey:           fmt.Sprintf("demo-%s-%05d", account.ID, sequence),
 				Send: &models.SendInput{

--- a/examples/tracing-example/main.go
+++ b/examples/tracing-example/main.go
@@ -96,7 +96,7 @@ func createOrganizationWithTracing(midazClient *client.Client, provider observab
 	}
 
 	// Create organization input
-	orgInput := models.NewCreateOrganizationInput("Example Corp").
+	orgInput := models.NewCreateOrganizationInput("Example Corp", "123456789012345").
 		WithAddress(models.Address{
 			Line1:   "123 Main St",
 			City:    "San Francisco",

--- a/examples/tracing-server-example/main.go
+++ b/examples/tracing-server-example/main.go
@@ -258,8 +258,9 @@ func (s *Server) createOrganization(ctx context.Context, w http.ResponseWriter, 
 
 	// Parse request body
 	var reqBody struct {
-		LegalName string         `json:"legal_name"`
-		Metadata  map[string]any `json:"metadata,omitempty"`
+		LegalName     string         `json:"legal_name"`
+		LegalDocument string         `json:"legal_document"`
+		Metadata      map[string]any `json:"metadata,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
@@ -277,7 +278,7 @@ func (s *Server) createOrganization(ctx context.Context, w http.ResponseWriter, 
 	logger.Info("Creating organization", "legal_name", sanitizeLogInput(reqBody.LegalName)) // lgtm[go/log-injection]
 
 	// Create organization through Midaz client
-	orgInput := models.NewCreateOrganizationInput(reqBody.LegalName)
+	orgInput := models.NewCreateOrganizationInput(reqBody.LegalName, reqBody.LegalDocument)
 	if reqBody.Metadata != nil {
 		orgInput = orgInput.WithMetadata(reqBody.Metadata)
 	}

--- a/examples/tracing-server-example/main.go
+++ b/examples/tracing-server-example/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	client "github.com/LerianStudio/midaz-sdk-golang/v2"
@@ -267,6 +268,12 @@ func (s *Server) createOrganization(ctx context.Context, w http.ResponseWriter, 
 		span.SetStatus(codes.Error, "Invalid request body")
 		span.RecordError(err)
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if strings.TrimSpace(reqBody.LegalName) == "" || strings.TrimSpace(reqBody.LegalDocument) == "" {
+		span.SetStatus(codes.Error, "Missing required fields")
+		http.Error(w, "legal_name and legal_document are required", http.StatusBadRequest)
 		return
 	}
 

--- a/examples/tracing-server-example/main.go
+++ b/examples/tracing-server-example/main.go
@@ -277,6 +277,9 @@ func (s *Server) createOrganization(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
+	reqBody.LegalName = strings.TrimSpace(reqBody.LegalName)
+	reqBody.LegalDocument = strings.TrimSpace(reqBody.LegalDocument)
+
 	span.SetAttributes(
 		attribute.String("organization.legal_name", reqBody.LegalName),
 	)

--- a/examples/workflow-with-entities/main.go
+++ b/examples/workflow-with-entities/main.go
@@ -30,8 +30,8 @@
 //
 //	MIDAZ_AUTH_TOKEN=example-auth-token
 //	MIDAZ_ENVIRONMENT=local  # Can be local, development, or production
-//	MIDAZ_ONBOARDING_URL=http://localhost:3000/v1 # Optional override
-//	MIDAZ_TRANSACTION_URL=http://localhost:3001/v1 # Optional override
+//	MIDAZ_ONBOARDING_URL=http://localhost:3002/v1 # Optional override
+//	MIDAZ_TRANSACTION_URL=http://localhost:3002/v1 # Optional override
 //	MIDAZ_DEBUG=true # Optional, enables detailed API logging
 //
 // # Workflow Steps

--- a/examples/workflow-with-entities/pkg/entities/organizations.go
+++ b/examples/workflow-with-entities/pkg/entities/organizations.go
@@ -42,7 +42,7 @@ func CreateOrganization(ctx context.Context, service entities.OrganizationsServi
 	description := "Organization created"
 
 	// Create input using builder pattern
-	input := models.NewCreateOrganizationInput("Acme Corporation").
+	input := models.NewCreateOrganizationInput("Acme Corporation", "123456789012345").
 		WithDoingBusinessAs(dba).
 		WithLegalDocument("123456789").
 		WithStatus(models.Status{

--- a/examples/workflow-with-entities/pkg/entities/organizations.go
+++ b/examples/workflow-with-entities/pkg/entities/organizations.go
@@ -42,9 +42,8 @@ func CreateOrganization(ctx context.Context, service entities.OrganizationsServi
 	description := "Organization created"
 
 	// Create input using builder pattern
-	input := models.NewCreateOrganizationInput("Acme Corporation", "123456789012345").
+	input := models.NewCreateOrganizationInput("Acme Corporation", "123456789").
 		WithDoingBusinessAs(dba).
-		WithLegalDocument("123456789").
 		WithStatus(models.Status{
 			Code:        "ACTIVE",
 			Description: &description,

--- a/examples/workflow-with-entities/pkg/entities/transactions.go
+++ b/examples/workflow-with-entities/pkg/entities/transactions.go
@@ -117,6 +117,10 @@ func resolveSourceAccountAlias(ctx context.Context, entity *entities.Entity, org
 }
 
 func resolveDestinationAccountAlias(ctx context.Context, entity *entities.Entity, orgID, ledgerID, destAccountID string) (string, error) {
+	if strings.HasPrefix(destAccountID, "@external/") {
+		return destAccountID, nil
+	}
+
 	destAccount, err := entity.Accounts.GetAccount(ctx, orgID, ledgerID, destAccountID)
 	if err != nil {
 		return "", fmt.Errorf("failed to get destination account: %w", err)

--- a/examples/workflow-with-entities/pkg/entities/transactions.go
+++ b/examples/workflow-with-entities/pkg/entities/transactions.go
@@ -5,6 +5,7 @@ package entities
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -68,57 +69,84 @@ func TransferFunds(
 	amount string,
 	description string,
 ) (*models.Transaction, error) {
-	// Determine if source is an external account
-	isExternalSource := strings.HasPrefix(sourceAccountID, "@external/")
-
-	// Get source account alias - for external accounts, use the ID directly
-	sourceAccountAlias := sourceAccountID
-
-	// For internal accounts, get the account details to use the alias
-	// Use the account alias if available, otherwise use the ID as alias
-	if !isExternalSource {
-		sourceAccount, err := entity.Accounts.GetAccount(ctx, orgID, ledgerID, sourceAccountID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get source account: %w", err)
-		}
-
-		if sourceAccount.Alias != nil {
-			sourceAccountAlias = *sourceAccount.Alias
-		}
+	if err := requireTransactionEntity(entity); err != nil {
+		return nil, err
 	}
 
-	// Get destination account alias
-	destAccountAlias := destAccountID
+	amountValue, err := strconv.ParseFloat(amount, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount format: %w", err)
+	}
+
+	sourceAccountAlias, err := resolveSourceAccountAlias(ctx, entity, orgID, ledgerID, sourceAccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	destAccountAlias, err := resolveDestinationAccountAlias(ctx, entity, orgID, ledgerID, destAccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	input := newTransferFundsInput(sourceAccountAlias, destAccountAlias, assetCode, amountValue, description)
+
+	// Create the transaction
+	tx, err := entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to transfer funds: %w", err)
+	}
+
+	return tx, nil
+}
+
+func resolveSourceAccountAlias(ctx context.Context, entity *entities.Entity, orgID, ledgerID, sourceAccountID string) (string, error) {
+	if strings.HasPrefix(sourceAccountID, "@external/") {
+		return sourceAccountID, nil
+	}
+
+	sourceAccount, err := entity.Accounts.GetAccount(ctx, orgID, ledgerID, sourceAccountID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get source account: %w", err)
+	}
+
+	if sourceAccount.Alias != nil {
+		return *sourceAccount.Alias, nil
+	}
+
+	return sourceAccountID, nil
+}
+
+func resolveDestinationAccountAlias(ctx context.Context, entity *entities.Entity, orgID, ledgerID, destAccountID string) (string, error) {
 	destAccount, err := entity.Accounts.GetAccount(ctx, orgID, ledgerID, destAccountID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get destination account: %w", err)
+		return "", fmt.Errorf("failed to get destination account: %w", err)
 	}
 
-	// Use the account alias if available, otherwise use the ID as alias
 	if destAccount.Alias != nil {
-		destAccountAlias = *destAccount.Alias
+		return *destAccount.Alias, nil
 	}
 
-	// Create a transaction using the new format that matches the backend's expectations
-	input := &models.CreateTransactionInput{
+	return destAccountID, nil
+}
+
+func newTransferFundsInput(sourceAccountAlias, destAccountAlias, assetCode string, amountValue float64, description string) *models.CreateTransactionInput {
+	return &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "default_chart_group", // Required by API specification
 		Description:              description,
-		Amount:                   amount,
-		AssetCode:                assetCode,
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "transfer",
 		},
 		Send: &models.SendInput{
 			Asset: assetCode,
-			Value: amount,
+			Value: amountValue,
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
 						Account: sourceAccountAlias,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amount,
+							Value: amountValue,
 						},
 					},
 				},
@@ -129,7 +157,7 @@ func TransferFunds(
 						Account: destAccountAlias,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amount,
+							Value: amountValue,
 						},
 					},
 				},
@@ -137,14 +165,14 @@ func TransferFunds(
 		},
 		IdempotencyKey: uuid.New().String(),
 	}
+}
 
-	// Create the transaction
-	tx, err := entity.Transactions.CreateTransaction(ctx, orgID, ledgerID, input)
-	if err != nil {
-		return nil, fmt.Errorf("failed to transfer funds: %w", err)
+func requireTransactionEntity(entity *entities.Entity) error {
+	if entity == nil || entity.Accounts == nil || entity.Transactions == nil {
+		return errors.New("initialized entity with accounts and transactions services is required")
 	}
 
-	return tx, nil
+	return nil
 }
 
 // ExecuteTransferWithHelper transfers funds from one account to another using the transaction helpers
@@ -170,6 +198,9 @@ func ExecuteTransferWithHelper(
 	amount string,
 	assetCode string,
 ) (*models.Transaction, error) {
+	if midazClient == nil || midazClient.Entity == nil {
+		return nil, errors.New("initialized client entity is required")
+	}
 	// Use the Transaction helper from the SDK
 	transferOptions := &transaction.TransferOptions{
 		Description: "Payment using SDK helper",
@@ -231,6 +262,9 @@ func ExecuteDepositWithHelper(
 	amount string,
 	assetCode string,
 ) (*models.Transaction, error) {
+	if midazClient == nil || midazClient.Entity == nil {
+		return nil, errors.New("initialized client entity is required")
+	}
 	// Use the Deposit helper from the SDK
 	depositOptions := &transaction.DepositOptions{
 		Description: "Deposit using SDK helper",
@@ -291,6 +325,9 @@ func ExecuteWithdrawalWithHelper(
 	amount string,
 	assetCode string,
 ) (*models.Transaction, error) {
+	if midazClient == nil || midazClient.Entity == nil {
+		return nil, errors.New("initialized client entity is required")
+	}
 	// Use the Withdrawal helper from the SDK
 	withdrawalOptions := &transaction.WithdrawalOptions{
 		Description: "Withdrawal using SDK helper",
@@ -353,6 +390,9 @@ func ExecuteMultiAccountTransferWithHelper(
 	totalAmount string,
 	assetCode string,
 ) (*models.Transaction, error) {
+	if midazClient == nil || midazClient.Entity == nil {
+		return nil, errors.New("initialized client entity is required")
+	}
 	// Use the MultiAccountTransfer helper from the SDK
 	multiTransferOptions := &transaction.MultiTransferOptions{
 		Description: "Multi-account transfer using SDK helper",

--- a/examples/workflow-with-entities/pkg/workflows/organization.go
+++ b/examples/workflow-with-entities/pkg/workflows/organization.go
@@ -29,7 +29,7 @@ func CreateOrganization(ctx context.Context, midazClient *client.Client) (string
 	// Get plugin auth configuration from environment variables
 
 	organization, err := midazClient.Entity.Organizations.CreateOrganization(ctx,
-		models.NewCreateOrganizationInput("Example Corp").
+		models.NewCreateOrganizationInput("Example Corp", "123456789012345").
 			WithDoingBusinessAs("Example Corp DBA").
 			WithLegalDocument("123456789").
 			WithAddress(models.Address{

--- a/examples/workflow-with-entities/pkg/workflows/organization.go
+++ b/examples/workflow-with-entities/pkg/workflows/organization.go
@@ -29,9 +29,8 @@ func CreateOrganization(ctx context.Context, midazClient *client.Client) (string
 	// Get plugin auth configuration from environment variables
 
 	organization, err := midazClient.Entity.Organizations.CreateOrganization(ctx,
-		models.NewCreateOrganizationInput("Example Corp", "123456789012345").
+		models.NewCreateOrganizationInput("Example Corp", "123456789").
 			WithDoingBusinessAs("Example Corp DBA").
-			WithLegalDocument("123456789").
 			WithAddress(models.Address{
 				Country: "US",
 			}).

--- a/examples/workflow-with-entities/pkg/workflows/transaction.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction.go
@@ -62,11 +62,31 @@ func formatTransactionAmount(tx *models.Transaction) string {
 	return format.FormatCurrency(amount.Mul(decimal.NewFromInt(100)).IntPart(), 2, tx.AssetCode)
 }
 
-func accountIdentifier(account *models.Account) string {
+func accountIdentifier(account *models.Account) (string, error) {
 	if account == nil {
-		return ""
+		return "", errors.New("account is required")
 	}
-	return models.GetAccountIdentifier(*account)
+
+	identifier := models.GetAccountIdentifier(*account)
+	if identifier == "" {
+		return "", errors.New("account identifier is required")
+	}
+
+	return identifier, nil
+}
+
+func accountIdentifiers(customerAccount, merchantAccount *models.Account) (customerAccountID, merchantAccountID string, err error) {
+	customerAccountID, err = accountIdentifier(customerAccount)
+	if err != nil {
+		return "", "", err
+	}
+
+	merchantAccountID, err = accountIdentifier(merchantAccount)
+	if err != nil {
+		return "", "", err
+	}
+
+	return customerAccountID, merchantAccountID, nil
 }
 
 func operationRouteID(route *models.OperationRoute) string {
@@ -96,6 +116,12 @@ func executeInitialDeposit(ctx context.Context, midazClient *client.Client, orgI
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, err := accountIdentifier(customerAccount)
+	if err != nil {
+		return err
+	}
+
 	amount := 5000.00
 
 	input := &models.CreateTransactionInput{
@@ -123,8 +149,8 @@ func executeInitialDeposit(ctx context.Context, midazClient *client.Client, orgI
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      accountIdentifier(customerAccount),
-						AccountAlias: accountIdentifier(customerAccount),
+						Account:      customerAccountID,
+						AccountAlias: customerAccountID,
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -152,6 +178,12 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	amount := 10.00
 
 	input := &models.CreateTransactionInput{
@@ -167,8 +199,8 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      accountIdentifier(customerAccount),
-						AccountAlias: accountIdentifier(customerAccount),
+						Account:      customerAccountID,
+						AccountAlias: customerAccountID,
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -179,8 +211,8 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      accountIdentifier(merchantAccount),
-						AccountAlias: accountIdentifier(merchantAccount),
+						Account:      merchantAccountID,
+						AccountAlias: merchantAccountID,
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -275,6 +307,12 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, err := accountIdentifier(customerAccount)
+	if err != nil {
+		return err
+	}
+
 	amount := 5000.00
 
 	input := &models.CreateTransactionInput{
@@ -304,8 +342,8 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      accountIdentifier(customerAccount),
-						AccountAlias: accountIdentifier(customerAccount),
+						Account:      customerAccountID,
+						AccountAlias: customerAccountID,
 						Route:        operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{
 							Asset: "USD",
@@ -350,6 +388,12 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	amount := 10.00
 
 	input := &models.CreateTransactionInput{
@@ -366,8 +410,8 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      accountIdentifier(customerAccount),
-						AccountAlias: accountIdentifier(customerAccount),
+						Account:      customerAccountID,
+						AccountAlias: customerAccountID,
 						Route:        operationRouteID(destinationOperationRoute), // Customer account uses destination route
 						Amount: models.AmountInput{
 							Asset: "USD",
@@ -379,8 +423,8 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      accountIdentifier(merchantAccount),
-						AccountAlias: accountIdentifier(merchantAccount),
+						Account:      merchantAccountID,
+						AccountAlias: merchantAccountID,
 						Route:        operationRouteID(destinationOperationRoute), // Merchant account also uses destination route
 						Amount: models.AmountInput{
 							Asset: "USD",
@@ -500,15 +544,27 @@ func executeParallelTransactionsWithRoutes(ctx context.Context, midazClient *cli
 
 func createParallelTransactionProcessor(midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute, amounts []float64) func(context.Context, int) (*models.Transaction, error) {
 	clientErr := requireTransactionsClient(midazClient)
+	customerAccountID, customerErr := accountIdentifier(customerAccount)
+	merchantAccountID, merchantErr := accountIdentifier(merchantAccount)
+
 	return func(ctx context.Context, index int) (*models.Transaction, error) {
 		if clientErr != nil {
 			return nil, clientErr
 		}
+
+		if customerErr != nil {
+			return nil, customerErr
+		}
+
+		if merchantErr != nil {
+			return nil, merchantErr
+		}
+
 		txCtx, txSpan := observability.StartSpan(ctx, "ProcessParallelTransaction")
 		defer txSpan.End()
 
 		amount := amounts[index]
-		input := buildParallelTransactionInput(index, amount, customerAccount, merchantAccount, destinationOperationRoute, transactionRoute)
+		input := buildParallelTransactionInput(index, amount, customerAccountID, merchantAccountID, destinationOperationRoute, transactionRoute)
 
 		tx, err := midazClient.Entity.Transactions.CreateTransaction(txCtx, orgID, ledgerID, input)
 		if err != nil {
@@ -519,7 +575,7 @@ func createParallelTransactionProcessor(midazClient *client.Client, orgID, ledge
 	}
 }
 
-func buildParallelTransactionInput(index int, amount float64, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) *models.CreateTransactionInput {
+func buildParallelTransactionInput(index int, amount float64, customerAccountID, merchantAccountID string, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) *models.CreateTransactionInput {
 	var routeID string
 	if transactionRoute != nil {
 		routeID = transactionRouteID(transactionRoute)
@@ -546,8 +602,8 @@ func buildParallelTransactionInput(index int, amount float64, customerAccount, m
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      accountIdentifier(customerAccount),
-						AccountAlias: accountIdentifier(customerAccount),
+						Account:      customerAccountID,
+						AccountAlias: customerAccountID,
 						Route:        destRouteID,
 						Amount:       models.AmountInput{Asset: "USD", Value: amount},
 					},
@@ -556,12 +612,38 @@ func buildParallelTransactionInput(index int, amount float64, customerAccount, m
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      accountIdentifier(merchantAccount),
-						AccountAlias: accountIdentifier(merchantAccount),
+						Account:      merchantAccountID,
+						AccountAlias: merchantAccountID,
 						Route:        destRouteID,
 						Amount:       models.AmountInput{Asset: "USD", Value: amount},
 					},
 				},
+			},
+		},
+		IdempotencyKey: uuid.New().String(),
+	}
+}
+
+func buildOptimizedTransferInput(chartGroup, description, routeID, customerAccountID, merchantAccountID, destinationRouteID string, amount float64) *models.CreateTransactionInput {
+	return &models.CreateTransactionInput{
+		ChartOfAccountsGroupName: chartGroup,
+		Description:              description,
+		Route:                    routeID,
+		Send: &models.SendInput{
+			Asset: "USD", Value: amount,
+			Source: &models.SourceInput{
+				From: []models.FromToInput{{
+					Account: customerAccountID, AccountAlias: customerAccountID,
+					Route:  destinationRouteID,
+					Amount: models.AmountInput{Asset: "USD", Value: amount},
+				}},
+			},
+			Distribute: &models.DistributeInput{
+				To: []models.FromToInput{{
+					Account: merchantAccountID, AccountAlias: merchantAccountID,
+					Route:  destinationRouteID,
+					Amount: models.AmountInput{Asset: "USD", Value: amount},
+				}},
 			},
 		},
 		IdempotencyKey: uuid.New().String(),
@@ -649,6 +731,12 @@ func demonstrateHighWorkerCount(ctx context.Context, midazClient *client.Client,
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	transactionCount := 20
 	amounts := make([]float64, transactionCount)
 
@@ -671,14 +759,14 @@ func demonstrateHighWorkerCount(ctx context.Context, midazClient *client.Client,
 				Value: amounts[index],
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Account: customerAccountID, AccountAlias: customerAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amounts[index]},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Account: merchantAccountID, AccountAlias: merchantAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amounts[index]},
 					}},
@@ -722,6 +810,12 @@ func demonstrateConnectionPooling(ctx context.Context, midazClient *client.Clien
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	// Apply performance optimizations
 	perfOptions := performance.Options{
 		EnableHTTPPooling:   true,
@@ -748,14 +842,14 @@ func demonstrateConnectionPooling(ctx context.Context, midazClient *client.Clien
 				Asset: "USD", Value: amount,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Account: customerAccountID, AccountAlias: customerAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Account: merchantAccountID, AccountAlias: merchantAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
@@ -798,34 +892,26 @@ func demonstrateBatchProcessing(ctx context.Context, midazClient *client.Client,
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	transactionCount := 30
 	transactionInputs := make([]*models.CreateTransactionInput, transactionCount)
 
 	for i := 0; i < transactionCount; i++ {
 		amount := 0.05
-		transactionInputs[i] = &models.CreateTransactionInput{
-			ChartOfAccountsGroupName: "batch-transfers",
-			Description:              fmt.Sprintf("Batch transfer #%d", i+1),
-			Route:                    transactionRouteID(transactionRoute),
-			Send: &models.SendInput{
-				Asset: "USD", Value: amount,
-				Source: &models.SourceInput{
-					From: []models.FromToInput{{
-						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
-						Route:  operationRouteID(destinationOperationRoute),
-						Amount: models.AmountInput{Asset: "USD", Value: amount},
-					}},
-				},
-				Distribute: &models.DistributeInput{
-					To: []models.FromToInput{{
-						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
-						Route:  operationRouteID(destinationOperationRoute),
-						Amount: models.AmountInput{Asset: "USD", Value: amount},
-					}},
-				},
-			},
-			IdempotencyKey: uuid.New().String(),
-		}
+		transactionInputs[i] = buildOptimizedTransferInput(
+			"batch-transfers",
+			fmt.Sprintf("Batch transfer #%d", i+1),
+			transactionRouteID(transactionRoute),
+			customerAccountID,
+			merchantAccountID,
+			operationRouteID(destinationOperationRoute),
+			amount,
+		)
 	}
 
 	batchSize := performance.GetOptimalBatchSize(transactionCount, 10) // Max 10 per batch
@@ -886,6 +972,12 @@ func demonstrateCombinedOptimizations(ctx context.Context, midazClient *client.C
 	if err := requireTransactionsClient(midazClient); err != nil {
 		return err
 	}
+
+	customerAccountID, merchantAccountID, err := accountIdentifiers(customerAccount, merchantAccount)
+	if err != nil {
+		return err
+	}
+
 	// Apply all performance optimizations
 	perfOptions := performance.Options{
 		EnableHTTPPooling:   true,
@@ -912,14 +1004,14 @@ func demonstrateCombinedOptimizations(ctx context.Context, midazClient *client.C
 				Asset: "USD", Value: amount,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Account: customerAccountID, AccountAlias: customerAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Account: merchantAccountID, AccountAlias: merchantAccountID,
 						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},

--- a/examples/workflow-with-entities/pkg/workflows/transaction.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction.go
@@ -2,8 +2,8 @@ package workflows
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	client "github.com/LerianStudio/midaz-sdk-golang/v2"
@@ -13,12 +13,16 @@ import (
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/observability"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/performance"
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 // ExecuteTransactions executes various transactions between accounts
 func ExecuteTransactions(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account) error {
 	ctx, span := observability.StartSpan(ctx, "ExecuteTransactions")
 	defer span.End()
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
 
 	fmt.Println("\n\n💸 STEP 5: TRANSACTION EXECUTION")
 	fmt.Println("=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=" + "=")
@@ -45,15 +49,58 @@ func ExecuteTransactions(ctx context.Context, midazClient *client.Client, orgID,
 	return nil
 }
 
+func formatTransactionAmount(tx *models.Transaction) string {
+	if tx == nil {
+		return format.FormatCurrency(0, 2, "")
+	}
+
+	amount, err := decimal.NewFromString(tx.Amount)
+	if err != nil {
+		return tx.Amount + " " + tx.AssetCode
+	}
+
+	return format.FormatCurrency(amount.Mul(decimal.NewFromInt(100)).IntPart(), 2, tx.AssetCode)
+}
+
+func accountIdentifier(account *models.Account) string {
+	if account == nil {
+		return ""
+	}
+	return models.GetAccountIdentifier(*account)
+}
+
+func operationRouteID(route *models.OperationRoute) string {
+	if route == nil {
+		return ""
+	}
+	return route.ID.String()
+}
+
+func transactionRouteID(route *models.TransactionRoute) string {
+	if route == nil {
+		return ""
+	}
+	return route.ID.String()
+}
+
+func requireTransactionsClient(midazClient *client.Client) error {
+	if midazClient == nil || midazClient.Entity == nil || midazClient.Entity.Transactions == nil {
+		return errors.New("initialized client with transactions service is required")
+	}
+
+	return nil
+}
+
 // executeInitialDeposit performs initial deposit from external account
 func executeInitialDeposit(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount *models.Account, externalAccountID string) error {
-	amount := "5000.00"
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
+	amount := 5000.00
 
 	input := &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "external-deposits",
 		Description:              "Initial deposit from external account",
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "deposit",
@@ -76,8 +123,8 @@ func executeInitialDeposit(ctx context.Context, midazClient *client.Client, orgI
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      *customerAccount.Alias,
-						AccountAlias: *customerAccount.Alias,
+						Account:      accountIdentifier(customerAccount),
+						AccountAlias: accountIdentifier(customerAccount),
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -94,27 +141,22 @@ func executeInitialDeposit(ctx context.Context, midazClient *client.Client, orgI
 		return fmt.Errorf("failed to create deposit transaction: %w", err)
 	}
 
-	// Parse amount for formatting
-	amountFloat, err := strconv.ParseFloat(tx.Amount, 64)
-	if err != nil {
-		fmt.Printf("✅ Deposit completed: %s (ID: %s)\n", tx.Amount, tx.ID)
-	} else {
-		formattedAmount := format.FormatCurrency(int64(amountFloat*100), 2, tx.AssetCode)
-		fmt.Printf("✅ Deposit completed: %s (ID: %s)\n", formattedAmount, tx.ID)
-	}
+	formattedAmount := formatTransactionAmount(tx)
+	fmt.Printf("✅ Deposit completed: %s (ID: %s)\n", formattedAmount, tx.ID)
 
 	return nil
 }
 
 // executeTransfer performs transfer between two accounts
 func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account) error {
-	amount := "10.00"
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
+	amount := 10.00
 
 	input := &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "transfer-transactions",
 		Description:              "Payment for services",
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "transfer",
@@ -125,8 +167,8 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      *customerAccount.Alias,
-						AccountAlias: *customerAccount.Alias,
+						Account:      accountIdentifier(customerAccount),
+						AccountAlias: accountIdentifier(customerAccount),
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -137,8 +179,8 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      *merchantAccount.Alias,
-						AccountAlias: *merchantAccount.Alias,
+						Account:      accountIdentifier(merchantAccount),
+						AccountAlias: accountIdentifier(merchantAccount),
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -155,14 +197,8 @@ func executeTransfer(ctx context.Context, midazClient *client.Client, orgID, led
 		return fmt.Errorf("failed to create transfer transaction: %w", err)
 	}
 
-	// Parse amount for formatting
-	amountFloat, err := strconv.ParseFloat(tx.Amount, 64)
-	if err != nil {
-		fmt.Printf("✅ Transfer completed: %s (ID: %s)\n", tx.Amount, tx.ID)
-	} else {
-		formattedAmount := format.FormatCurrency(int64(amountFloat*100), 2, tx.AssetCode)
-		fmt.Printf("✅ Transfer completed: %s (ID: %s)\n", formattedAmount, tx.ID)
-	}
+	formattedAmount := formatTransactionAmount(tx)
+	fmt.Printf("✅ Transfer completed: %s (ID: %s)\n", formattedAmount, tx.ID)
 
 	return nil
 }
@@ -194,6 +230,15 @@ func ExecuteWithdrawals(_ context.Context, _ *client.Client, _, _ string, _, _ *
 // ExecuteTransactionsWithRoutes executes transactions using routes
 func ExecuteTransactionsWithRoutes(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, sourceOperationRoute, destinationOperationRoute *models.OperationRoute, paymentTransactionRoute, _ *models.TransactionRoute) error {
 	fmt.Println("\n🔀 Executing transactions with routes")
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
+	if customerAccount == nil || merchantAccount == nil {
+		return errors.New("customer and merchant accounts are required")
+	}
+	if sourceOperationRoute == nil || destinationOperationRoute == nil {
+		return errors.New("source and destination operation routes are required")
+	}
 
 	// Get external account ID
 	externalAccountID := "@external/USD"
@@ -227,13 +272,14 @@ func ExecuteTransactionsWithRoutes(ctx context.Context, midazClient *client.Clie
 
 // executeInitialDepositWithRoutes performs initial deposit using transaction and operation routes
 func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount *models.Account, externalAccountID string, sourceOperationRoute, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
-	amount := "5000.00"
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
+	amount := 5000.00
 
 	input := &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "external-deposits",
 		Description:              "Initial deposit from external account using routes",
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source":    "go-sdk-example",
 			"type":      "deposit",
@@ -247,7 +293,7 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 					{
 						Account:      externalAccountID,
 						AccountAlias: externalAccountID,
-						Route:        sourceOperationRoute.ID.String(),
+						Route:        operationRouteID(sourceOperationRoute),
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -258,9 +304,9 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      *customerAccount.Alias,
-						AccountAlias: *customerAccount.Alias,
-						Route:        destinationOperationRoute.ID.String(),
+						Account:      accountIdentifier(customerAccount),
+						AccountAlias: accountIdentifier(customerAccount),
+						Route:        operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -274,8 +320,8 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 
 	// Add transaction route if available
 	if transactionRoute != nil {
-		input.Route = transactionRoute.ID.String()
-		input.Metadata["transactionRouteID"] = transactionRoute.ID.String()
+		input.Route = transactionRouteID(transactionRoute)
+		input.Metadata["transactionRouteID"] = transactionRouteID(transactionRoute)
 		input.Metadata["transactionRouteTitle"] = transactionRoute.Title
 	}
 
@@ -285,20 +331,15 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 	}
 
 	// Parse amount for formatting
-	amountFloat, parseErr := strconv.ParseFloat(tx.Amount, 64)
-	if parseErr != nil {
-		fmt.Printf("✅ Deposit with routes completed: %s (ID: %s)\n", tx.Amount, tx.ID)
-	} else {
-		formattedAmount := format.FormatCurrency(int64(amountFloat*100), 2, tx.AssetCode)
-		fmt.Printf("✅ Deposit with routes completed: %s (ID: %s)\n", formattedAmount, tx.ID)
-	}
+	formattedAmount := formatTransactionAmount(tx)
+	fmt.Printf("✅ Deposit with routes completed: %s (ID: %s)\n", formattedAmount, tx.ID)
 
 	if sourceOperationRoute != nil && destinationOperationRoute != nil {
 		fmt.Printf("   📍 Used routes: %s → %s\n", sourceOperationRoute.Title, destinationOperationRoute.Title)
 	}
 
 	if transactionRoute != nil {
-		fmt.Printf("   🗺️  Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRoute.ID.String())
+		fmt.Printf("   🗺️  Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRouteID(transactionRoute))
 	}
 
 	return nil
@@ -306,13 +347,14 @@ func executeInitialDepositWithRoutes(ctx context.Context, midazClient *client.Cl
 
 // executeTransferWithRoutes performs transfer using transaction and operation routes
 func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, sourceOperationRoute, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
-	amount := "10.00"
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
+	amount := 10.00
 
 	input := &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "transfer-transactions",
 		Description:              "Payment for services using routes",
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source":    "go-sdk-example",
 			"type":      "transfer",
@@ -324,9 +366,9 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      *customerAccount.Alias,
-						AccountAlias: *customerAccount.Alias,
-						Route:        destinationOperationRoute.ID.String(), // Customer account uses destination route
+						Account:      accountIdentifier(customerAccount),
+						AccountAlias: accountIdentifier(customerAccount),
+						Route:        operationRouteID(destinationOperationRoute), // Customer account uses destination route
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -337,9 +379,9 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      *merchantAccount.Alias,
-						AccountAlias: *merchantAccount.Alias,
-						Route:        destinationOperationRoute.ID.String(), // Merchant account also uses destination route
+						Account:      accountIdentifier(merchantAccount),
+						AccountAlias: accountIdentifier(merchantAccount),
+						Route:        operationRouteID(destinationOperationRoute), // Merchant account also uses destination route
 						Amount: models.AmountInput{
 							Asset: "USD",
 							Value: amount,
@@ -353,8 +395,8 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 
 	// Add transaction route if available
 	if transactionRoute != nil {
-		input.Route = transactionRoute.ID.String()
-		input.Metadata["transactionRouteID"] = transactionRoute.ID.String()
+		input.Route = transactionRouteID(transactionRoute)
+		input.Metadata["transactionRouteID"] = transactionRouteID(transactionRoute)
 		input.Metadata["transactionRouteTitle"] = transactionRoute.Title
 	}
 
@@ -364,32 +406,25 @@ func executeTransferWithRoutes(ctx context.Context, midazClient *client.Client, 
 	}
 
 	// Parse amount for formatting
-	amountFloat, parseErr := strconv.ParseFloat(tx.Amount, 64)
-	if parseErr != nil {
-		fmt.Printf("✅ Transfer with routes completed: %s (ID: %s)\n", tx.Amount, tx.ID)
-	} else {
-		formattedAmount := format.FormatCurrency(int64(amountFloat*100), 2, tx.AssetCode)
-		fmt.Printf("✅ Transfer with routes completed: %s (ID: %s)\n", formattedAmount, tx.ID)
-	}
+	formattedAmount := formatTransactionAmount(tx)
+	fmt.Printf("✅ Transfer with routes completed: %s (ID: %s)\n", formattedAmount, tx.ID)
 
 	if sourceOperationRoute != nil && destinationOperationRoute != nil {
 		fmt.Printf("   📍 Used operation routes: %s → %s\n", sourceOperationRoute.Title, destinationOperationRoute.Title)
 	}
 
 	if transactionRoute != nil {
-		fmt.Printf("   🗺️  Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRoute.ID.String())
+		fmt.Printf("   🗺️  Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRouteID(transactionRoute))
 	}
 
 	return nil
 }
 
 // CreateTransferInput creates a transfer transaction input
-func CreateTransferInput(description string, amount string, fromAccountID, toAccountID string, index int) *models.CreateTransactionInput {
+func CreateTransferInput(description string, amount float64, fromAccountID, toAccountID string, index int) *models.CreateTransactionInput {
 	return &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "transfer-transactions",
 		Description:              description,
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "transfer",
@@ -433,7 +468,7 @@ func executeParallelTransactionsWithRoutes(ctx context.Context, midazClient *cli
 	defer span.End()
 
 	transactionCount := 5
-	amounts := []string{"1.00", "2.00", "3.00", "4.00", "5.00"}
+	amounts := []float64{1.00, 2.00, 3.00, 4.00, 5.00}
 
 	fmt.Printf("   Creating %d parallel transactions with routes...\n", transactionCount)
 
@@ -463,8 +498,12 @@ func executeParallelTransactionsWithRoutes(ctx context.Context, midazClient *cli
 	return firstError
 }
 
-func createParallelTransactionProcessor(midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute, amounts []string) func(context.Context, int) (*models.Transaction, error) {
+func createParallelTransactionProcessor(midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute, amounts []float64) func(context.Context, int) (*models.Transaction, error) {
+	clientErr := requireTransactionsClient(midazClient)
 	return func(ctx context.Context, index int) (*models.Transaction, error) {
+		if clientErr != nil {
+			return nil, clientErr
+		}
 		txCtx, txSpan := observability.StartSpan(ctx, "ProcessParallelTransaction")
 		defer txSpan.End()
 
@@ -480,22 +519,20 @@ func createParallelTransactionProcessor(midazClient *client.Client, orgID, ledge
 	}
 }
 
-func buildParallelTransactionInput(index int, amount string, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) *models.CreateTransactionInput {
+func buildParallelTransactionInput(index int, amount float64, customerAccount, merchantAccount *models.Account, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) *models.CreateTransactionInput {
 	var routeID string
 	if transactionRoute != nil {
-		routeID = transactionRoute.ID.String()
+		routeID = transactionRouteID(transactionRoute)
 	}
 
 	var destRouteID string
 	if destinationOperationRoute != nil {
-		destRouteID = destinationOperationRoute.ID.String()
+		destRouteID = operationRouteID(destinationOperationRoute)
 	}
 
 	return &models.CreateTransactionInput{
 		ChartOfAccountsGroupName: "parallel-transfers",
 		Description:              fmt.Sprintf("Parallel transfer #%d with routes", index+1),
-		Amount:                   amount,
-		AssetCode:                "USD",
 		Route:                    routeID,
 		Metadata: map[string]any{
 			"source":    "go-sdk-example-parallel",
@@ -509,8 +546,8 @@ func buildParallelTransactionInput(index int, amount string, customerAccount, me
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
-						Account:      *customerAccount.Alias,
-						AccountAlias: *customerAccount.Alias,
+						Account:      accountIdentifier(customerAccount),
+						AccountAlias: accountIdentifier(customerAccount),
 						Route:        destRouteID,
 						Amount:       models.AmountInput{Asset: "USD", Value: amount},
 					},
@@ -519,8 +556,8 @@ func buildParallelTransactionInput(index int, amount string, customerAccount, me
 			Distribute: &models.DistributeInput{
 				To: []models.FromToInput{
 					{
-						Account:      *merchantAccount.Alias,
-						AccountAlias: *merchantAccount.Alias,
+						Account:      accountIdentifier(merchantAccount),
+						AccountAlias: accountIdentifier(merchantAccount),
 						Route:        destRouteID,
 						Amount:       models.AmountInput{Asset: "USD", Value: amount},
 					},
@@ -551,13 +588,8 @@ func processTransactionResults(results []concurrent.Result[int, *models.Transact
 }
 
 func printTransactionResult(index int, tx *models.Transaction) {
-	amountFloat, parseErr := strconv.ParseFloat(tx.Amount, 64)
-	if parseErr != nil {
-		fmt.Printf("   Transaction #%d completed: %s (ID: %s)\n", index, tx.Amount, tx.ID)
-	} else {
-		formattedAmount := format.FormatCurrency(int64(amountFloat*100), 2, tx.AssetCode)
-		fmt.Printf("   Transaction #%d completed: %s (ID: %s)\n", index, formattedAmount, tx.ID)
-	}
+	formattedAmount := formatTransactionAmount(tx)
+	fmt.Printf("   Transaction #%d completed: %s (ID: %s)\n", index, formattedAmount, tx.ID)
 }
 
 func printParallelMetrics(successCount, transactionCount int, duration time.Duration) {
@@ -573,7 +605,7 @@ func printParallelMetrics(successCount, transactionCount int, duration time.Dura
 func printRouteInfo(transactionRoute *models.TransactionRoute, sourceOperationRoute, destinationOperationRoute *models.OperationRoute) {
 	if transactionRoute != nil && sourceOperationRoute != nil && destinationOperationRoute != nil {
 		fmt.Printf("   Used routes:\n")
-		fmt.Printf("      - Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRoute.ID.String())
+		fmt.Printf("      - Transaction Route: %s (%s)\n", transactionRoute.Title, transactionRouteID(transactionRoute))
 		fmt.Printf("      - Operation Routes: %s -> %s\n", sourceOperationRoute.Title, destinationOperationRoute.Title)
 	}
 }
@@ -613,14 +645,15 @@ func executeHighTPSTransactions(ctx context.Context, midazClient *client.Client,
 }
 
 // demonstrateHighWorkerCount shows increased TPS with more workers
-//
-//nolint:unparam // Error return kept for API consistency in examples
 func demonstrateHighWorkerCount(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, _ /* sourceOperationRoute */, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
 	transactionCount := 20
-	amounts := make([]string, transactionCount)
+	amounts := make([]float64, transactionCount)
 
 	for i := 0; i < transactionCount; i++ {
-		amounts[i] = "0.10" // Small amounts for speed
+		amounts[i] = 0.10 // Small amounts for speed
 	}
 
 	indices := make([]int, transactionCount)
@@ -632,23 +665,21 @@ func demonstrateHighWorkerCount(ctx context.Context, midazClient *client.Client,
 		input := &models.CreateTransactionInput{
 			ChartOfAccountsGroupName: "high-worker-transfers",
 			Description:              fmt.Sprintf("High-worker transfer #%d", index+1),
-			Amount:                   amounts[index],
-			AssetCode:                "USD",
-			Route:                    transactionRoute.ID.String(),
+			Route:                    transactionRouteID(transactionRoute),
 			Send: &models.SendInput{
 				Asset: "USD",
 				Value: amounts[index],
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: *customerAccount.Alias, AccountAlias: *customerAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
+						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amounts[index]},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: *merchantAccount.Alias, AccountAlias: *merchantAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
+						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Route:  operationRouteID(destinationOperationRoute),
 						Amount: models.AmountInput{Asset: "USD", Value: amounts[index]},
 					}},
 				},
@@ -687,9 +718,10 @@ func demonstrateHighWorkerCount(ctx context.Context, midazClient *client.Client,
 
 // demonstrateConnectionPooling shows HTTP connection pool optimization
 // demonstrateConnectionPooling demonstrates optimized connection pooling
-//
-//nolint:unparam // Error return kept for API consistency in examples
 func demonstrateConnectionPooling(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, _ /* sourceOperationRoute */, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
 	// Apply performance optimizations
 	perfOptions := performance.Options{
 		EnableHTTPPooling:   true,
@@ -707,26 +739,25 @@ func demonstrateConnectionPooling(ctx context.Context, midazClient *client.Clien
 	}
 
 	processTransaction := func(ctx context.Context, index int) (*models.Transaction, error) {
+		amount := 0.15
 		input := &models.CreateTransactionInput{
 			ChartOfAccountsGroupName: "pooled-transfers",
 			Description:              fmt.Sprintf("Pooled transfer #%d", index+1),
-			Amount:                   "0.15",
-			AssetCode:                "USD",
-			Route:                    transactionRoute.ID.String(),
+			Route:                    transactionRouteID(transactionRoute),
 			Send: &models.SendInput{
-				Asset: "USD", Value: "0.15",
+				Asset: "USD", Value: amount,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: *customerAccount.Alias, AccountAlias: *customerAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.15"},
+						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: *merchantAccount.Alias, AccountAlias: *merchantAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.15"},
+						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 			},
@@ -763,33 +794,33 @@ func demonstrateConnectionPooling(ctx context.Context, midazClient *client.Clien
 
 // demonstrateBatchProcessing shows optimal batch processing
 // demonstrateBatchProcessing demonstrates batch processing optimization
-//
-//nolint:unparam // Error return kept for API consistency in examples
 func demonstrateBatchProcessing(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, _ /* sourceOperationRoute */, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
 	transactionCount := 30
 	transactionInputs := make([]*models.CreateTransactionInput, transactionCount)
 
 	for i := 0; i < transactionCount; i++ {
+		amount := 0.05
 		transactionInputs[i] = &models.CreateTransactionInput{
 			ChartOfAccountsGroupName: "batch-transfers",
 			Description:              fmt.Sprintf("Batch transfer #%d", i+1),
-			Amount:                   "0.05",
-			AssetCode:                "USD",
-			Route:                    transactionRoute.ID.String(),
+			Route:                    transactionRouteID(transactionRoute),
 			Send: &models.SendInput{
-				Asset: "USD", Value: "0.05",
+				Asset: "USD", Value: amount,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: *customerAccount.Alias, AccountAlias: *customerAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.05"},
+						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: *merchantAccount.Alias, AccountAlias: *merchantAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.05"},
+						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 			},
@@ -851,9 +882,10 @@ func demonstrateBatchProcessing(ctx context.Context, midazClient *client.Client,
 
 // demonstrateCombinedOptimizations shows all optimizations combined for maximum TPS
 // demonstrateCombinedOptimizations demonstrates all performance optimizations combined
-//
-//nolint:unparam // Error return kept for API consistency in examples
 func demonstrateCombinedOptimizations(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *models.Account, _ /* sourceOperationRoute */, destinationOperationRoute *models.OperationRoute, transactionRoute *models.TransactionRoute) error {
+	if err := requireTransactionsClient(midazClient); err != nil {
+		return err
+	}
 	// Apply all performance optimizations
 	perfOptions := performance.Options{
 		EnableHTTPPooling:   true,
@@ -871,26 +903,25 @@ func demonstrateCombinedOptimizations(ctx context.Context, midazClient *client.C
 	}
 
 	processTransaction := func(ctx context.Context, index int) (*models.Transaction, error) {
+		amount := 0.01
 		input := &models.CreateTransactionInput{
 			ChartOfAccountsGroupName: "optimized-transfers",
 			Description:              fmt.Sprintf("Optimized transfer #%d", index+1),
-			Amount:                   "0.01", // Minimal amount for speed
-			AssetCode:                "USD",
-			Route:                    transactionRoute.ID.String(),
+			Route:                    transactionRouteID(transactionRoute),
 			Send: &models.SendInput{
-				Asset: "USD", Value: "0.01",
+				Asset: "USD", Value: amount,
 				Source: &models.SourceInput{
 					From: []models.FromToInput{{
-						Account: *customerAccount.Alias, AccountAlias: *customerAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.01"},
+						Account: accountIdentifier(customerAccount), AccountAlias: accountIdentifier(customerAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 				Distribute: &models.DistributeInput{
 					To: []models.FromToInput{{
-						Account: *merchantAccount.Alias, AccountAlias: *merchantAccount.Alias,
-						Route:  destinationOperationRoute.ID.String(),
-						Amount: models.AmountInput{Asset: "USD", Value: "0.01"},
+						Account: accountIdentifier(merchantAccount), AccountAlias: accountIdentifier(merchantAccount),
+						Route:  operationRouteID(destinationOperationRoute),
+						Amount: models.AmountInput{Asset: "USD", Value: amount},
 					}},
 				},
 			},

--- a/examples/workflow-with-entities/pkg/workflows/transaction_concurrent.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction_concurrent.go
@@ -107,15 +107,15 @@ func runConcurrentTransactionBatch(ctx context.Context, label, spanName string, 
 	defer batchSpan.End()
 
 	if err := execute(batchCtx); err != nil {
-		observability.RecordError(ctx, err, errorEvent)
+		observability.RecordError(batchCtx, err, errorEvent)
 		return err
 	}
 
 	duration := time.Since(startTime)
 	tps := float64(count) / duration.Seconds()
 
-	observability.RecordSpanMetric(ctx, metricPrefix+"_transaction_duration_seconds", duration.Seconds())
-	observability.RecordSpanMetric(ctx, metricPrefix+"_transactions_per_second", tps)
+	observability.RecordSpanMetric(batchCtx, metricPrefix+"_transaction_duration_seconds", duration.Seconds())
+	observability.RecordSpanMetric(batchCtx, metricPrefix+"_transactions_per_second", tps)
 
 	fmt.Printf(" Completed %d %s transactions in %.2f seconds (%.2f TPS)\n\n", count, label, duration.Seconds(), tps)
 

--- a/examples/workflow-with-entities/pkg/workflows/transaction_concurrent.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction_concurrent.go
@@ -52,16 +52,34 @@ func ExecuteConcurrentTransactions(ctx context.Context, midazClient *client.Clie
 	defer span.End()
 
 	fmt.Println("\n Executing concurrent transactions for TPS testing...")
+	if err := validateConcurrentTransactionAccounts(ctx, customerAccount, merchantAccount); err != nil {
+		return err
+	}
 
-	// Record transaction parameters in observability
-	observability.AddAttribute(ctx, "organization_id", orgID)
-	observability.AddAttribute(ctx, "ledger_id", ledgerID)
-	observability.AddAttribute(ctx, "customer_account_id", customerAccount.ID)
-	observability.AddAttribute(ctx, "merchant_account_id", merchantAccount.ID)
-	observability.AddAttribute(ctx, "c2m_tx_count", concurrentCustomerToMerchantTxs)
-	observability.AddAttribute(ctx, "m2c_tx_count", concurrentMerchantToCustomerTxs)
+	addConcurrentTransactionAttributes(ctx, orgID, ledgerID, customerAccount, merchantAccount)
 
-	// Validate account IDs
+	if err := runConcurrentTransactionBatch(ctx, "customer to merchant", "CustomerToMerchantTransactions", concurrentCustomerToMerchantTxs, "c2m", "c2m_transactions_failed", func(batchCtx context.Context) error {
+		return ExecuteCustomerToMerchantConcurrent(batchCtx, midazClient, orgID, ledgerID, customerAccount, merchantAccount, concurrentCustomerToMerchantTxs)
+	}); err != nil {
+		return fmt.Errorf("failed to execute concurrent transactions: %w", err)
+	}
+
+	if err := runConcurrentTransactionBatch(ctx, "merchant to customer", "MerchantToCustomerTransactions", concurrentMerchantToCustomerTxs, "m2c", "m2c_transactions_failed", func(batchCtx context.Context) error {
+		return ExecuteMerchantToCustomerConcurrent(batchCtx, midazClient, orgID, ledgerID, customerAccount, merchantAccount, concurrentMerchantToCustomerTxs)
+	}); err != nil {
+		return fmt.Errorf("failed to execute concurrent transactions: %w", err)
+	}
+
+	return nil
+}
+
+func validateConcurrentTransactionAccounts(ctx context.Context, customerAccount, merchantAccount *midazmodels.Account) error {
+	if customerAccount == nil || merchantAccount == nil {
+		err := errors.New("customer and merchant accounts are required")
+		observability.RecordError(ctx, err, "missing_accounts")
+		return err
+	}
+
 	if !validation.IsValidUUID(customerAccount.ID) || !validation.IsValidUUID(merchantAccount.ID) {
 		err := errors.New("invalid account IDs")
 		observability.RecordError(ctx, err, "invalid_account_ids")
@@ -69,55 +87,37 @@ func ExecuteConcurrentTransactions(ctx context.Context, midazClient *client.Clie
 		return err
 	}
 
-	// Execute concurrent transactions from customer to merchant
-	fmt.Printf("Running %d concurrent transactions from customer to merchant...\n", concurrentCustomerToMerchantTxs)
+	return nil
+}
 
-	startTimeC2M := time.Now()
+func addConcurrentTransactionAttributes(ctx context.Context, orgID, ledgerID string, customerAccount, merchantAccount *midazmodels.Account) {
+	observability.AddAttribute(ctx, "organization_id", orgID)
+	observability.AddAttribute(ctx, "ledger_id", ledgerID)
+	observability.AddAttribute(ctx, "customer_account_id", customerAccount.ID)
+	observability.AddAttribute(ctx, "merchant_account_id", merchantAccount.ID)
+	observability.AddAttribute(ctx, "c2m_tx_count", concurrentCustomerToMerchantTxs)
+	observability.AddAttribute(ctx, "m2c_tx_count", concurrentMerchantToCustomerTxs)
+}
 
-	c2mCtx, c2mSpan := observability.StartSpan(ctx, "CustomerToMerchantTransactions")
-	if err := ExecuteCustomerToMerchantConcurrent(c2mCtx, midazClient, orgID, ledgerID, customerAccount, merchantAccount, concurrentCustomerToMerchantTxs); err != nil {
-		c2mSpan.End()
-		observability.RecordError(ctx, err, "c2m_transactions_failed")
+func runConcurrentTransactionBatch(ctx context.Context, label, spanName string, count int, metricPrefix, errorEvent string, execute func(context.Context) error) error {
+	fmt.Printf("Running %d concurrent transactions from %s...\n", count, label)
 
-		return fmt.Errorf("failed to execute concurrent transactions: %w", err)
+	startTime := time.Now()
+	batchCtx, batchSpan := observability.StartSpan(ctx, spanName)
+	defer batchSpan.End()
+
+	if err := execute(batchCtx); err != nil {
+		observability.RecordError(ctx, err, errorEvent)
+		return err
 	}
 
-	c2mSpan.End()
+	duration := time.Since(startTime)
+	tps := float64(count) / duration.Seconds()
 
-	customerToMerchantDuration := time.Since(startTimeC2M)
-	customerToMerchantTPS := float64(concurrentCustomerToMerchantTxs) / customerToMerchantDuration.Seconds()
+	observability.RecordSpanMetric(ctx, metricPrefix+"_transaction_duration_seconds", duration.Seconds())
+	observability.RecordSpanMetric(ctx, metricPrefix+"_transactions_per_second", tps)
 
-	// Record metrics
-	observability.RecordSpanMetric(ctx, "c2m_transaction_duration_seconds", customerToMerchantDuration.Seconds())
-	observability.RecordSpanMetric(ctx, "c2m_transactions_per_second", customerToMerchantTPS)
-
-	fmt.Printf(" Completed %d customer to merchant transactions in %.2f seconds (%.2f TPS)\n\n",
-		concurrentCustomerToMerchantTxs, customerToMerchantDuration.Seconds(), customerToMerchantTPS)
-
-	// Execute concurrent transactions from merchant to customer
-	fmt.Printf("Running %d concurrent transactions from merchant to customer...\n", concurrentMerchantToCustomerTxs)
-
-	startTimeM2C := time.Now()
-
-	m2cCtx, m2cSpan := observability.StartSpan(ctx, "MerchantToCustomerTransactions")
-	if err := ExecuteMerchantToCustomerConcurrent(m2cCtx, midazClient, orgID, ledgerID, customerAccount, merchantAccount, concurrentMerchantToCustomerTxs); err != nil {
-		m2cSpan.End()
-		observability.RecordError(ctx, err, "m2c_transactions_failed")
-
-		return fmt.Errorf("failed to execute concurrent transactions: %w", err)
-	}
-
-	m2cSpan.End()
-
-	merchantToCustomerDuration := time.Since(startTimeM2C)
-	merchantToCustomerTPS := float64(concurrentMerchantToCustomerTxs) / merchantToCustomerDuration.Seconds()
-
-	// Record metrics
-	observability.RecordSpanMetric(ctx, "m2c_transaction_duration_seconds", merchantToCustomerDuration.Seconds())
-	observability.RecordSpanMetric(ctx, "m2c_transactions_per_second", merchantToCustomerTPS)
-
-	fmt.Printf(" Completed %d merchant to customer transactions in %.2f seconds (%.2f TPS)\n\n",
-		concurrentMerchantToCustomerTxs, merchantToCustomerDuration.Seconds(), merchantToCustomerTPS)
+	fmt.Printf(" Completed %d %s transactions in %.2f seconds (%.2f TPS)\n\n", count, label, duration.Seconds(), tps)
 
 	return nil
 }
@@ -224,6 +224,9 @@ func handleTransactionError(ctx context.Context, err error, index int, operation
 func ExecuteCustomerToMerchantConcurrent(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *midazmodels.Account, count int) error {
 	ctx, span := observability.StartSpan(ctx, "ExecuteCustomerToMerchantConcurrent")
 	defer span.End()
+	if customerAccount == nil || merchantAccount == nil {
+		return errors.New("customer and merchant accounts are required")
+	}
 
 	rateLimiter := concurrent.NewRateLimiter(20000, 20000)
 	defer rateLimiter.Stop()
@@ -297,8 +300,6 @@ func buildC2MTransactionInput(index int, customerAccount, merchantAccount *midaz
 	return &midazmodels.CreateTransactionInput{
 		ChartOfAccountsGroupName: "default_chart_group",
 		Description:              fmt.Sprintf("Concurrent customer to merchant transfer #%d", index+1),
-		Amount:                   "0.01",
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "transfer",
@@ -306,12 +307,12 @@ func buildC2MTransactionInput(index int, customerAccount, merchantAccount *midaz
 		},
 		Send: &midazmodels.SendInput{
 			Asset: "USD",
-			Value: "0.01",
+			Value: 0.01,
 			Source: &midazmodels.SourceInput{
 				From: []midazmodels.FromToInput{
 					{
 						Account: customerAccount.ID,
-						Amount:  midazmodels.AmountInput{Asset: "USD", Value: "0.01"},
+						Amount:  midazmodels.AmountInput{Asset: "USD", Value: 0.01},
 					},
 				},
 			},
@@ -319,7 +320,7 @@ func buildC2MTransactionInput(index int, customerAccount, merchantAccount *midaz
 				To: []midazmodels.FromToInput{
 					{
 						Account: merchantAccount.ID,
-						Amount:  midazmodels.AmountInput{Asset: "USD", Value: "0.01"},
+						Amount:  midazmodels.AmountInput{Asset: "USD", Value: 0.01},
 					},
 				},
 			},
@@ -372,6 +373,9 @@ func recordC2MMetrics(ctx context.Context, duration time.Duration, successCount,
 func ExecuteMerchantToCustomerConcurrent(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount *midazmodels.Account, count int) error {
 	ctx, span := observability.StartSpan(ctx, "ExecuteMerchantToCustomerConcurrent")
 	defer span.End()
+	if customerAccount == nil || merchantAccount == nil {
+		return errors.New("customer and merchant accounts are required")
+	}
 
 	transactionInputs, err := buildM2CTransactionInputs(ctx, merchantAccount, customerAccount, count)
 	if err != nil {
@@ -402,6 +406,9 @@ func ExecuteMerchantToCustomerConcurrent(ctx context.Context, midazClient *clien
 }
 
 func buildM2CTransactionInputs(ctx context.Context, merchantAccount, customerAccount *midazmodels.Account, count int) ([]*midazmodels.CreateTransactionInput, error) {
+	if merchantAccount == nil || customerAccount == nil {
+		return nil, errors.New("merchant and customer accounts are required")
+	}
 	if !validation.IsValidUUID(merchantAccount.ID) || !validation.IsValidUUID(customerAccount.ID) {
 		err := errors.New("invalid account IDs")
 		observability.RecordError(ctx, err, "invalid_account_ids")
@@ -420,8 +427,6 @@ func buildM2CTransactionInput(index int, merchantAccount, customerAccount *midaz
 	return &midazmodels.CreateTransactionInput{
 		ChartOfAccountsGroupName: "default_chart_group",
 		Description:              fmt.Sprintf("Concurrent merchant to customer transfer #%d", index+1),
-		Amount:                   "0.01",
-		AssetCode:                "USD",
 		Metadata: map[string]any{
 			"source": "go-sdk-example",
 			"type":   "transfer",
@@ -429,12 +434,12 @@ func buildM2CTransactionInput(index int, merchantAccount, customerAccount *midaz
 		},
 		Send: &midazmodels.SendInput{
 			Asset: "USD",
-			Value: "0.01",
+			Value: 0.01,
 			Source: &midazmodels.SourceInput{
 				From: []midazmodels.FromToInput{
 					{
 						Account: merchantAccount.ID,
-						Amount:  midazmodels.AmountInput{Asset: "USD", Value: "0.01"},
+						Amount:  midazmodels.AmountInput{Asset: "USD", Value: 0.01},
 					},
 				},
 			},
@@ -442,7 +447,7 @@ func buildM2CTransactionInput(index int, merchantAccount, customerAccount *midaz
 				To: []midazmodels.FromToInput{
 					{
 						Account: customerAccount.ID,
-						Amount:  midazmodels.AmountInput{Asset: "USD", Value: "0.01"},
+						Amount:  midazmodels.AmountInput{Asset: "USD", Value: 0.01},
 					},
 				},
 			},

--- a/examples/workflow-with-entities/pkg/workflows/transaction_helpers.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction_helpers.go
@@ -2,6 +2,7 @@ package workflows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,6 +29,9 @@ import (
 func DemonstrateTransactionHelpers(ctx context.Context, midazClient *client.Client, orgID, ledgerID string, customerAccount, merchantAccount, dummyOneAccount, dummyTwoAccount *models.Account) error {
 	ctx, span := observability.StartSpan(ctx, "DemonstrateTransactionHelpers")
 	defer span.End()
+	if customerAccount == nil || merchantAccount == nil || dummyOneAccount == nil || dummyTwoAccount == nil {
+		return errors.New("customer, merchant, and dummy accounts are required")
+	}
 
 	observability.AddAttribute(ctx, "organization_id", orgID)
 	observability.AddAttribute(ctx, "ledger_id", ledgerID)
@@ -49,7 +53,9 @@ func DemonstrateTransactionHelpers(ctx context.Context, midazClient *client.Clie
 		return err
 	}
 
-	demonstrateBatchTransactions(ctx, customerAccount, merchantAccount)
+	if err := demonstrateBatchTransactions(ctx, customerAccount, merchantAccount); err != nil {
+		return err
+	}
 
 	observability.AddEvent(ctx, "TransactionHelpersDemonstrated", nil)
 	fmt.Println("\n🎉 All transaction helpers demonstrated successfully!")
@@ -138,28 +144,34 @@ func demonstrateMultiAccountTransfer(ctx context.Context, midazClient *client.Cl
 	return nil
 }
 
-func demonstrateBatchTransactions(ctx context.Context, customerAccount, merchantAccount *models.Account) {
+func demonstrateBatchTransactions(ctx context.Context, customerAccount, merchantAccount *models.Account) error {
 	fmt.Println("\n📦 Demonstrating batch transactions...")
 
 	_, batchSpan := observability.StartSpan(ctx, "BatchTransactionsWithHelper")
-	batchInputs := buildBatchTransactionInputs(customerAccount, merchantAccount)
+	batchInputs, err := buildBatchTransactionInputs(customerAccount, merchantAccount)
 	batchSpan.End()
+	if err != nil {
+		return err
+	}
 
 	fmt.Printf("\n\n📋 Batch transactions prepared (not executed - batch feature not yet implemented)\n")
 	fmt.Printf("   Total Transactions: %d\n", len(batchInputs))
 	fmt.Printf("   This feature will be implemented in future versions\n")
+
+	return nil
 }
 
-func buildBatchTransactionInputs(customerAccount, merchantAccount *models.Account) []*models.CreateTransactionInput {
+func buildBatchTransactionInputs(customerAccount, merchantAccount *models.Account) ([]*models.CreateTransactionInput, error) {
+	if customerAccount == nil || merchantAccount == nil {
+		return nil, errors.New("customer and merchant accounts are required")
+	}
 	batchInputs := make([]*models.CreateTransactionInput, 0, 5)
 
 	for i := 1; i <= 5; i++ {
-		amount := fmt.Sprintf("%d.00", i)
+		amount := float64(i)
 		input := &models.CreateTransactionInput{
 			ChartOfAccountsGroupName: "default_chart_group",
 			Description:              fmt.Sprintf("Batch transfer #%d", i),
-			Amount:                   amount,
-			AssetCode:                "USD",
 			Metadata: map[string]any{
 				"source": "go-sdk-example",
 				"type":   "batch-transfer",
@@ -183,7 +195,7 @@ func buildBatchTransactionInputs(customerAccount, merchantAccount *models.Accoun
 		batchInputs = append(batchInputs, input)
 	}
 
-	return batchInputs
+	return batchInputs, nil
 }
 
 func printTransactionSuccess(txType string, tx *models.Transaction) {

--- a/examples/workflow-with-entities/pkg/workflows/transaction_insufficient_funds.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction_insufficient_funds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -148,9 +149,14 @@ func validateTestAmount(ctx context.Context, amount string) {
 }
 
 func createInsufficientFundsTransferInput(test insufficientFundsTest, testIndex int) *models.CreateTransactionInput {
+	amount, err := strconv.ParseFloat(test.Amount, 64)
+	if err != nil {
+		amount = 0
+	}
+
 	transferInput := CreateTransferInput(
 		test.Description,
-		test.Amount,
+		amount,
 		test.FromAccount.ID,
 		test.ToAccount,
 		testIndex,

--- a/examples/workflow-with-entities/pkg/workflows/transaction_insufficient_funds.go
+++ b/examples/workflow-with-entities/pkg/workflows/transaction_insufficient_funds.go
@@ -113,10 +113,15 @@ func runInsufficientFundsTest(ctx context.Context, midazClient *client.Client, o
 	printTestHeader(test, testIndex)
 	validateTestAmount(testCtx, test.Amount)
 
-	transferInput := createInsufficientFundsTransferInput(test, testIndex)
+	transferInput, err := createInsufficientFundsTransferInput(test, testIndex)
+	if err != nil {
+		observability.RecordError(testCtx, err, "invalid_insufficient_funds_test_input")
+		fmt.Printf("❌ Test input error: %s\n", err.Error())
+		return
+	}
 
 	startTime := time.Now()
-	_, err := midazClient.Entity.Transactions.CreateTransaction(testCtx, orgID, ledgerID, transferInput)
+	_, err = midazClient.Entity.Transactions.CreateTransaction(testCtx, orgID, ledgerID, transferInput)
 	duration := time.Since(startTime)
 
 	observability.RecordSpanMetric(testCtx, "test_duration_ms", float64(duration.Milliseconds()))
@@ -148,10 +153,10 @@ func validateTestAmount(ctx context.Context, amount string) {
 	}
 }
 
-func createInsufficientFundsTransferInput(test insufficientFundsTest, testIndex int) *models.CreateTransactionInput {
+func createInsufficientFundsTransferInput(test insufficientFundsTest, testIndex int) (*models.CreateTransactionInput, error) {
 	amount, err := strconv.ParseFloat(test.Amount, 64)
 	if err != nil {
-		amount = 0
+		return nil, fmt.Errorf("invalid amount %q: %w", test.Amount, err)
 	}
 
 	transferInput := CreateTransferInput(
@@ -169,7 +174,7 @@ func createInsufficientFundsTransferInput(test insufficientFundsTest, testIndex 
 		"timestamp":        time.Now().Unix(),
 	})
 
-	return transferInput
+	return transferInput, nil
 }
 
 func handleExpectedError(ctx context.Context, err error, test insufficientFundsTest, testIndex int) {

--- a/models/account.go
+++ b/models/account.go
@@ -127,6 +127,10 @@ func (input *CreateAccountInput) Validate() error {
 		return errors.New("name must be at most 256 characters")
 	}
 
+	if input.EntityID != nil && len(*input.EntityID) > 256 {
+		return errors.New("entityId must be at most 256 characters")
+	}
+
 	if input.AssetCode == "" {
 		return errors.New("asset code is required")
 	}
@@ -324,6 +328,10 @@ type UpdateAccountInput struct {
 func (input *UpdateAccountInput) Validate() error {
 	if input.Name != "" && len(input.Name) > 256 {
 		return errors.New("name must be at most 256 characters")
+	}
+
+	if input.EntityID != nil && len(*input.EntityID) > 256 {
+		return errors.New("entityId must be at most 256 characters")
 	}
 
 	// Validate status if provided

--- a/models/account.go
+++ b/models/account.go
@@ -79,7 +79,7 @@ func GetAccountIdentifier(account Account) string {
 type CreateAccountInput struct {
 	// Name is the human-readable name of the account.
 	// Max length: 256 characters. Optional in the Midaz API.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// ParentAccountID is the ID of the parent account, if this is a sub-account.
 	// Must be a valid UUID if provided.

--- a/models/account.go
+++ b/models/account.go
@@ -295,7 +295,7 @@ func (input CreateAccountInput) ToMmodel() mmodel.CreateAccountInput {
 type UpdateAccountInput struct {
 	// Name is the human-readable name of the account.
 	// Max length: 256 characters.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// SegmentID is the optional ID of the segment this account belongs to.
 	// Must be a valid UUID if provided.

--- a/models/account.go
+++ b/models/account.go
@@ -9,6 +9,8 @@ import (
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 )
 
+const maxAccountFieldLength = 256
+
 // Account represents an account in the Midaz Ledger.
 // This is now an alias to mmodel.Account to avoid duplication while maintaining
 // SDK-specific documentation and examples.
@@ -123,12 +125,14 @@ type CreateAccountInput struct {
 // Validate checks if the CreateAccountInput meets the validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *CreateAccountInput) Validate() error {
-	if input.Name != "" && len(input.Name) > 256 {
-		return errors.New("name must be at most 256 characters")
+	if err := validateAccountStringLength("name", input.Name); err != nil {
+		return err
 	}
 
-	if input.EntityID != nil && len(*input.EntityID) > 256 {
-		return errors.New("entityId must be at most 256 characters")
+	if input.EntityID != nil {
+		if err := validateAccountStringLength("entityId", *input.EntityID); err != nil {
+			return err
+		}
 	}
 
 	if input.AssetCode == "" {
@@ -326,12 +330,14 @@ type UpdateAccountInput struct {
 // Validate checks if the UpdateAccountInput meets the validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *UpdateAccountInput) Validate() error {
-	if input.Name != "" && len(input.Name) > 256 {
-		return errors.New("name must be at most 256 characters")
+	if err := validateAccountStringLength("name", input.Name); err != nil {
+		return err
 	}
 
-	if input.EntityID != nil && len(*input.EntityID) > 256 {
-		return errors.New("entityId must be at most 256 characters")
+	if input.EntityID != nil {
+		if err := validateAccountStringLength("entityId", *input.EntityID); err != nil {
+			return err
+		}
 	}
 
 	// Validate status if provided
@@ -343,6 +349,14 @@ func (input *UpdateAccountInput) Validate() error {
 		if err := core.ValidateMetadata(input.Metadata); err != nil {
 			return fmt.Errorf("invalid metadata: %w", err)
 		}
+	}
+
+	return nil
+}
+
+func validateAccountStringLength(field, value string) error {
+	if value != "" && len(value) > maxAccountFieldLength {
+		return fmt.Errorf("%s must be at most %d characters", field, maxAccountFieldLength)
 	}
 
 	return nil

--- a/models/account.go
+++ b/models/account.go
@@ -78,7 +78,7 @@ func GetAccountIdentifier(account Account) string {
 // This structure contains all the fields that can be specified when creating a new account.
 type CreateAccountInput struct {
 	// Name is the human-readable name of the account.
-	// Max length: 256 characters.
+	// Max length: 256 characters. Optional in the Midaz API.
 	Name string `json:"name"`
 
 	// ParentAccountID is the ID of the parent account, if this is a sub-account.
@@ -88,6 +88,9 @@ type CreateAccountInput struct {
 	// EntityID is an optional external identifier for the account owner.
 	// Max length: 256 characters.
 	EntityID *string `json:"entityId,omitempty"`
+
+	// Blocked indicates whether the account should start blocked.
+	Blocked *bool `json:"blocked,omitempty"`
 
 	// AssetCode identifies the type of asset held in this account.
 	// Required. Max length: 100 characters.
@@ -120,11 +123,7 @@ type CreateAccountInput struct {
 // Validate checks if the CreateAccountInput meets the validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *CreateAccountInput) Validate() error {
-	if input.Name == "" {
-		return errors.New("name is required")
-	}
-
-	if len(input.Name) > 256 {
+	if input.Name != "" && len(input.Name) > 256 {
 		return errors.New("name must be at most 256 characters")
 	}
 
@@ -267,6 +266,12 @@ func (input *CreateAccountInput) WithMetadata(metadata map[string]any) *CreateAc
 	return input
 }
 
+// WithBlocked sets whether the account should start blocked.
+func (input *CreateAccountInput) WithBlocked(blocked bool) *CreateAccountInput {
+	input.Blocked = &blocked
+	return input
+}
+
 // ToMmodel converts the SDK CreateAccountInput to mmodel.CreateAccountInput.
 // This method is used internally to convert between SDK and backend models.
 func (input CreateAccountInput) ToMmodel() mmodel.CreateAccountInput {
@@ -274,6 +279,7 @@ func (input CreateAccountInput) ToMmodel() mmodel.CreateAccountInput {
 		Name:            input.Name,
 		ParentAccountID: input.ParentAccountID,
 		EntityID:        input.EntityID,
+		Blocked:         input.Blocked,
 		AssetCode:       input.AssetCode,
 		PortfolioID:     input.PortfolioID,
 		SegmentID:       input.SegmentID,
@@ -305,6 +311,12 @@ type UpdateAccountInput struct {
 	// Metadata contains additional custom data associated with the account.
 	// Keys max length: 100 characters, Values max length: 2000 characters.
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// EntityID is an optional external identifier for the account owner.
+	EntityID *string `json:"entityId,omitempty"`
+
+	// Blocked indicates whether the account should be blocked.
+	Blocked *bool `json:"blocked,omitempty"`
 }
 
 // Validate checks if the UpdateAccountInput meets the validation requirements.
@@ -348,6 +360,12 @@ func NewUpdateAccountInput() *UpdateAccountInput {
 //   - A pointer to the modified UpdateAccountInput for method chaining
 func (input *UpdateAccountInput) WithName(name string) *UpdateAccountInput {
 	input.Name = name
+	return input
+}
+
+// WithEntityID sets the external entity identifier.
+func (input *UpdateAccountInput) WithEntityID(entityID string) *UpdateAccountInput {
+	input.EntityID = &entityID
 	return input
 }
 
@@ -403,6 +421,12 @@ func (input *UpdateAccountInput) WithMetadata(metadata map[string]any) *UpdateAc
 	return input
 }
 
+// WithBlocked sets whether the account should be blocked.
+func (input *UpdateAccountInput) WithBlocked(blocked bool) *UpdateAccountInput {
+	input.Blocked = &blocked
+	return input
+}
+
 // ToMmodel converts the SDK UpdateAccountInput to mmodel.UpdateAccountInput.
 // This method is used internally to convert between SDK and backend models.
 func (input UpdateAccountInput) ToMmodel() mmodel.UpdateAccountInput {
@@ -412,6 +436,8 @@ func (input UpdateAccountInput) ToMmodel() mmodel.UpdateAccountInput {
 		PortfolioID: input.PortfolioID,
 		Status:      input.Status,
 		Metadata:    input.Metadata,
+		EntityID:    input.EntityID,
+		Blocked:     input.Blocked,
 	}
 }
 

--- a/models/account_test.go
+++ b/models/account_test.go
@@ -60,6 +60,7 @@ func TestNewCreateAccountInput(t *testing.T) {
 			assert.Equal(t, "ACTIVE", input.Status.Code)
 			assert.Nil(t, input.ParentAccountID)
 			assert.Nil(t, input.EntityID)
+			assert.Nil(t, input.Blocked)
 			assert.Nil(t, input.PortfolioID)
 			assert.Nil(t, input.SegmentID)
 			assert.Nil(t, input.Alias)
@@ -87,14 +88,13 @@ func TestCreateAccountInputValidate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "empty name",
+			name: "empty name is allowed",
 			input: &CreateAccountInput{
 				Name:      "",
 				AssetCode: "USD",
 				Type:      "deposit",
 			},
-			expectError: true,
-			errContains: "name is required",
+			expectError: false,
 		},
 		{
 			name: "name exceeds max length",
@@ -485,11 +485,13 @@ func TestCreateAccountInputToMmodel(t *testing.T) {
 	entityID := "entity-456"
 	portfolioID := "portfolio-789"
 	segmentID := "segment-012"
+	blocked := true
 
 	input := CreateAccountInput{
 		Name:            "Test Account",
 		ParentAccountID: &parentID,
 		EntityID:        &entityID,
+		Blocked:         &blocked,
 		AssetCode:       "USD",
 		PortfolioID:     &portfolioID,
 		SegmentID:       &segmentID,
@@ -506,6 +508,7 @@ func TestCreateAccountInputToMmodel(t *testing.T) {
 	assert.Equal(t, input.Name, result.Name)
 	assert.Equal(t, input.ParentAccountID, result.ParentAccountID)
 	assert.Equal(t, input.EntityID, result.EntityID)
+	assert.Equal(t, input.Blocked, result.Blocked)
 	assert.Equal(t, input.AssetCode, result.AssetCode)
 	assert.Equal(t, input.PortfolioID, result.PortfolioID)
 	assert.Equal(t, input.SegmentID, result.SegmentID)
@@ -520,6 +523,7 @@ func TestCreateAccountInputBuilderChaining(t *testing.T) {
 	input := NewCreateAccountInput("Chained Account", "EUR", "savings").
 		WithParentAccountID("parent-id").
 		WithEntityID("entity-id").
+		WithBlocked(true).
 		WithPortfolioID("portfolio-id").
 		WithSegmentID("segment-id").
 		WithStatus(NewStatus("PENDING")).
@@ -533,6 +537,8 @@ func TestCreateAccountInputBuilderChaining(t *testing.T) {
 	assert.Equal(t, "parent-id", *input.ParentAccountID)
 	assert.NotNil(t, input.EntityID)
 	assert.Equal(t, "entity-id", *input.EntityID)
+	assert.NotNil(t, input.Blocked)
+	assert.True(t, *input.Blocked)
 	assert.NotNil(t, input.PortfolioID)
 	assert.Equal(t, "portfolio-id", *input.PortfolioID)
 	assert.NotNil(t, input.SegmentID)
@@ -553,6 +559,8 @@ func TestNewUpdateAccountInput(t *testing.T) {
 	assert.Nil(t, input.PortfolioID)
 	assert.Empty(t, input.Status.Code)
 	assert.Nil(t, input.Metadata)
+	assert.Nil(t, input.EntityID)
+	assert.Nil(t, input.Blocked)
 }
 
 // TestUpdateAccountInputValidate tests the Validate method for UpdateAccountInput
@@ -708,11 +716,15 @@ func TestUpdateAccountInputWithMetadata(t *testing.T) {
 func TestUpdateAccountInputToMmodel(t *testing.T) {
 	segmentID := "segment-123"
 	portfolioID := "portfolio-456"
+	entityID := "entity-789"
+	blocked := true
 
 	input := UpdateAccountInput{
 		Name:        "Updated Account",
 		SegmentID:   &segmentID,
 		PortfolioID: &portfolioID,
+		EntityID:    &entityID,
+		Blocked:     &blocked,
 		Status:      NewStatus("ACTIVE"),
 		Metadata: map[string]any{
 			"key": "value",
@@ -724,6 +736,8 @@ func TestUpdateAccountInputToMmodel(t *testing.T) {
 	assert.Equal(t, input.Name, result.Name)
 	assert.Equal(t, input.SegmentID, result.SegmentID)
 	assert.Equal(t, input.PortfolioID, result.PortfolioID)
+	assert.Equal(t, input.EntityID, result.EntityID)
+	assert.Equal(t, input.Blocked, result.Blocked)
 	assert.Equal(t, input.Status.Code, result.Status.Code)
 	assert.Equal(t, input.Metadata, result.Metadata)
 }
@@ -734,6 +748,8 @@ func TestUpdateAccountInputBuilderChaining(t *testing.T) {
 		WithName("Chained Update").
 		WithSegmentID("segment-id").
 		WithPortfolioID("portfolio-id").
+		WithEntityID("entity-id").
+		WithBlocked(true).
 		WithStatus(NewStatus("CLOSED")).
 		WithMetadata(map[string]any{"chain": "update"})
 
@@ -742,6 +758,10 @@ func TestUpdateAccountInputBuilderChaining(t *testing.T) {
 	assert.Equal(t, "segment-id", *input.SegmentID)
 	assert.NotNil(t, input.PortfolioID)
 	assert.Equal(t, "portfolio-id", *input.PortfolioID)
+	assert.NotNil(t, input.EntityID)
+	assert.Equal(t, "entity-id", *input.EntityID)
+	assert.NotNil(t, input.Blocked)
+	assert.True(t, *input.Blocked)
 	assert.Equal(t, "CLOSED", input.Status.Code)
 	assert.Equal(t, "update", input.Metadata["chain"])
 }
@@ -1231,14 +1251,14 @@ func TestMetadataValidation(t *testing.T) {
 					"key": "value",
 				},
 			},
-			expectError: false,
+			expectError: true,
 		},
 		{
 			name: "array value",
 			metadata: map[string]any{
 				"tags": []any{"tag1", "tag2"},
 			},
-			expectError: false,
+			expectError: true,
 		},
 	}
 

--- a/models/alias.go
+++ b/models/alias.go
@@ -1,0 +1,264 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation/core"
+)
+
+// RegulatoryFields contains regulatory-specific fields for an alias.
+type RegulatoryFields struct {
+	ParticipantDocument *string `json:"participantDocument,omitempty"`
+}
+
+// RelatedParty represents a party related to an alias.
+type RelatedParty struct {
+	ID        *uuid.UUID `json:"id,omitempty"`
+	Document  string     `json:"document"`
+	Name      string     `json:"name"`
+	Role      string     `json:"role"`
+	StartDate string     `json:"startDate"`
+	EndDate   *string    `json:"endDate,omitempty"`
+}
+
+// CreateAliasInput is the payload for creating an account alias.
+type CreateAliasInput struct {
+	LedgerID         string            `json:"ledgerId"`
+	AccountID        string            `json:"accountId"`
+	Metadata         map[string]any    `json:"metadata"`
+	BankingDetails   *BankingDetails   `json:"bankingDetails"`
+	RegulatoryFields *RegulatoryFields `json:"regulatoryFields,omitempty"`
+	RelatedParties   []*RelatedParty   `json:"relatedParties,omitempty"`
+}
+
+// UpdateAliasInput is the payload for updating an account alias.
+type UpdateAliasInput struct {
+	Metadata         map[string]any    `json:"metadata,omitempty"`
+	BankingDetails   *BankingDetails   `json:"bankingDetails,omitempty"`
+	RegulatoryFields *RegulatoryFields `json:"regulatoryFields,omitempty"`
+	RelatedParties   []*RelatedParty   `json:"relatedParties,omitempty"`
+	NullFields       []string          `json:"-"`
+}
+
+// Validate validates the CreateAliasInput fields.
+func (input *CreateAliasInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if strings.TrimSpace(input.LedgerID) == "" {
+		return errors.New("ledgerId is required")
+	}
+
+	if strings.TrimSpace(input.AccountID) == "" {
+		return errors.New("accountId is required")
+	}
+
+	if err := validateAliasMetadata(input.Metadata); err != nil {
+		return err
+	}
+
+	return validateRelatedParties(input.RelatedParties)
+}
+
+// WithNullFields marks fields that should be sent as explicit JSON null in PATCH requests.
+func (input *UpdateAliasInput) WithNullFields(fields ...string) *UpdateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.NullFields = append(input.NullFields, fields...)
+
+	return input
+}
+
+// MarshalJSON emits only set fields plus fields explicitly marked for null removal.
+func (input UpdateAliasInput) MarshalJSON() ([]byte, error) {
+	payload := map[string]any{}
+	if input.Metadata != nil {
+		payload["metadata"] = input.Metadata
+	}
+
+	if input.BankingDetails != nil {
+		payload["bankingDetails"] = input.BankingDetails
+	}
+
+	if input.RegulatoryFields != nil {
+		payload["regulatoryFields"] = input.RegulatoryFields
+	}
+
+	if input.RelatedParties != nil {
+		payload["relatedParties"] = input.RelatedParties
+	}
+
+	for _, field := range input.NullFields {
+		field = strings.TrimSpace(field)
+		if !validAliasNullFields[field] {
+			return nil, fmt.Errorf("unsupported null field %q", field)
+		}
+
+		payload[field] = nil
+	}
+
+	return json.Marshal(payload)
+}
+
+var validAliasNullFields = map[string]bool{
+	"metadata":         true,
+	"bankingDetails":   true,
+	"regulatoryFields": true,
+	"relatedParties":   true,
+}
+
+// Validate validates the UpdateAliasInput fields.
+func (input *UpdateAliasInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if err := validateAliasMetadata(input.Metadata); err != nil {
+		return err
+	}
+
+	if err := validateRelatedParties(input.RelatedParties); err != nil {
+		return err
+	}
+
+	return validateCRMNullFields(input.NullFields, validAliasNullFields)
+}
+
+func validateAliasMetadata(metadata map[string]any) error {
+	if len(metadata) == 0 {
+		return nil
+	}
+
+	if err := core.ValidateMetadata(metadata); err != nil {
+		return fmt.Errorf("invalid metadata: %w", err)
+	}
+
+	return nil
+}
+
+func validateRelatedParties(parties []*RelatedParty) error {
+	for i, party := range parties {
+		if party == nil {
+			return fmt.Errorf("relatedParties[%d] is required", i)
+		}
+
+		if err := validateRelatedPartyRequiredFields(i, party); err != nil {
+			return err
+		}
+
+		if err := validateRelatedPartyRole(i, party.Role); err != nil {
+			return err
+		}
+
+		if err := validateRelatedPartyDates(i, party.StartDate, party.EndDate); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRelatedPartyRequiredFields(index int, party *RelatedParty) error {
+	requiredFields := []struct {
+		name  string
+		value string
+	}{
+		{name: "document", value: party.Document},
+		{name: "name", value: party.Name},
+		{name: "role", value: party.Role},
+	}
+
+	for _, field := range requiredFields {
+		if strings.TrimSpace(field.value) == "" {
+			return fmt.Errorf("relatedParties[%d].%s is required", index, field.name)
+		}
+	}
+
+	return nil
+}
+
+func validateRelatedPartyRole(index int, role string) error {
+	switch role {
+	case "PRIMARY_HOLDER", "LEGAL_REPRESENTATIVE", "RESPONSIBLE_PARTY":
+		return nil
+	default:
+		return fmt.Errorf("relatedParties[%d].role must be PRIMARY_HOLDER, LEGAL_REPRESENTATIVE, or RESPONSIBLE_PARTY", index)
+	}
+}
+
+func validateRelatedPartyDates(index int, startDateValue string, endDateValue *string) error {
+	if strings.TrimSpace(startDateValue) == "" {
+		return fmt.Errorf("relatedParties[%d].startDate is required", index)
+	}
+
+	startDate, err := parseCRMDate(startDateValue)
+	if err != nil {
+		return fmt.Errorf("relatedParties[%d].startDate must be YYYY-MM-DD or RFC3339", index)
+	}
+
+	return validateRelatedPartyEndDate(index, startDate, endDateValue)
+}
+
+func validateRelatedPartyEndDate(index int, startDate time.Time, endDateValue *string) error {
+	if endDateValue == nil {
+		return nil
+	}
+
+	endDate, err := parseCRMDate(*endDateValue)
+	if err != nil {
+		return fmt.Errorf("relatedParties[%d].endDate must be YYYY-MM-DD or RFC3339", index)
+	}
+
+	if endDate.Before(startDate) {
+		return fmt.Errorf("relatedParties[%d].endDate must not be before startDate", index)
+	}
+
+	return nil
+}
+
+func parseCRMDate(value string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if parsed, err := time.Parse("2006-01-02", trimmed); err == nil {
+		return parsed, nil
+	}
+
+	return time.Parse(time.RFC3339, trimmed)
+}
+
+// Alias represents a CRM account alias.
+type Alias struct {
+	ID               *uuid.UUID        `json:"id,omitempty"`
+	Document         *string           `json:"document,omitempty"`
+	Type             *string           `json:"type,omitempty"`
+	LedgerID         *string           `json:"ledgerId"`
+	AccountID        *string           `json:"accountId"`
+	HolderID         *uuid.UUID        `json:"holderId"`
+	Metadata         map[string]any    `json:"metadata,omitempty"`
+	BankingDetails   *BankingDetails   `json:"bankingDetails,omitempty"`
+	RegulatoryFields *RegulatoryFields `json:"regulatoryFields,omitempty"`
+	RelatedParties   []*RelatedParty   `json:"relatedParties,omitempty"`
+	CreatedAt        time.Time         `json:"createdAt"`
+	UpdatedAt        time.Time         `json:"updatedAt"`
+	DeletedAt        *time.Time        `json:"deletedAt"`
+}
+
+// BankingDetails stores account banking details associated with an alias.
+type BankingDetails struct {
+	Branch      *string `json:"branch,omitempty"`
+	Account     *string `json:"account,omitempty"`
+	Type        *string `json:"type,omitempty"`
+	OpeningDate *string `json:"openingDate,omitempty"`
+	ClosingDate *string `json:"closingDate,omitempty"`
+	IBAN        *string `json:"iban,omitempty"`
+	CountryCode *string `json:"countryCode,omitempty"`
+	BankID      *string `json:"bankId,omitempty"`
+}

--- a/models/alias.go
+++ b/models/alias.go
@@ -12,6 +12,15 @@ import (
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation/core"
 )
 
+// RelatedPartyRolePrimaryHolder identifies the primary holder related-party role.
+const RelatedPartyRolePrimaryHolder = "PRIMARY_HOLDER"
+
+// RelatedPartyRoleLegalRepresentative identifies the legal representative related-party role.
+const RelatedPartyRoleLegalRepresentative = "LEGAL_REPRESENTATIVE"
+
+// RelatedPartyRoleResponsibleParty identifies the responsible party related-party role.
+const RelatedPartyRoleResponsibleParty = "RESPONSIBLE_PARTY"
+
 // RegulatoryFields contains regulatory-specific fields for an alias.
 type RegulatoryFields struct {
 	ParticipantDocument *string `json:"participantDocument,omitempty"`
@@ -211,7 +220,23 @@ func (input UpdateAliasInput) MarshalJSON() ([]byte, error) {
 		payload[field] = nil
 	}
 
+	if len(payload) == 0 {
+		return nil, errors.New("empty update payload not allowed")
+	}
+
 	return json.Marshal(payload)
+}
+
+func (input *UpdateAliasInput) hasChanges() bool {
+	if input == nil {
+		return false
+	}
+
+	return input.Metadata != nil ||
+		input.BankingDetails != nil ||
+		input.RegulatoryFields != nil ||
+		input.RelatedParties != nil ||
+		len(input.NullFields) > 0
 }
 
 func (input *UpdateAliasInput) validateNullFieldConflicts() error {
@@ -247,6 +272,10 @@ var validAliasNullFields = map[string]bool{
 func (input *UpdateAliasInput) Validate() error {
 	if input == nil {
 		return errors.New("input is required")
+	}
+
+	if !input.hasChanges() {
+		return errors.New("empty update payload not allowed")
 	}
 
 	if err := validateAliasMetadata(input.Metadata); err != nil {
@@ -319,7 +348,7 @@ func validateRelatedPartyRequiredFields(index int, party *RelatedParty) error {
 
 func validateRelatedPartyRole(index int, role string) error {
 	switch role {
-	case "PRIMARY_HOLDER", "LEGAL_REPRESENTATIVE", "RESPONSIBLE_PARTY":
+	case RelatedPartyRolePrimaryHolder, RelatedPartyRoleLegalRepresentative, RelatedPartyRoleResponsibleParty:
 		return nil
 	default:
 		return fmt.Errorf("relatedParties[%d].role must be PRIMARY_HOLDER, LEGAL_REPRESENTATIVE, or RESPONSIBLE_PARTY", index)

--- a/models/alias.go
+++ b/models/alias.go
@@ -80,6 +80,10 @@ func (input *UpdateAliasInput) WithNullFields(fields ...string) *UpdateAliasInpu
 
 // MarshalJSON emits only set fields plus fields explicitly marked for null removal.
 func (input UpdateAliasInput) MarshalJSON() ([]byte, error) {
+	if err := input.validateNullFieldConflicts(); err != nil {
+		return nil, err
+	}
+
 	payload := map[string]any{}
 	if input.Metadata != nil {
 		payload["metadata"] = input.Metadata
@@ -109,6 +113,28 @@ func (input UpdateAliasInput) MarshalJSON() ([]byte, error) {
 	return json.Marshal(payload)
 }
 
+func (input *UpdateAliasInput) validateNullFieldConflicts() error {
+	if input == nil {
+		return nil
+	}
+
+	setFields := map[string]bool{
+		"metadata":         input.Metadata != nil,
+		"bankingDetails":   input.BankingDetails != nil,
+		"regulatoryFields": input.RegulatoryFields != nil,
+		"relatedParties":   input.RelatedParties != nil,
+	}
+
+	for _, field := range input.NullFields {
+		field = strings.TrimSpace(field)
+		if setFields[field] {
+			return fmt.Errorf("field %q cannot be set and cleared in the same request", field)
+		}
+	}
+
+	return nil
+}
+
 var validAliasNullFields = map[string]bool{
 	"metadata":         true,
 	"bankingDetails":   true,
@@ -130,7 +156,11 @@ func (input *UpdateAliasInput) Validate() error {
 		return err
 	}
 
-	return validateCRMNullFields(input.NullFields, validAliasNullFields)
+	if err := validateCRMNullFields(input.NullFields, validAliasNullFields); err != nil {
+		return err
+	}
+
+	return input.validateNullFieldConflicts()
 }
 
 func validateAliasMetadata(metadata map[string]any) error {

--- a/models/alias.go
+++ b/models/alias.go
@@ -31,8 +31,8 @@ type RelatedParty struct {
 type CreateAliasInput struct {
 	LedgerID         string            `json:"ledgerId"`
 	AccountID        string            `json:"accountId"`
-	Metadata         map[string]any    `json:"metadata"`
-	BankingDetails   *BankingDetails   `json:"bankingDetails"`
+	Metadata         map[string]any    `json:"metadata,omitempty"`
+	BankingDetails   *BankingDetails   `json:"bankingDetails,omitempty"`
 	RegulatoryFields *RegulatoryFields `json:"regulatoryFields,omitempty"`
 	RelatedParties   []*RelatedParty   `json:"relatedParties,omitempty"`
 }
@@ -327,8 +327,13 @@ func validateRelatedPartyRole(index int, role string) error {
 }
 
 func validateRelatedPartyDates(index int, startDateValue string, endDateValue *string) error {
-	if strings.TrimSpace(startDateValue) == "" {
+	trimmedStartDate := strings.TrimSpace(startDateValue)
+	if trimmedStartDate == "" {
 		return fmt.Errorf("relatedParties[%d].startDate is required", index)
+	}
+
+	if startDateValue != trimmedStartDate {
+		return fmt.Errorf("relatedParties[%d].startDate must not contain leading/trailing whitespace", index)
 	}
 
 	startDate, err := parseCRMDate(startDateValue)
@@ -342,6 +347,10 @@ func validateRelatedPartyDates(index int, startDateValue string, endDateValue *s
 func validateRelatedPartyEndDate(index int, startDate time.Time, endDateValue *string) error {
 	if endDateValue == nil {
 		return nil
+	}
+
+	if *endDateValue != strings.TrimSpace(*endDateValue) {
+		return fmt.Errorf("relatedParties[%d].endDate must not contain leading/trailing whitespace", index)
 	}
 
 	endDate, err := parseCRMDate(*endDateValue)

--- a/models/alias.go
+++ b/models/alias.go
@@ -46,6 +46,107 @@ type UpdateAliasInput struct {
 	NullFields       []string          `json:"-"`
 }
 
+// NewCreateAliasInput creates an alias create payload with required fields set.
+func NewCreateAliasInput(ledgerID, accountID string) *CreateAliasInput {
+	return &CreateAliasInput{
+		LedgerID:  ledgerID,
+		AccountID: accountID,
+	}
+}
+
+// WithMetadata sets alias metadata.
+func (input *CreateAliasInput) WithMetadata(metadata map[string]any) *CreateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Metadata = metadata
+
+	return input
+}
+
+// WithBankingDetails sets alias banking details.
+func (input *CreateAliasInput) WithBankingDetails(bankingDetails *BankingDetails) *CreateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.BankingDetails = bankingDetails
+
+	return input
+}
+
+// WithRegulatoryFields sets alias regulatory fields.
+func (input *CreateAliasInput) WithRegulatoryFields(regulatoryFields *RegulatoryFields) *CreateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.RegulatoryFields = regulatoryFields
+
+	return input
+}
+
+// WithRelatedParties sets alias related parties.
+func (input *CreateAliasInput) WithRelatedParties(relatedParties []*RelatedParty) *CreateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.RelatedParties = relatedParties
+
+	return input
+}
+
+// NewUpdateAliasInput creates an empty alias update payload.
+func NewUpdateAliasInput() *UpdateAliasInput {
+	return &UpdateAliasInput{}
+}
+
+// WithMetadata sets alias metadata for update.
+func (input *UpdateAliasInput) WithMetadata(metadata map[string]any) *UpdateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Metadata = metadata
+
+	return input
+}
+
+// WithBankingDetails sets alias banking details for update.
+func (input *UpdateAliasInput) WithBankingDetails(bankingDetails *BankingDetails) *UpdateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.BankingDetails = bankingDetails
+
+	return input
+}
+
+// WithRegulatoryFields sets alias regulatory fields for update.
+func (input *UpdateAliasInput) WithRegulatoryFields(regulatoryFields *RegulatoryFields) *UpdateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.RegulatoryFields = regulatoryFields
+
+	return input
+}
+
+// WithRelatedParties sets alias related parties for update.
+func (input *UpdateAliasInput) WithRelatedParties(relatedParties []*RelatedParty) *UpdateAliasInput {
+	if input == nil {
+		return nil
+	}
+
+	input.RelatedParties = relatedParties
+
+	return input
+}
+
 // Validate validates the CreateAliasInput fields.
 func (input *CreateAliasInput) Validate() error {
 	if input == nil {

--- a/models/asset_rate_test.go
+++ b/models/asset_rate_test.go
@@ -776,7 +776,7 @@ func TestAssetRateListOptionsToQueryParams(t *testing.T) {
 		{
 			name:       "default options",
 			options:    NewAssetRateListOptions(),
-			wantParams: map[string]string{"limit": "10", "sort_order": "desc"},
+			wantParams: map[string]string{"limit": "10", "sort_order": "asc"},
 		},
 		{
 			name: "single to asset",

--- a/models/balance.go
+++ b/models/balance.go
@@ -10,11 +10,21 @@ import (
 // Balance is an alias for mmodel.Balance to maintain compatibility while using midaz entities.
 type Balance = mmodel.Balance
 
+// BalanceHistory is an alias for mmodel.BalanceHistory.
+type BalanceHistory = mmodel.BalanceHistory
+
 // UpdateBalanceInput is the input for updating a balance.
 // This structure contains the fields that can be modified when updating an existing balance.
 type UpdateBalanceInput struct {
-	// Metadata contains additional custom data associated with the balance.
-	Metadata map[string]any `json:"metadata,omitempty"`
+	// AllowSending controls whether this balance can be used for outgoing transactions.
+	AllowSending *bool `json:"allowSending,omitempty"`
+
+	// AllowReceiving controls whether this balance can receive incoming transactions.
+	AllowReceiving *bool `json:"allowReceiving,omitempty"`
+
+	// Metadata is retained for backward compatibility, but is not part of the
+	// current Midaz UpdateBalance contract.
+	Metadata map[string]any `json:"-"`
 }
 
 // Validate validates the UpdateBalanceInput fields.
@@ -28,7 +38,20 @@ func NewUpdateBalanceInput() *UpdateBalanceInput {
 	return &UpdateBalanceInput{}
 }
 
-// WithMetadata sets the metadata for UpdateBalanceInput.
+// WithAllowSending sets whether this balance can be used for outgoing transactions.
+func (input *UpdateBalanceInput) WithAllowSending(allow bool) *UpdateBalanceInput {
+	input.AllowSending = &allow
+	return input
+}
+
+// WithAllowReceiving sets whether this balance can receive incoming transactions.
+func (input *UpdateBalanceInput) WithAllowReceiving(allow bool) *UpdateBalanceInput {
+	input.AllowReceiving = &allow
+	return input
+}
+
+// WithMetadata sets legacy metadata data on UpdateBalanceInput.
+// Deprecated: metadata is not sent to the Midaz UpdateBalance endpoint.
 func (input *UpdateBalanceInput) WithMetadata(metadata map[string]any) *UpdateBalanceInput {
 	input.Metadata = metadata
 	return input

--- a/models/balance.go
+++ b/models/balance.go
@@ -28,8 +28,12 @@ type UpdateBalanceInput struct {
 }
 
 // Validate validates the UpdateBalanceInput fields.
-func (*UpdateBalanceInput) Validate() error {
+func (input *UpdateBalanceInput) Validate() error {
 	// For balance updates, validation is minimal since most fields are controlled by the system
+	if input != nil && input.Metadata != nil {
+		return errors.New("metadata updates are no longer supported in UpdateBalanceInput")
+	}
+
 	return nil
 }
 

--- a/models/common.go
+++ b/models/common.go
@@ -167,6 +167,32 @@ type Pagination struct {
 	ItemCount int `json:"-"`
 }
 
+// UnmarshalJSON supports both current snake_case and legacy camelCase cursor keys.
+func (p *Pagination) UnmarshalJSON(data []byte) error {
+	type alias Pagination
+
+	aux := struct {
+		alias
+		PrevCursorLegacy string `json:"prevCursor,omitempty"`
+		NextCursorLegacy string `json:"nextCursor,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*p = Pagination(aux.alias)
+	if p.PrevCursor == "" {
+		p.PrevCursor = aux.PrevCursorLegacy
+	}
+
+	if p.NextCursor == "" {
+		p.NextCursor = aux.NextCursorLegacy
+	}
+
+	return nil
+}
+
 // HasMorePages returns true if there are more pages available.
 // This is determined by checking if the offset plus limit is less than the total.
 //
@@ -745,13 +771,15 @@ func (r *ListResponse[T]) UnmarshalJSON(data []byte) error {
 
 	aux := struct {
 		alias
-		Limit      int         `json:"limit,omitempty"`
-		Page       int         `json:"page,omitempty"`
-		Offset     int         `json:"offset,omitempty"`
-		Total      int         `json:"total,omitempty"`
-		NextCursor string      `json:"next_cursor,omitempty"`
-		PrevCursor string      `json:"prev_cursor,omitempty"`
-		Pagination *Pagination `json:"pagination,omitempty"`
+		Limit            int         `json:"limit,omitempty"`
+		Page             int         `json:"page,omitempty"`
+		Offset           int         `json:"offset,omitempty"`
+		Total            int         `json:"total,omitempty"`
+		NextCursor       string      `json:"next_cursor,omitempty"`
+		PrevCursor       string      `json:"prev_cursor,omitempty"`
+		NextCursorLegacy string      `json:"nextCursor,omitempty"`
+		PrevCursorLegacy string      `json:"prevCursor,omitempty"`
+		Pagination       *Pagination `json:"pagination,omitempty"`
 	}{}
 
 	if err := json.Unmarshal(data, &aux); err != nil {
@@ -766,13 +794,23 @@ func (r *ListResponse[T]) UnmarshalJSON(data []byte) error {
 	if aux.Pagination != nil {
 		r.Pagination = *aux.Pagination
 	} else {
+		nextCursor := aux.NextCursor
+		if nextCursor == "" {
+			nextCursor = aux.NextCursorLegacy
+		}
+
+		prevCursor := aux.PrevCursor
+		if prevCursor == "" {
+			prevCursor = aux.PrevCursorLegacy
+		}
+
 		r.Pagination = Pagination{
 			Limit:      aux.Limit,
 			Page:       aux.Page,
 			Offset:     aux.Offset,
 			Total:      aux.Total,
-			NextCursor: aux.NextCursor,
-			PrevCursor: aux.PrevCursor,
+			NextCursor: nextCursor,
+			PrevCursor: prevCursor,
 		}
 	}
 

--- a/models/common.go
+++ b/models/common.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -146,17 +148,23 @@ type Pagination struct {
 	// Limit is the number of items per page
 	Limit int `json:"limit"`
 
-	// Offset is the starting position for the current page
-	Offset int `json:"offset"`
+	// Page is the current page number for page-based endpoints.
+	Page int `json:"page,omitempty"`
 
-	// Total is the total number of items available across all pages
-	Total int `json:"total"`
+	// Offset is the starting position for legacy offset-based pagination.
+	Offset int `json:"offset,omitempty"`
+
+	// Total is the total number of items available across all pages when provided.
+	Total int `json:"total,omitempty"`
 
 	// PrevCursor is the cursor for the previous page (for cursor-based pagination)
-	PrevCursor string `json:"prevCursor,omitempty"`
+	PrevCursor string `json:"prev_cursor,omitempty"`
 
 	// NextCursor is the cursor for the next page (for cursor-based pagination)
-	NextCursor string `json:"nextCursor,omitempty"`
+	NextCursor string `json:"next_cursor,omitempty"`
+
+	// ItemCount tracks the number of decoded items for cursor/page heuristics.
+	ItemCount int `json:"-"`
 }
 
 // HasMorePages returns true if there are more pages available.
@@ -165,7 +173,15 @@ type Pagination struct {
 // Returns:
 //   - true if there are more pages available, false otherwise
 func (p *Pagination) HasMorePages() bool {
-	return p.Offset+p.Limit < p.Total
+	if p.Total > 0 && p.Limit > 0 {
+		if p.Page > 0 {
+			return p.Page*p.Limit < p.Total
+		}
+
+		return p.Offset+p.Limit < p.Total
+	}
+
+	return p.Page > 0 && p.Limit > 0 && p.ItemCount >= p.Limit
 }
 
 // HasPrevPage returns true if there is a previous page available.
@@ -174,7 +190,7 @@ func (p *Pagination) HasMorePages() bool {
 // Returns:
 //   - true if there is a previous page available, false otherwise
 func (p *Pagination) HasPrevPage() bool {
-	return p.Offset > 0 || p.PrevCursor != ""
+	return p.Page > 1 || p.Offset > 0 || p.PrevCursor != ""
 }
 
 // HasNextPage returns true if there is a next page available.
@@ -205,6 +221,13 @@ func (p *Pagination) NextPageOptions() *ListOptions {
 		return options.WithCursor(p.NextCursor)
 	}
 
+	if p.Page > 0 {
+		options.Page = p.Page + 1
+		options.Offset = DefaultOffset
+
+		return options
+	}
+
 	// Fall back to offset-based pagination
 	return options.WithOffset(p.Offset + p.Limit)
 }
@@ -228,6 +251,13 @@ func (p *Pagination) PrevPageOptions() *ListOptions {
 		return options.WithCursor(p.PrevCursor)
 	}
 
+	if p.Page > 1 {
+		options.Page = p.Page - 1
+		options.Offset = DefaultOffset
+
+		return options
+	}
+
 	// Fall back to offset-based pagination
 	newOffset := p.Offset - p.Limit
 	if newOffset < 0 {
@@ -243,6 +273,10 @@ func (p *Pagination) PrevPageOptions() *ListOptions {
 // Returns:
 //   - The current page number (starts from 1)
 func (p *Pagination) CurrentPage() int {
+	if p.Page > 0 {
+		return p.Page
+	}
+
 	if p.Limit <= 0 {
 		return 1
 	}
@@ -256,7 +290,7 @@ func (p *Pagination) CurrentPage() int {
 // Returns:
 //   - The total number of pages
 func (p *Pagination) TotalPages() int {
-	if p.Limit <= 0 {
+	if p.Limit <= 0 || p.Total <= 0 {
 		return 1
 	}
 
@@ -474,6 +508,46 @@ func (o *ListOptions) WithAdditionalParam(key, value string) *ListOptions {
 	return o
 }
 
+// WithIncludeDeleted adds the CRM include_deleted filter.
+func (o *ListOptions) WithIncludeDeleted(includeDeleted bool) *ListOptions {
+	return o.WithAdditionalParam("include_deleted", strconv.FormatBool(includeDeleted))
+}
+
+// WithHolderID adds the CRM holder_id filter.
+func (o *ListOptions) WithHolderID(holderID string) *ListOptions {
+	return o.WithAdditionalParam("holder_id", holderID)
+}
+
+// WithExternalID adds the CRM external_id filter.
+func (o *ListOptions) WithExternalID(externalID string) *ListOptions {
+	return o.WithAdditionalParam("external_id", externalID)
+}
+
+// WithDocument adds the CRM document filter.
+func (o *ListOptions) WithDocument(document string) *ListOptions {
+	return o.WithAdditionalParam("document", document)
+}
+
+// WithAccountID adds the CRM account_id filter.
+func (o *ListOptions) WithAccountID(accountID string) *ListOptions {
+	return o.WithAdditionalParam("account_id", accountID)
+}
+
+// WithLedgerID adds the CRM ledger_id filter.
+func (o *ListOptions) WithLedgerID(ledgerID string) *ListOptions {
+	return o.WithAdditionalParam("ledger_id", ledgerID)
+}
+
+// WithParticipantDocument adds the CRM regulatory_fields_participant_document filter.
+func (o *ListOptions) WithParticipantDocument(document string) *ListOptions {
+	return o.WithAdditionalParam("regulatory_fields_participant_document", document)
+}
+
+// WithRelatedPartyDocument adds the CRM related_party_document filter.
+func (o *ListOptions) WithRelatedPartyDocument(document string) *ListOptions {
+	return o.WithAdditionalParam("related_party_document", document)
+}
+
 // NextPage returns a copy of the ListOptions configured for the next page.
 // This method is useful for implementing pagination in client code.
 //
@@ -532,23 +606,28 @@ func (o *ListOptions) ToQueryParams() map[string]string {
 // Parameters:
 //   - params: The map to add the pagination parameters to
 func (o *ListOptions) addPaginationParams(params map[string]string) {
+	limit := o.Limit
+
 	// Always include limit parameter with at least the default
 	if o.Limit <= 0 {
+		limit = DefaultLimit
 		params[QueryParamLimit] = fmt.Sprintf("%d", DefaultLimit)
 	} else if o.Limit > MaxLimit {
+		limit = MaxLimit
 		params[QueryParamLimit] = fmt.Sprintf("%d", MaxLimit)
 	} else {
 		params[QueryParamLimit] = fmt.Sprintf("%d", o.Limit)
 	}
 
-	// Add offset if specified
-	if o.Offset > 0 {
-		params[QueryParamOffset] = fmt.Sprintf("%d", o.Offset)
-	}
-
-	// These are kept for backward compatibility
 	if o.Page > 0 {
 		params[QueryParamPage] = fmt.Sprintf("%d", o.Page)
+		return
+	}
+
+	// Keep offset as a client-side compatibility input, but serialize Midaz's
+	// page-based contract on the wire.
+	if o.Offset > 0 {
+		params[QueryParamPage] = fmt.Sprintf("%d", (o.Offset/limit)+1)
 	}
 
 	if o.Cursor != "" {
@@ -580,11 +659,8 @@ func (o *ListOptions) addFilteringParams(params map[string]string) {
 // Parameters:
 //   - params: The map to add the sorting parameters to
 func (o *ListOptions) addSortingParams(params map[string]string) {
-	if o.OrderBy != "" {
-		params[QueryParamOrderBy] = o.OrderBy
-	}
-
-	// Always include order direction with at least the default
+	// Midaz list endpoints expose sort direction, but not a generic order-by field.
+	// Keep OrderBy as an SDK-side compatibility field without serializing it.
 	if o.OrderDirection == "" {
 		params[QueryParamOrderDirection] = DefaultSortDirection
 	} else {
@@ -658,6 +734,49 @@ type ListResponse[T any] struct {
 
 	// Pagination contains information about the pagination state
 	Pagination Pagination `json:"pagination,omitempty"`
+}
+
+// UnmarshalJSON supports both the legacy nested pagination envelope and the
+// current Midaz top-level pagination fields.
+func (r *ListResponse[T]) UnmarshalJSON(data []byte) error {
+	type alias ListResponse[T]
+
+	aux := struct {
+		alias
+		Limit      int         `json:"limit,omitempty"`
+		Page       int         `json:"page,omitempty"`
+		Offset     int         `json:"offset,omitempty"`
+		Total      int         `json:"total,omitempty"`
+		NextCursor string      `json:"next_cursor,omitempty"`
+		PrevCursor string      `json:"prev_cursor,omitempty"`
+		Pagination *Pagination `json:"pagination,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*r = ListResponse[T](aux.alias)
+	if r.Items == nil {
+		r.Items = make([]T, 0)
+	}
+
+	if aux.Pagination != nil {
+		r.Pagination = *aux.Pagination
+	} else {
+		r.Pagination = Pagination{
+			Limit:      aux.Limit,
+			Page:       aux.Page,
+			Offset:     aux.Offset,
+			Total:      aux.Total,
+			NextCursor: aux.NextCursor,
+			PrevCursor: aux.PrevCursor,
+		}
+	}
+
+	r.Pagination.ItemCount = len(r.Items)
+
+	return nil
 }
 
 // ErrorResponse represents an error response from the API.

--- a/models/common.go
+++ b/models/common.go
@@ -624,10 +624,12 @@ func (o *ListOptions) addPaginationParams(params map[string]string) {
 		return
 	}
 
-	// Keep offset as a client-side compatibility input, but serialize Midaz's
-	// page-based contract on the wire.
 	if o.Offset > 0 {
-		params[QueryParamPage] = fmt.Sprintf("%d", (o.Offset/limit)+1)
+		if o.Offset%limit == 0 {
+			params[QueryParamPage] = fmt.Sprintf("%d", (o.Offset/limit)+1)
+		} else {
+			params[QueryParamOffset] = fmt.Sprintf("%d", o.Offset)
+		}
 	}
 
 	if o.Cursor != "" {

--- a/models/constants.go
+++ b/models/constants.go
@@ -106,8 +106,8 @@ const (
 	// DefaultPage is the default page number for backward compatibility
 	DefaultPage = 1
 
-	// DefaultSortDirection is the default sort direction
-	DefaultSortDirection = string(SortDescending)
+	// DefaultSortDirection is the default sort direction.
+	DefaultSortDirection = string(SortAscending)
 )
 
 // QueryParamNames contains the names of query parameters used for API requests.
@@ -116,7 +116,8 @@ const (
 	// QueryParamLimit is the query parameter name for limit
 	QueryParamLimit = "limit"
 
-	// QueryParamOffset is the query parameter name for offset
+	// QueryParamOffset is the legacy query parameter name for offset.
+	// Deprecated: current Midaz list endpoints use page-based pagination on the wire.
 	QueryParamOffset = "offset"
 
 	// QueryParamPage is the query parameter name for page (backward compatibility)
@@ -125,15 +126,16 @@ const (
 	// QueryParamCursor is the query parameter name for cursor
 	QueryParamCursor = "cursor"
 
-	// QueryParamOrderBy is the query parameter name for the field to order by
+	// QueryParamOrderBy is the legacy query parameter name for the field to order by.
+	// Deprecated: current Midaz list endpoints do not expose a generic order-by query parameter.
 	QueryParamOrderBy = "orderBy"
 
-	// QueryParamOrderDirection is the query parameter name for sort direction
-	QueryParamOrderDirection = "orderDirection"
+	// QueryParamOrderDirection is the query parameter name for sort direction.
+	QueryParamOrderDirection = "sort_order"
 
-	// QueryParamStartDate is the query parameter name for start date
-	QueryParamStartDate = "startDate"
+	// QueryParamStartDate is the query parameter name for start date.
+	QueryParamStartDate = "start_date"
 
-	// QueryParamEndDate is the query parameter name for end date
-	QueryParamEndDate = "endDate"
+	// QueryParamEndDate is the query parameter name for end date.
+	QueryParamEndDate = "end_date"
 )

--- a/models/constants_test.go
+++ b/models/constants_test.go
@@ -143,8 +143,8 @@ func TestPaginationDefaults(t *testing.T) {
 }
 
 func TestDefaultSortDirection(t *testing.T) {
-	if DefaultSortDirection != string(SortDescending) {
-		t.Errorf("Expected DefaultSortDirection to be %s, got %s", string(SortDescending), DefaultSortDirection)
+	if DefaultSortDirection != string(SortAscending) {
+		t.Errorf("Expected DefaultSortDirection to be %s, got %s", string(SortAscending), DefaultSortDirection)
 	}
 }
 
@@ -182,17 +182,17 @@ func TestQueryParamNames(t *testing.T) {
 		{
 			name:     "QueryParamOrderDirection",
 			constant: QueryParamOrderDirection,
-			expected: "orderDirection",
+			expected: "sort_order",
 		},
 		{
 			name:     "QueryParamStartDate",
 			constant: QueryParamStartDate,
-			expected: "startDate",
+			expected: "start_date",
 		},
 		{
 			name:     "QueryParamEndDate",
 			constant: QueryParamEndDate,
-			expected: "endDate",
+			expected: "end_date",
 		},
 	}
 

--- a/models/crm_test.go
+++ b/models/crm_test.go
@@ -37,6 +37,15 @@ func TestUpdateAliasInput_JSONExplicitNullFields(t *testing.T) {
 	assert.JSONEq(t, `{"regulatoryFields":null}`, string(data))
 }
 
+func TestUpdateAliasInput_RejectsEmptyPayload(t *testing.T) {
+	input := NewUpdateAliasInput()
+
+	require.ErrorContains(t, input.Validate(), "empty update payload not allowed")
+
+	_, err := json.Marshal(input)
+	require.ErrorContains(t, err, "empty update payload not allowed")
+}
+
 func TestCreateHolderInput_Validate(t *testing.T) {
 	holderType := "NATURAL_PERSON"
 	input := &CreateHolderInput{

--- a/models/crm_test.go
+++ b/models/crm_test.go
@@ -1,0 +1,97 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateHolderInput_JSONOmitEmpty(t *testing.T) {
+	name := "Jane Updated"
+	data, err := json.Marshal(&UpdateHolderInput{Name: &name})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"name":"Jane Updated"}`, string(data))
+}
+
+func TestUpdateHolderInput_JSONExplicitNullFields(t *testing.T) {
+	data, err := json.Marshal((&UpdateHolderInput{}).WithNullFields("contact", "metadata"))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"contact":null,"metadata":null}`, string(data))
+}
+
+func TestUpdateAliasInput_JSONOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(&UpdateAliasInput{Metadata: map[string]any{"risk": "low"}})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"metadata":{"risk":"low"}}`, string(data))
+}
+
+func TestUpdateAliasInput_JSONExplicitNullFields(t *testing.T) {
+	data, err := json.Marshal((&UpdateAliasInput{}).WithNullFields("regulatoryFields"))
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"regulatoryFields":null}`, string(data))
+}
+
+func TestCreateHolderInput_Validate(t *testing.T) {
+	holderType := "NATURAL_PERSON"
+	input := &CreateHolderInput{
+		Type:     &holderType,
+		Name:     "Jane Doe",
+		Document: "12345678900",
+		Metadata: map[string]any{"tier": "gold"},
+	}
+
+	require.NoError(t, input.Validate())
+}
+
+func TestCreateHolderInput_ValidateRejectsInvalidType(t *testing.T) {
+	holderType := "INVALID"
+	input := &CreateHolderInput{
+		Type:     &holderType,
+		Name:     "Jane Doe",
+		Document: "12345678900",
+	}
+
+	err := input.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NATURAL_PERSON or LEGAL_PERSON")
+}
+
+func TestCreateAliasInput_Validate(t *testing.T) {
+	input := &CreateAliasInput{
+		LedgerID:  "ledger-123",
+		AccountID: "account-123",
+		RelatedParties: []*RelatedParty{{
+			Document:  "12345678900",
+			Name:      "Jane Doe",
+			Role:      "PRIMARY_HOLDER",
+			StartDate: "2026-01-01",
+		}},
+	}
+
+	require.NoError(t, input.Validate())
+}
+
+func TestCreateAliasInput_ValidateRelatedPartyDates(t *testing.T) {
+	endDate := "2025-12-31"
+	input := &CreateAliasInput{
+		LedgerID:  "ledger-123",
+		AccountID: "account-123",
+		RelatedParties: []*RelatedParty{{
+			Document:  "12345678900",
+			Name:      "Jane Doe",
+			Role:      "PRIMARY_HOLDER",
+			StartDate: "2026-01-01",
+			EndDate:   &endDate,
+		}},
+	}
+
+	err := input.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "endDate must not be before startDate")
+}

--- a/models/holder.go
+++ b/models/holder.go
@@ -37,6 +37,172 @@ type UpdateHolderInput struct {
 	NullFields    []string       `json:"-"`
 }
 
+// NewCreateHolderInput creates a holder create payload with required fields set.
+func NewCreateHolderInput(holderType, name, document string) *CreateHolderInput {
+	return &CreateHolderInput{
+		Type:     holderStringPtr(holderType),
+		Name:     name,
+		Document: document,
+	}
+}
+
+// WithExternalID sets the holder external identifier.
+func (input *CreateHolderInput) WithExternalID(externalID string) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.ExternalID = holderStringPtr(externalID)
+
+	return input
+}
+
+// WithAddresses sets holder addresses.
+func (input *CreateHolderInput) WithAddresses(addresses *Addresses) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Addresses = addresses
+
+	return input
+}
+
+// WithContact sets holder contact data.
+func (input *CreateHolderInput) WithContact(contact *Contact) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Contact = contact
+
+	return input
+}
+
+// WithNaturalPerson sets natural-person holder details.
+func (input *CreateHolderInput) WithNaturalPerson(naturalPerson *NaturalPerson) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.NaturalPerson = naturalPerson
+
+	return input
+}
+
+// WithLegalPerson sets legal-person holder details.
+func (input *CreateHolderInput) WithLegalPerson(legalPerson *LegalPerson) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.LegalPerson = legalPerson
+
+	return input
+}
+
+// WithMetadata sets holder metadata.
+func (input *CreateHolderInput) WithMetadata(metadata map[string]any) *CreateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Metadata = metadata
+
+	return input
+}
+
+// NewUpdateHolderInput creates an empty holder update payload.
+func NewUpdateHolderInput() *UpdateHolderInput {
+	return &UpdateHolderInput{}
+}
+
+// WithExternalID sets the holder external identifier for update.
+func (input *UpdateHolderInput) WithExternalID(externalID string) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.ExternalID = holderStringPtr(externalID)
+
+	return input
+}
+
+// WithName sets the holder name for update.
+func (input *UpdateHolderInput) WithName(name string) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Name = holderStringPtr(name)
+
+	return input
+}
+
+// WithAddresses sets holder addresses for update.
+func (input *UpdateHolderInput) WithAddresses(addresses *Addresses) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Addresses = addresses
+
+	return input
+}
+
+// WithContact sets holder contact data for update.
+func (input *UpdateHolderInput) WithContact(contact *Contact) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Contact = contact
+
+	return input
+}
+
+// WithNaturalPerson sets natural-person holder details for update.
+func (input *UpdateHolderInput) WithNaturalPerson(naturalPerson *NaturalPerson) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.NaturalPerson = naturalPerson
+
+	return input
+}
+
+// WithLegalPerson sets legal-person holder details for update.
+func (input *UpdateHolderInput) WithLegalPerson(legalPerson *LegalPerson) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.LegalPerson = legalPerson
+
+	return input
+}
+
+// WithMetadata sets holder metadata for update.
+func (input *UpdateHolderInput) WithMetadata(metadata map[string]any) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Metadata = metadata
+
+	return input
+}
+
+// WithNullField marks one field for explicit null removal.
+func (input *UpdateHolderInput) WithNullField(field string) *UpdateHolderInput {
+	return input.WithNullFields(field)
+}
+
+func holderStringPtr(value string) *string {
+	return &value
+}
+
 // Validate validates the CreateHolderInput fields.
 func (input *CreateHolderInput) Validate() error {
 	if input == nil {

--- a/models/holder.go
+++ b/models/holder.go
@@ -1,0 +1,236 @@
+package models
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation/core"
+)
+
+// CreateHolderInput is the payload for creating a CRM holder.
+type CreateHolderInput struct {
+	ExternalID    *string        `json:"externalId"`
+	Type          *string        `json:"type"`
+	Name          string         `json:"name"`
+	Document      string         `json:"document"`
+	Addresses     *Addresses     `json:"addresses"`
+	Contact       *Contact       `json:"contact"`
+	NaturalPerson *NaturalPerson `json:"naturalPerson"`
+	LegalPerson   *LegalPerson   `json:"legalPerson"`
+	Metadata      map[string]any `json:"metadata"`
+}
+
+// UpdateHolderInput is the payload for updating a CRM holder.
+type UpdateHolderInput struct {
+	ExternalID    *string        `json:"externalId,omitempty"`
+	Name          *string        `json:"name,omitempty"`
+	Addresses     *Addresses     `json:"addresses,omitempty"`
+	Contact       *Contact       `json:"contact,omitempty"`
+	NaturalPerson *NaturalPerson `json:"naturalPerson,omitempty"`
+	LegalPerson   *LegalPerson   `json:"legalPerson,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	NullFields    []string       `json:"-"`
+}
+
+// Validate validates the CreateHolderInput fields.
+func (input *CreateHolderInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if input.Type == nil || *input.Type == "" {
+		return errors.New("type is required")
+	}
+
+	if !isValidHolderType(*input.Type) {
+		return errors.New("type must be NATURAL_PERSON or LEGAL_PERSON")
+	}
+
+	if input.Name == "" {
+		return errors.New("name is required")
+	}
+
+	if input.Document == "" {
+		return errors.New("document is required")
+	}
+
+	if len(input.Metadata) > 0 {
+		if err := core.ValidateMetadata(input.Metadata); err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// WithNullFields marks fields that should be sent as explicit JSON null in PATCH requests.
+func (input *UpdateHolderInput) WithNullFields(fields ...string) *UpdateHolderInput {
+	if input == nil {
+		return nil
+	}
+
+	input.NullFields = append(input.NullFields, fields...)
+
+	return input
+}
+
+// MarshalJSON emits only set fields plus fields explicitly marked for null removal.
+func (input UpdateHolderInput) MarshalJSON() ([]byte, error) {
+	payload := map[string]any{}
+	if input.ExternalID != nil {
+		payload["externalId"] = input.ExternalID
+	}
+
+	if input.Name != nil {
+		payload["name"] = input.Name
+	}
+
+	if input.Addresses != nil {
+		payload["addresses"] = input.Addresses
+	}
+
+	if input.Contact != nil {
+		payload["contact"] = input.Contact
+	}
+
+	if input.NaturalPerson != nil {
+		payload["naturalPerson"] = input.NaturalPerson
+	}
+
+	if input.LegalPerson != nil {
+		payload["legalPerson"] = input.LegalPerson
+	}
+
+	if input.Metadata != nil {
+		payload["metadata"] = input.Metadata
+	}
+
+	for _, field := range input.NullFields {
+		field = strings.TrimSpace(field)
+		if !validHolderNullFields[field] {
+			return nil, fmt.Errorf("unsupported null field %q", field)
+		}
+
+		payload[field] = nil
+	}
+
+	return json.Marshal(payload)
+}
+
+var validHolderNullFields = map[string]bool{
+	"externalId":    true,
+	"name":          true,
+	"addresses":     true,
+	"contact":       true,
+	"naturalPerson": true,
+	"legalPerson":   true,
+	"metadata":      true,
+}
+
+func isValidHolderType(holderType string) bool {
+	switch holderType {
+	case "NATURAL_PERSON", "LEGAL_PERSON":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateCRMNullFields(fields []string, allowed map[string]bool) error {
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			return errors.New("null field cannot be empty")
+		}
+
+		if !allowed[field] {
+			return fmt.Errorf("unsupported null field %q", field)
+		}
+	}
+
+	return nil
+}
+
+// Validate validates the UpdateHolderInput fields.
+func (input *UpdateHolderInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if len(input.Metadata) > 0 {
+		if err := core.ValidateMetadata(input.Metadata); err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+	}
+
+	return validateCRMNullFields(input.NullFields, validHolderNullFields)
+}
+
+// Holder represents a CRM holder.
+type Holder struct {
+	ID            *uuid.UUID     `json:"id,omitempty"`
+	ExternalID    *string        `json:"externalId,omitempty"`
+	Type          *string        `json:"type,omitempty"`
+	Name          *string        `json:"name,omitempty"`
+	Document      *string        `json:"document,omitempty"`
+	Addresses     *Addresses     `json:"addresses,omitempty"`
+	Contact       *Contact       `json:"contact,omitempty"`
+	NaturalPerson *NaturalPerson `json:"naturalPerson,omitempty"`
+	LegalPerson   *LegalPerson   `json:"legalPerson,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+	DeletedAt     *time.Time     `json:"deletedAt"`
+}
+
+// Addresses stores primary and additional holder addresses.
+type Addresses struct {
+	Primary     *Address `json:"primary,omitempty"`
+	Additional1 *Address `json:"additional1,omitempty"`
+	Additional2 *Address `json:"additional2,omitempty"`
+}
+
+// Contact stores holder contact information.
+type Contact struct {
+	PrimaryEmail   *string `json:"primaryEmail,omitempty"`
+	SecondaryEmail *string `json:"secondaryEmail,omitempty"`
+	MobilePhone    *string `json:"mobilePhone,omitempty"`
+	OtherPhone     *string `json:"otherPhone,omitempty"`
+}
+
+// NaturalPerson stores natural-person holder details.
+type NaturalPerson struct {
+	FavoriteName *string `json:"favoriteName,omitempty"`
+	SocialName   *string `json:"socialName,omitempty"`
+	Gender       *string `json:"gender,omitempty"`
+	BirthDate    *string `json:"birthDate,omitempty"`
+	CivilStatus  *string `json:"civilStatus,omitempty"`
+	Nationality  *string `json:"nationality,omitempty"`
+	MotherName   *string `json:"motherName,omitempty"`
+	FatherName   *string `json:"fatherName,omitempty"`
+	Status       *string `json:"status,omitempty"`
+}
+
+// LegalPerson stores legal-person holder details.
+type LegalPerson struct {
+	TradeName      *string         `json:"tradeName,omitempty"`
+	Activity       *string         `json:"activity,omitempty"`
+	Type           *string         `json:"type,omitempty"`
+	FoundingDate   *string         `json:"foundingDate,omitempty"`
+	Size           *string         `json:"size,omitempty"`
+	Status         *string         `json:"status,omitempty"`
+	Representative *Representative `json:"representative,omitempty"`
+}
+
+// Representative stores legal-person representative data.
+type Representative struct {
+	Name     *string `json:"name,omitempty"`
+	Document *string `json:"document,omitempty"`
+	Email    *string `json:"email,omitempty"`
+	Role     *string `json:"role,omitempty"`
+}

--- a/models/holder.go
+++ b/models/holder.go
@@ -217,11 +217,11 @@ func (input *CreateHolderInput) Validate() error {
 		return errors.New("type must be NATURAL_PERSON or LEGAL_PERSON")
 	}
 
-	if input.Name == "" {
+	if strings.TrimSpace(input.Name) == "" {
 		return errors.New("name is required")
 	}
 
-	if input.Document == "" {
+	if strings.TrimSpace(input.Document) == "" {
 		return errors.New("document is required")
 	}
 
@@ -247,6 +247,10 @@ func (input *UpdateHolderInput) WithNullFields(fields ...string) *UpdateHolderIn
 
 // MarshalJSON emits only set fields plus fields explicitly marked for null removal.
 func (input UpdateHolderInput) MarshalJSON() ([]byte, error) {
+	if err := input.validateNullFieldConflicts(); err != nil {
+		return nil, err
+	}
+
 	payload := map[string]any{}
 	if input.ExternalID != nil {
 		payload["externalId"] = input.ExternalID
@@ -286,6 +290,31 @@ func (input UpdateHolderInput) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(payload)
+}
+
+func (input *UpdateHolderInput) validateNullFieldConflicts() error {
+	if input == nil {
+		return nil
+	}
+
+	setFields := map[string]bool{
+		"externalId":    input.ExternalID != nil,
+		"name":          input.Name != nil,
+		"addresses":     input.Addresses != nil,
+		"contact":       input.Contact != nil,
+		"naturalPerson": input.NaturalPerson != nil,
+		"legalPerson":   input.LegalPerson != nil,
+		"metadata":      input.Metadata != nil,
+	}
+
+	for _, field := range input.NullFields {
+		field = strings.TrimSpace(field)
+		if setFields[field] {
+			return fmt.Errorf("field %q cannot be set and cleared in the same request", field)
+		}
+	}
+
+	return nil
 }
 
 var validHolderNullFields = map[string]bool{
@@ -334,7 +363,11 @@ func (input *UpdateHolderInput) Validate() error {
 		}
 	}
 
-	return validateCRMNullFields(input.NullFields, validHolderNullFields)
+	if err := validateCRMNullFields(input.NullFields, validHolderNullFields); err != nil {
+		return err
+	}
+
+	return input.validateNullFieldConflicts()
 }
 
 // Holder represents a CRM holder.

--- a/models/ledger.go
+++ b/models/ledger.go
@@ -10,6 +10,47 @@ import (
 // Ledger is an alias for mmodel.Ledger to maintain compatibility while using midaz entities.
 type Ledger = mmodel.Ledger
 
+// LedgerSettings is an alias for the Midaz ledger settings payload.
+type LedgerSettings = mmodel.LedgerSettings
+
+// UpdateLedgerSettingsAccountingInput is the partial accounting settings payload.
+type UpdateLedgerSettingsAccountingInput struct {
+	ValidateAccountType *bool `json:"validateAccountType,omitempty"`
+	ValidateRoutes      *bool `json:"validateRoutes,omitempty"`
+}
+
+// UpdateLedgerSettingsInput is the partial ledger settings patch payload.
+type UpdateLedgerSettingsInput struct {
+	Accounting *UpdateLedgerSettingsAccountingInput `json:"accounting,omitempty"`
+}
+
+// NewUpdateLedgerSettingsInput creates a new empty ledger settings patch.
+func NewUpdateLedgerSettingsInput() *UpdateLedgerSettingsInput {
+	return &UpdateLedgerSettingsInput{}
+}
+
+// WithValidateAccountType sets the validateAccountType accounting flag.
+func (input *UpdateLedgerSettingsInput) WithValidateAccountType(enabled bool) *UpdateLedgerSettingsInput {
+	if input.Accounting == nil {
+		input.Accounting = &UpdateLedgerSettingsAccountingInput{}
+	}
+
+	input.Accounting.ValidateAccountType = &enabled
+
+	return input
+}
+
+// WithValidateRoutes sets the validateRoutes accounting flag.
+func (input *UpdateLedgerSettingsInput) WithValidateRoutes(enabled bool) *UpdateLedgerSettingsInput {
+	if input.Accounting == nil {
+		input.Accounting = &UpdateLedgerSettingsAccountingInput{}
+	}
+
+	input.Accounting.ValidateRoutes = &enabled
+
+	return input
+}
+
 // CreateLedgerInput wraps mmodel.CreateLedgerInput to maintain compatibility while using midaz entities.
 type CreateLedgerInput struct {
 	mmodel.CreateLedgerInput

--- a/models/metadata_index.go
+++ b/models/metadata_index.go
@@ -26,7 +26,7 @@ type IndexStats struct {
 type CreateMetadataIndexInput struct {
 	MetadataKey string `json:"metadataKey"`
 	Unique      bool   `json:"unique"`
-	Sparse      *bool  `json:"sparse"`
+	Sparse      *bool  `json:"sparse,omitempty"`
 }
 
 var metadataKeyPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)

--- a/models/metadata_index.go
+++ b/models/metadata_index.go
@@ -52,13 +52,10 @@ func (input *CreateMetadataIndexInput) Validate() error {
 	return nil
 }
 
-// NewCreateMetadataIndexInput creates a new CreateMetadataIndexInput with defaults.
+// NewCreateMetadataIndexInput creates a new CreateMetadataIndexInput.
 func NewCreateMetadataIndexInput(metadataKey string) *CreateMetadataIndexInput {
-	sparse := true
-
 	return &CreateMetadataIndexInput{
 		MetadataKey: metadataKey,
-		Sparse:      &sparse,
 	}
 }
 

--- a/models/metadata_index.go
+++ b/models/metadata_index.go
@@ -1,0 +1,96 @@
+package models
+
+import (
+	"errors"
+	"regexp"
+	"time"
+)
+
+// MetadataIndex represents a custom metadata index.
+type MetadataIndex struct {
+	IndexName   string      `json:"indexName"`
+	EntityName  string      `json:"entityName"`
+	MetadataKey string      `json:"metadataKey"`
+	Unique      bool        `json:"unique"`
+	Sparse      bool        `json:"sparse"`
+	Stats       *IndexStats `json:"stats,omitempty"`
+}
+
+// IndexStats represents usage statistics for a metadata index.
+type IndexStats struct {
+	Accesses   int64      `json:"accesses"`
+	StatsSince *time.Time `json:"statsSince,omitempty"`
+}
+
+// CreateMetadataIndexInput is the payload for creating a metadata index.
+type CreateMetadataIndexInput struct {
+	MetadataKey string `json:"metadataKey"`
+	Unique      bool   `json:"unique"`
+	Sparse      *bool  `json:"sparse"`
+}
+
+var metadataKeyPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_]*$`)
+
+// Validate validates the CreateMetadataIndexInput fields.
+func (input *CreateMetadataIndexInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if input.MetadataKey == "" {
+		return errors.New("metadataKey is required")
+	}
+
+	if len(input.MetadataKey) > 100 {
+		return errors.New("metadataKey must be at most 100 characters")
+	}
+
+	if !metadataKeyPattern.MatchString(input.MetadataKey) {
+		return errors.New("metadataKey must start with a letter and contain only letters, numbers, or underscores")
+	}
+
+	return nil
+}
+
+// NewCreateMetadataIndexInput creates a new CreateMetadataIndexInput with defaults.
+func NewCreateMetadataIndexInput(metadataKey string) *CreateMetadataIndexInput {
+	sparse := true
+
+	return &CreateMetadataIndexInput{
+		MetadataKey: metadataKey,
+		Sparse:      &sparse,
+	}
+}
+
+// WithUnique sets whether the metadata index should be unique.
+func (input *CreateMetadataIndexInput) WithUnique(unique bool) *CreateMetadataIndexInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Unique = unique
+
+	return input
+}
+
+// WithSparse sets whether the metadata index should be sparse.
+func (input *CreateMetadataIndexInput) WithSparse(sparse bool) *CreateMetadataIndexInput {
+	if input == nil {
+		return nil
+	}
+
+	input.Sparse = &sparse
+
+	return input
+}
+
+// IsValidMetadataIndexEntity reports whether entityName supports metadata indexes.
+func IsValidMetadataIndexEntity(entityName string) bool {
+	switch entityName {
+	case "organization", "ledger", "segment", "account", "portfolio", "asset", "account_type",
+		"transaction", "operation", "operation_route", "transaction_route":
+		return true
+	default:
+		return false
+	}
+}

--- a/models/model_test.go
+++ b/models/model_test.go
@@ -624,7 +624,7 @@ func TestListOptionsToQueryParams(t *testing.T) {
 
 	expectedParams := map[string]string{
 		QueryParamLimit:          "25",
-		QueryParamPage:           "1",
+		QueryParamOffset:         "10",
 		QueryParamOrderDirection: string(SortAscending),
 		QueryParamStartDate:      "2023-01-01",
 		QueryParamEndDate:        "2023-12-31",
@@ -638,8 +638,8 @@ func TestListOptionsToQueryParams(t *testing.T) {
 		}
 	}
 
-	if _, exists := params[QueryParamOffset]; exists {
-		t.Errorf("Did not expect legacy offset query parameter")
+	if _, exists := params[QueryParamPage]; exists {
+		t.Errorf("Did not expect lossy page query parameter for non-aligned offset")
 	}
 
 	if _, exists := params[QueryParamOrderBy]; exists {

--- a/models/model_test.go
+++ b/models/model_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
@@ -623,8 +624,7 @@ func TestListOptionsToQueryParams(t *testing.T) {
 
 	expectedParams := map[string]string{
 		QueryParamLimit:          "25",
-		QueryParamOffset:         "10",
-		QueryParamOrderBy:        "name",
+		QueryParamPage:           "1",
 		QueryParamOrderDirection: string(SortAscending),
 		QueryParamStartDate:      "2023-01-01",
 		QueryParamEndDate:        "2023-12-31",
@@ -636,6 +636,128 @@ func TestListOptionsToQueryParams(t *testing.T) {
 		if actualValue, exists := params[key]; !exists || actualValue != expectedValue {
 			t.Errorf("Expected %s=%s, got %s=%s", key, expectedValue, key, actualValue)
 		}
+	}
+
+	if _, exists := params[QueryParamOffset]; exists {
+		t.Errorf("Did not expect legacy offset query parameter")
+	}
+
+	if _, exists := params[QueryParamOrderBy]; exists {
+		t.Errorf("Did not expect legacy orderBy query parameter")
+	}
+}
+
+func TestListOptionsCRMFilters(t *testing.T) {
+	params := NewListOptions().
+		WithIncludeDeleted(true).
+		WithHolderID("holder-123").
+		WithExternalID("external-123").
+		WithDocument("12345678900").
+		WithAccountID("account-123").
+		WithLedgerID("ledger-123").
+		WithParticipantDocument("11222333000199").
+		WithRelatedPartyDocument("99988877766").
+		ToQueryParams()
+
+	expected := map[string]string{
+		"include_deleted":                        "true",
+		"holder_id":                              "holder-123",
+		"external_id":                            "external-123",
+		"document":                               "12345678900",
+		"account_id":                             "account-123",
+		"ledger_id":                              "ledger-123",
+		"regulatory_fields_participant_document": "11222333000199",
+		"related_party_document":                 "99988877766",
+	}
+	for key, value := range expected {
+		if params[key] != value {
+			t.Errorf("Expected %s=%s, got %s", key, value, params[key])
+		}
+	}
+}
+
+func TestListResponseUnmarshalJSONTopLevelPagination(t *testing.T) {
+	data := []byte(`{
+		"items": [{"id": "org-1"}],
+		"limit": 10,
+		"page": 2,
+		"next_cursor": "next-123",
+		"prev_cursor": "prev-456"
+	}`)
+
+	var response ListResponse[map[string]any]
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(response.Items))
+	}
+
+	if response.Pagination.Limit != 10 {
+		t.Fatalf("expected limit 10, got %d", response.Pagination.Limit)
+	}
+
+	if response.Pagination.Page != 2 {
+		t.Fatalf("expected page 2, got %d", response.Pagination.Page)
+	}
+
+	if response.Pagination.NextCursor != "next-123" {
+		t.Fatalf("expected next cursor next-123, got %s", response.Pagination.NextCursor)
+	}
+
+	if response.Pagination.PrevCursor != "prev-456" {
+		t.Fatalf("expected prev cursor prev-456, got %s", response.Pagination.PrevCursor)
+	}
+
+	if response.Pagination.ItemCount != 1 {
+		t.Fatalf("expected item count 1, got %d", response.Pagination.ItemCount)
+	}
+}
+
+func TestListResponseUnmarshalJSONLegacyNestedPagination(t *testing.T) {
+	data := []byte(`{
+		"items": [{"id": "org-1"}],
+		"pagination": {
+			"limit": 10,
+			"offset": 20,
+			"total": 55,
+			"next_cursor": "next-legacy",
+			"prev_cursor": "prev-legacy"
+		}
+	}`)
+
+	var response ListResponse[map[string]any]
+	if err := json.Unmarshal(data, &response); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(response.Items))
+	}
+
+	if response.Pagination.Limit != 10 {
+		t.Fatalf("expected limit 10, got %d", response.Pagination.Limit)
+	}
+
+	if response.Pagination.Offset != 20 {
+		t.Fatalf("expected offset 20, got %d", response.Pagination.Offset)
+	}
+
+	if response.Pagination.Total != 55 {
+		t.Fatalf("expected total 55, got %d", response.Pagination.Total)
+	}
+
+	if response.Pagination.NextCursor != "next-legacy" {
+		t.Fatalf("expected next cursor next-legacy, got %s", response.Pagination.NextCursor)
+	}
+
+	if response.Pagination.PrevCursor != "prev-legacy" {
+		t.Fatalf("expected prev cursor prev-legacy, got %s", response.Pagination.PrevCursor)
+	}
+
+	if response.Pagination.ItemCount != 1 {
+		t.Fatalf("expected item count 1, got %d", response.Pagination.ItemCount)
 	}
 }
 

--- a/models/operation-route.go
+++ b/models/operation-route.go
@@ -20,16 +20,12 @@ func (input *CreateOperationRouteInput) Validate() error {
 		return errors.New("title is required")
 	}
 
-	if input.Description == "" {
-		return errors.New("description is required")
-	}
-
 	if input.OperationType == "" {
 		return errors.New("operationType is required")
 	}
 	// Validate operation type
-	if input.OperationType != "source" && input.OperationType != "destination" {
-		return errors.New("operationType must be 'source' or 'destination'")
+	if input.OperationType != "source" && input.OperationType != "destination" && input.OperationType != "bidirectional" {
+		return errors.New("operationType must be 'source', 'destination', or 'bidirectional'")
 	}
 
 	return nil
@@ -116,6 +112,8 @@ const (
 	OperationRouteTypeSource OperationRouteType = "source"
 	// OperationRouteTypeDestination represents destination operation type
 	OperationRouteTypeDestination OperationRouteType = "destination"
+	// OperationRouteTypeBidirectional represents bidirectional operation type
+	OperationRouteTypeBidirectional OperationRouteType = "bidirectional"
 )
 
 // OperationRouteInputType represents the type for operation route input (different from response)
@@ -127,6 +125,8 @@ const (
 	OperationRouteInputTypeSource OperationRouteInputType = "source"
 	// OperationRouteInputTypeDestination represents destination input type
 	OperationRouteInputTypeDestination OperationRouteInputType = "destination"
+	// OperationRouteInputTypeBidirectional represents bidirectional input type
+	OperationRouteInputTypeBidirectional OperationRouteInputType = "bidirectional"
 )
 
 // NewCreateOperationRouteInput creates a new CreateOperationRouteInput with required fields.
@@ -134,7 +134,7 @@ const (
 // Parameters:
 //   - title: Short text summarizing the purpose of the operation
 //   - description: Detailed description of the operation route purpose and usage
-//   - operationType: The type of the operation route ("source" or "destination")
+//   - operationType: The type of the operation route ("source", "destination", or "bidirectional")
 //
 // Returns:
 //   - A pointer to the newly created CreateOperationRouteInput

--- a/models/operation.go
+++ b/models/operation.go
@@ -390,7 +390,7 @@ func (input *CreateOperationInput) Validate() error {
 	}
 
 	if err := validatePositiveDecimalString(input.Amount, "amount"); err != nil {
-		return errors.New("amount must be a positive decimal")
+		return fmt.Errorf("invalid amount: %w", err)
 	}
 
 	// Validate asset code if provided

--- a/models/operation.go
+++ b/models/operation.go
@@ -139,7 +139,7 @@ type Operation struct {
 	Direction string `json:"direction,omitempty"`
 
 	// BalanceAffected indicates whether the operation changes balances.
-	BalanceAffected bool `json:"balanceAffected,omitempty"`
+	BalanceAffected *bool `json:"balanceAffected,omitempty"`
 
 	// BalanceKey is the key of the affected balance.
 	BalanceKey string `json:"balanceKey,omitempty"`
@@ -341,7 +341,10 @@ type CreateOperationInput struct {
 	// This must be a valid account ID in the ledger
 	AccountID string `json:"accountId"`
 
-	// Amount is the exact decimal value of the operation.
+	// Amount is the exact decimal value of the operation. Use Amount or *Amount
+	// when decimal scaling is required, or pass an already-formatted decimal
+	// string. Raw numeric types such as int and float are treated as literal
+	// decimal strings by normalizedOperationAmount through decimalStringFromAny.
 	Amount any `json:"amount"`
 
 	// AssetCode identifies the currency or asset type for this operation

--- a/models/operation.go
+++ b/models/operation.go
@@ -126,6 +126,24 @@ type Operation struct {
 	// format: string
 	Route string `json:"route" example:"00000000-0000-0000-0000-000000000000" format:"string"`
 
+	// RouteID is the UUID of the operation route.
+	RouteID string `json:"routeId,omitempty"`
+
+	// RouteCode is the human-readable code of the operation route.
+	RouteCode string `json:"routeCode,omitempty"`
+
+	// RouteDescription is the human-readable description of the operation route.
+	RouteDescription string `json:"routeDescription,omitempty"`
+
+	// Direction indicates whether the operation is a debit or credit.
+	Direction string `json:"direction,omitempty"`
+
+	// BalanceAffected indicates whether the operation changes balances.
+	BalanceAffected bool `json:"balanceAffected,omitempty"`
+
+	// BalanceKey is the key of the affected balance.
+	BalanceKey string `json:"balanceKey,omitempty"`
+
 	// Timestamp when the operation was created
 	// example: 2021-01-01T00:00:00Z
 	// format: date-time
@@ -323,9 +341,8 @@ type CreateOperationInput struct {
 	// This must be a valid account ID in the ledger
 	AccountID string `json:"accountId"`
 
-	// Amount is the numeric value of the operation as a decimal string
-	// Examples: "100.50", "1000.00", "0.25"
-	Amount string `json:"amount"`
+	// Amount is the exact decimal value of the operation.
+	Amount any `json:"amount"`
 
 	// AssetCode identifies the currency or asset type for this operation
 	// Common examples include "USD", "EUR", "BTC", etc.
@@ -349,6 +366,10 @@ type CreateOperationInput struct {
 // Returns:
 //   - error: An error if validation fails, nil otherwise
 func (input *CreateOperationInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
 	// Validate required fields
 	if input.Type == "" {
 		return errors.New("type is required")
@@ -364,8 +385,12 @@ func (input *CreateOperationInput) Validate() error {
 	}
 
 	// Validate amount
-	if input.Amount == "" {
+	if input.Amount == nil {
 		return errors.New("amount is required")
+	}
+
+	if err := validatePositiveDecimalString(input.Amount, "amount"); err != nil {
+		return errors.New("amount must be a positive decimal")
 	}
 
 	// Validate asset code if provided

--- a/models/organization.go
+++ b/models/organization.go
@@ -21,6 +21,10 @@ func (input *CreateOrganizationInput) Validate() error {
 		return errors.New("legalName is required")
 	}
 
+	if input.LegalDocument == "" {
+		return errors.New("legalDocument is required")
+	}
+
 	return nil
 }
 
@@ -46,10 +50,11 @@ func (input *UpdateOrganizationInput) ToMmodelUpdateOrganizationInput() *mmodel.
 }
 
 // NewCreateOrganizationInput creates a new CreateOrganizationInput with required fields.
-func NewCreateOrganizationInput(legalName string) *CreateOrganizationInput {
+func NewCreateOrganizationInput(legalName, legalDocument string) *CreateOrganizationInput {
 	return &CreateOrganizationInput{
 		CreateOrganizationInput: mmodel.CreateOrganizationInput{
-			LegalName: legalName,
+			LegalName:     legalName,
+			LegalDocument: legalDocument,
 		},
 	}
 }

--- a/models/transaction-route.go
+++ b/models/transaction-route.go
@@ -57,16 +57,18 @@ func NewCreateTransactionRouteInput(title, description string, operationRoutes [
 	// Convert string UUIDs to uuid.UUID type
 	var parseErr error
 
-	uuidRoutes := make([]uuid.UUID, len(operationRoutes))
+	uuidRoutes := make([]uuid.UUID, 0, len(operationRoutes))
 
 	for i, routeStr := range operationRoutes {
 		routeUUID, err := uuid.Parse(routeStr)
 		if err != nil {
 			parseErr = fmt.Errorf("operationRoutes[%d] must be a valid UUID: %w", i, err)
+			uuidRoutes = nil
+
 			break
 		}
 
-		uuidRoutes[i] = routeUUID
+		uuidRoutes = append(uuidRoutes, routeUUID)
 	}
 
 	return &CreateTransactionRouteInput{

--- a/models/transaction-route.go
+++ b/models/transaction-route.go
@@ -23,12 +23,12 @@ func (input *CreateTransactionRouteInput) Validate() error {
 		return errors.New("title is required")
 	}
 
-	if len(input.OperationRoutes) == 0 {
-		return errors.New("operationRoutes is required")
-	}
-
 	if input.parseErr != nil {
 		return input.parseErr
+	}
+
+	if len(input.OperationRoutes) == 0 {
+		return errors.New("operationRoutes is required")
 	}
 
 	return nil

--- a/models/transaction-route.go
+++ b/models/transaction-route.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/LerianStudio/midaz/v3/pkg/mmodel"
 	"github.com/google/uuid"
@@ -13,6 +14,7 @@ type TransactionRoute = mmodel.TransactionRoute
 // CreateTransactionRouteInput wraps mmodel.CreateTransactionRouteInput to maintain compatibility while using midaz entities.
 type CreateTransactionRouteInput struct {
 	mmodel.CreateTransactionRouteInput
+	parseErr error
 }
 
 // Validate validates the CreateTransactionRouteInput fields.
@@ -21,8 +23,12 @@ func (input *CreateTransactionRouteInput) Validate() error {
 		return errors.New("title is required")
 	}
 
-	if input.Description == "" {
-		return errors.New("description is required")
+	if len(input.OperationRoutes) == 0 {
+		return errors.New("operationRoutes is required")
+	}
+
+	if input.parseErr != nil {
+		return input.parseErr
 	}
 
 	return nil
@@ -49,12 +55,18 @@ func (*UpdateTransactionRouteInput) Validate() error {
 //   - A pointer to the newly created CreateTransactionRouteInput
 func NewCreateTransactionRouteInput(title, description string, operationRoutes []string) *CreateTransactionRouteInput {
 	// Convert string UUIDs to uuid.UUID type
+	var parseErr error
+
 	uuidRoutes := make([]uuid.UUID, len(operationRoutes))
 
 	for i, routeStr := range operationRoutes {
-		if routeUUID, err := uuid.Parse(routeStr); err == nil {
-			uuidRoutes[i] = routeUUID
+		routeUUID, err := uuid.Parse(routeStr)
+		if err != nil {
+			parseErr = fmt.Errorf("operationRoutes[%d] must be a valid UUID: %w", i, err)
+			break
 		}
+
+		uuidRoutes[i] = routeUUID
 	}
 
 	return &CreateTransactionRouteInput{
@@ -63,6 +75,7 @@ func NewCreateTransactionRouteInput(title, description string, operationRoutes [
 			Description:     description,
 			OperationRoutes: uuidRoutes,
 		},
+		parseErr: parseErr,
 	}
 }
 

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -791,7 +791,7 @@ func (input *CreateTransactionInput) ensureSendFromLegacyOperations() {
 
 	send := &SendInput{
 		Asset:      asset,
-		Value:      input.Amount,
+		Value:      normalizedOperationAmount(input.Amount),
 		Source:     &SourceInput{},
 		Distribute: &DistributeInput{},
 	}
@@ -801,7 +801,7 @@ func (input *CreateTransactionInput) ensureSendFromLegacyOperations() {
 			Account: operation.AccountID,
 			Amount: AmountInput{
 				Asset: operation.AssetCode,
-				Value: operation.Amount,
+				Value: normalizedOperationAmount(operation.Amount),
 			},
 			Route: operation.Route,
 		}
@@ -823,6 +823,31 @@ func (input *CreateTransactionInput) ensureSendFromLegacyOperations() {
 	}
 
 	input.Send = send
+}
+
+func normalizedOperationAmount(amount any) string {
+	switch value := amount.(type) {
+	case Amount:
+		if value.Value == nil {
+			return ""
+		}
+
+		return value.Value.String()
+	case *Amount:
+		if value == nil || value.Value == nil {
+			return ""
+		}
+
+		return value.Value.String()
+	case *decimal.Decimal:
+		if value == nil {
+			return ""
+		}
+
+		return value.String()
+	default:
+		return decimalStringFromAny(amount)
+	}
 }
 
 // ToMap converts a SendInput to a map.

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -138,7 +138,7 @@ func validatePositiveDecimalString(value any, field string) error {
 	}
 
 	if !parsed.IsPositive() {
-		return fmt.Errorf("%s must be greater than zero; %s must be greater than 0", field, field)
+		return fmt.Errorf("%s must be greater than zero", field)
 	}
 
 	return nil
@@ -431,13 +431,12 @@ type AmountInput struct {
 	Value any `json:"value"`
 }
 
+// transactionDateFormats require explicit timezone information to avoid local-date ambiguity.
 var transactionDateFormats = []string{
 	time.RFC3339Nano,
 	time.RFC3339,
 	"2006-01-02T15:04:05.000Z",
 	"2006-01-02T15:04:05Z",
-	"2006-01-02T15:04:05",
-	"2006-01-02",
 }
 
 // Validate checks that the CreateTransactionInput meets all validation requirements.
@@ -512,7 +511,7 @@ func parseTransactionDate(value string) (time.Time, error) {
 		}
 	}
 
-	return time.Time{}, errors.New("transactionDate must be ISO 8601 date or date-time")
+	return time.Time{}, errors.New("transactionDate must be RFC3339 date-time with explicit timezone")
 }
 
 func transactionCommonMap(chartOfAccountsGroupName, description, code string, metadata map[string]any, route, routeID, transactionDate string, pending bool) map[string]any {
@@ -1499,8 +1498,18 @@ func (input *CreateOutflowInput) ToMap() map[string]any {
 	return tx
 }
 
-// CreateAnnotationInput reuses the Ledger CreateTransactionInput contract.
-type CreateAnnotationInput = CreateTransactionInput
+// CreateAnnotationInput is the payload for creating an annotation transaction.
+type CreateAnnotationInput struct {
+	ChartOfAccountsGroupName string         `json:"chartOfAccountsGroupName,omitempty"`
+	Description              string         `json:"description,omitempty"`
+	Pending                  bool           `json:"pending,omitempty"`
+	Code                     string         `json:"code,omitempty"`
+	Route                    string         `json:"route,omitempty"`
+	RouteID                  string         `json:"routeId,omitempty"`
+	TransactionDate          string         `json:"transactionDate,omitempty"`
+	Metadata                 map[string]any `json:"metadata,omitempty"`
+	Send                     *SendInput     `json:"send,omitempty"`
+}
 
 // NewCreateAnnotationInput creates a new CreateAnnotationInput.
 func NewCreateAnnotationInput(description string, send ...*SendInput) *CreateAnnotationInput {
@@ -1509,10 +1518,55 @@ func NewCreateAnnotationInput(description string, send ...*SendInput) *CreateAnn
 		sendInput = send[0]
 	}
 
-	return &CreateTransactionInput{
+	return &CreateAnnotationInput{
 		Description: description,
 		Send:        sendInput,
 	}
+}
+
+// Validate checks that the CreateAnnotationInput meets all validation requirements.
+func (input *CreateAnnotationInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
+	if err := validateTransactionCreateCommon(input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, input.Pending); err != nil {
+		return err
+	}
+
+	if input.Send != nil {
+		if err := input.Send.Validate(); err != nil {
+			return fmt.Errorf("invalid send: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ToLibTransaction converts a CreateAnnotationInput to the backend transaction payload.
+func (input *CreateAnnotationInput) ToLibTransaction() map[string]any {
+	if input == nil {
+		return nil
+	}
+
+	tx := transactionCommonMap(input.ChartOfAccountsGroupName, input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, input.Pending)
+	if input.Send != nil {
+		tx["send"] = input.Send.ToMap()
+	}
+
+	return tx
+}
+
+// WithCode sets the annotation transaction code.
+func (input *CreateAnnotationInput) WithCode(code string) *CreateAnnotationInput {
+	input.Code = code
+	return input
+}
+
+// WithMetadata sets annotation transaction metadata.
+func (input *CreateAnnotationInput) WithMetadata(metadata map[string]any) *CreateAnnotationInput {
+	input.Metadata = metadata
+	return input
 }
 
 // WithCode sets the transaction code.

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -145,6 +145,10 @@ func validatePositiveDecimalString(value any, field string) error {
 }
 
 func decimalStringFromAny(value any) string {
+	if decimalValue, ok := amountDecimalString(value); ok {
+		return decimalValue
+	}
+
 	switch v := value.(type) {
 	case nil:
 		return ""
@@ -164,6 +168,31 @@ func decimalStringFromAny(value any) string {
 		return v.String()
 	default:
 		return fmt.Sprint(v)
+	}
+}
+
+func amountDecimalString(value any) (string, bool) {
+	switch v := value.(type) {
+	case *decimal.Decimal:
+		if v == nil {
+			return "", true
+		}
+
+		return v.String(), true
+	case Amount:
+		if v.Value == nil {
+			return "", true
+		}
+
+		return v.Value.String(), true
+	case *Amount:
+		if v == nil || v.Value == nil {
+			return "", true
+		}
+
+		return v.Value.String(), true
+	default:
+		return "", false
 	}
 }
 

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -1,13 +1,16 @@
 package models
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation"
 	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation/core"
+	"github.com/shopspring/decimal"
 )
 
 // Transaction represents a transaction in the Midaz Ledger.
@@ -53,8 +56,7 @@ type Transaction struct {
 	// structures and validation rules
 	Template string `json:"template,omitempty"`
 
-	// Amount is the numeric value of the transaction as a decimal string
-	// This represents the total value of the transaction (e.g., "100.50" for $100.50)
+	// Amount is the exact decimal value of the transaction.
 	Amount string `json:"amount"`
 
 	// AssetCode identifies the currency or asset type for this transaction
@@ -64,6 +66,9 @@ type Transaction struct {
 	// Route is the transaction route identifier that defines the overall flow
 	// of the transaction, including the structure of operations to be executed
 	Route string `json:"route,omitempty"`
+
+	// RouteID is the UUID of the transaction route.
+	RouteID string `json:"routeId,omitempty"`
 
 	// Status indicates the current processing status of the transaction
 	// See the Status enum for possible values (PENDING, COMPLETED, FAILED, CANCELED)
@@ -92,6 +97,9 @@ type Transaction struct {
 	// OrganizationID identifies the organization this transaction belongs to
 	// An organization is the top-level entity that owns ledgers and accounts
 	OrganizationID string `json:"organizationId"`
+
+	// ParentTransactionID identifies the parent transaction for linked/reversal flows.
+	ParentTransactionID string `json:"parentTransactionId,omitempty"`
 
 	// Operations contains the individual debit and credit operations
 	// Each operation represents a single accounting entry (debit or credit)
@@ -123,658 +131,45 @@ type Transaction struct {
 	Description string `json:"description,omitempty"`
 }
 
-// DSLAmount represents an amount with a value and asset code for DSL transactions.
-// This is aligned with the lib-commons Amount structure.
-type DSLAmount struct {
-	// Value is the numeric value of the amount as a decimal string
-	Value string `json:"value"`
-
-	// Asset is the asset code for the amount
-	Asset string `json:"asset,omitempty"`
-}
-
-// DSLFromTo represents a source or destination in a DSL transaction.
-// This is aligned with the lib-commons FromTo structure.
-type DSLFromTo struct {
-	// Account is the identifier of the account
-	Account string `json:"account"`
-
-	// Amount specifies the amount details if applicable
-	Amount *DSLAmount `json:"amount,omitempty"`
-
-	// Share is the sharing configuration
-	Share *Share `json:"share,omitempty"`
-
-	// Remaining is an optional remaining account
-	Remaining string `json:"remaining,omitempty"`
-
-	// Rate is the exchange rate configuration
-	Rate *Rate `json:"rate,omitempty"`
-
-	// Description is a human-readable description
-	Description string `json:"description,omitempty"`
-
-	// ChartOfAccounts is the chart of accounts code
-	ChartOfAccounts string `json:"chartOfAccounts,omitempty"`
-
-	// Metadata contains additional custom data
-	Metadata map[string]any `json:"metadata,omitempty"`
-}
-
-// DSLSource represents the source of a DSL transaction.
-// This is aligned with the lib-commons Source structure.
-type DSLSource struct {
-	// Remaining is an optional remaining account
-	Remaining string `json:"remaining,omitempty"`
-
-	// From is a collection of source accounts and amounts
-	From []DSLFromTo `json:"from"`
-}
-
-// DSLDistribute represents the distribution of a DSL transaction.
-// This is aligned with the lib-commons Distribute structure.
-type DSLDistribute struct {
-	// Remaining is an optional remaining account
-	Remaining string `json:"remaining,omitempty"`
-
-	// To is a collection of destination accounts and amounts
-	To []DSLFromTo `json:"to"`
-}
-
-// DSLSend represents the send operation in a DSL transaction.
-// This is aligned with the lib-commons Send structure.
-type DSLSend struct {
-	// Asset identifies the currency or asset type for this transaction
-	Asset string `json:"asset"`
-
-	// Value is the numeric value of the transaction as a decimal string
-	Value string `json:"value"`
-
-	// Source specifies where the funds come from
-	Source *DSLSource `json:"source,omitempty"`
-
-	// Distribute specifies where the funds go to
-	Distribute *DSLDistribute `json:"distribute,omitempty"`
-}
-
-// TransactionDSLInput represents the input for creating a transaction using DSL.
-// This is aligned with the lib-commons Transaction structure.
-type TransactionDSLInput struct {
-	// ChartOfAccountsGroupName specifies the chart of accounts group to use
-	ChartOfAccountsGroupName string `json:"chartOfAccountsGroupName,omitempty"`
-
-	// Description provides a human-readable description of the transaction
-	Description string `json:"description,omitempty"`
-
-	// Send contains the sending configuration
-	Send *DSLSend `json:"send,omitempty"`
-
-	// Metadata contains additional custom data for the transaction
-	Metadata map[string]any `json:"metadata,omitempty"`
-
-	// Code is a custom transaction code for categorization
-	Code string `json:"code,omitempty"`
-
-	// Pending indicates whether the transaction requires explicit commitment
-	Pending bool `json:"pending,omitempty"`
-}
-
-// DSLAccountRef is a helper struct to implement the AccountReference interface
-type DSLAccountRef struct {
-	Account string
-}
-
-// GetAccount returns the account identifier
-func (ref *DSLAccountRef) GetAccount() string {
-	return ref.Account
-}
-
-// GetAsset returns the asset code for the transaction
-func (input *TransactionDSLInput) GetAsset() string {
-	if input.Send == nil {
-		return ""
-	}
-
-	return input.Send.Asset
-}
-
-// GetValue returns the amount value for the transaction
-func (input *TransactionDSLInput) GetValue() float64 {
-	if input.Send == nil {
-		return 0
-	}
-
-	// Convert string value to float64
-	value, err := strconv.ParseFloat(input.Send.Value, 64)
+func validatePositiveDecimalString(value any, field string) error {
+	parsed, err := decimal.NewFromString(strings.TrimSpace(decimalStringFromAny(value)))
 	if err != nil {
-		return 0
+		return fmt.Errorf("%s must be a valid decimal", field)
 	}
 
-	return value
-}
-
-// GetSourceAccounts returns the source accounts for the transaction
-func (input *TransactionDSLInput) GetSourceAccounts() []validation.AccountReference {
-	var accounts []validation.AccountReference
-
-	if input.Send != nil && input.Send.Source != nil {
-		for _, from := range input.Send.Source.From {
-			accounts = append(accounts, &DSLAccountRef{Account: from.Account})
-		}
-	}
-
-	return accounts
-}
-
-// GetDestinationAccounts returns the destination accounts for the transaction
-func (input *TransactionDSLInput) GetDestinationAccounts() []validation.AccountReference {
-	var accounts []validation.AccountReference
-
-	if input.Send != nil && input.Send.Distribute != nil {
-		for _, to := range input.Send.Distribute.To {
-			accounts = append(accounts, &DSLAccountRef{Account: to.Account})
-		}
-	}
-
-	return accounts
-}
-
-// GetMetadata returns the metadata for the transaction
-func (input *TransactionDSLInput) GetMetadata() map[string]any {
-	return input.Metadata
-}
-
-// Share represents the sharing configuration for a transaction.
-type Share struct {
-	Percentage             int64 `json:"percentage"`
-	PercentageOfPercentage int64 `json:"percentageOfPercentage,omitempty"`
-}
-
-// Rate represents an exchange rate configuration.
-type Rate struct {
-	From       string `json:"from"`
-	To         string `json:"to"`
-	Value      string `json:"value"`
-	ExternalID string `json:"externalId"`
-}
-
-// Validate checks that the DSLSend meets all validation requirements.
-func (send *DSLSend) Validate() error {
-	// Validate required fields
-	if send.Asset == "" {
-		return errors.New("asset is required")
-	}
-
-	// Validate asset code
-	if err := core.ValidateAssetCode(send.Asset); err != nil {
-		return err
-	}
-
-	if send.Value == "" || send.Value == "0" {
-		return errors.New("value must be greater than 0")
-	}
-
-	// Validate source
-	if err := send.validateSource(); err != nil {
-		return err
-	}
-
-	// Validate distribute
-	return send.validateDistribute()
-}
-
-// validateSource validates the source part of a DSLSend
-func (send *DSLSend) validateSource() error {
-	if send.Source == nil || len(send.Source.From) == 0 {
-		return errors.New("source.from must contain at least one entry")
-	}
-
-	for i, from := range send.Source.From {
-		if from.Account == "" {
-			return fmt.Errorf("source.from[%d].account is required", i)
-		}
-
-		if err := send.validateExternalAccount(from.Account, i, "source.from"); err != nil {
-			return err
-		}
+	if !parsed.IsPositive() {
+		return fmt.Errorf("%s must be greater than zero; %s must be greater than 0", field, field)
 	}
 
 	return nil
 }
 
-// validateDistribute validates the distribute part of a DSLSend
-func (send *DSLSend) validateDistribute() error {
-	if send.Distribute == nil || len(send.Distribute.To) == 0 {
-		return errors.New("distribute.to must contain at least one entry")
+func decimalStringFromAny(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case json.Number:
+		return v.String()
+	case decimal.Decimal:
+		return v.String()
+	default:
+		return fmt.Sprint(v)
 	}
-
-	for i, to := range send.Distribute.To {
-		if to.Account == "" {
-			return fmt.Errorf("distribute.to[%d].account is required", i)
-		}
-
-		if err := send.validateExternalAccount(to.Account, i, "distribute.to"); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
-// validateExternalAccount validates an external account reference
-func (send *DSLSend) validateExternalAccount(account string, index int, location string) error {
-	if account == "" || account[0] != '@' {
-		return nil
-	}
-
-	// For external accounts, check if they match the expected format
-	if !core.ExternalAccountPattern.MatchString(account) {
-		return fmt.Errorf("invalid external account format in %s[%d]: %s", location, index, account)
-	}
-
-	// Check if the asset code in the external account matches the transaction asset
-	matches := core.ExternalAccountPattern.FindStringSubmatch(account)
-	if len(matches) > 1 && matches[1] != send.Asset {
-		return fmt.Errorf("asset code mismatch in %s[%d]: transaction uses %s but external account uses %s",
-			location, index, send.Asset, matches[1])
-	}
-
-	return nil
-}
-
-// Validate checks if the TransactionDSLInput meets the validation requirements.
-// It returns an error if any of the validation checks fail.
-func (input *TransactionDSLInput) Validate() error {
-	// Validate send
-	if input.Send == nil {
-		return errors.New("send is required")
-	}
-
-	// Validate send operation
-	if err := input.Send.Validate(); err != nil {
-		return fmt.Errorf("invalid send operation: %w", err)
-	}
-
-	// Validate string length constraints
-	if len(input.ChartOfAccountsGroupName) > 256 {
-		return errors.New("chartOfAccountsGroupName must be at most 256 characters")
-	}
-
-	if len(input.Description) > 256 {
-		return errors.New("description must be at most 256 characters")
-	}
-
-	// Validate transaction code
-	if input.Code != "" {
-		if err := core.ValidateTransactionCode(input.Code); err != nil {
-			return err
-		}
-	}
-
-	// Validate metadata if present
-	if input.Metadata != nil {
-		if err := core.ValidateMetadata(input.Metadata); err != nil {
-			return fmt.Errorf("invalid metadata: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// ToTransactionMap converts a TransactionDSLInput to a map that can be used for API requests.
-// This replaces the previous direct lib-commons conversion.
-func (input *TransactionDSLInput) ToTransactionMap() map[string]any {
-	if input == nil {
-		return nil
-	}
-
-	// Create base transaction map
-	transaction := map[string]any{
-		"description": input.Description,
-		"metadata":    input.Metadata,
-	}
-
-	// Add optional fields if present
-	if input.ChartOfAccountsGroupName != "" {
-		transaction["chartOfAccountsGroupName"] = input.ChartOfAccountsGroupName
-	}
-
-	if input.Code != "" {
-		transaction["code"] = input.Code
-	}
-
-	if input.Pending {
-		transaction["pending"] = input.Pending
-	}
-
-	// Add Send information if present
-	if input.Send != nil {
-		transaction["send"] = input.sendToMap()
-	}
-
-	return transaction
-}
-
-// sendToMap converts the DSLSend to a map for API requests
-func (input *TransactionDSLInput) sendToMap() map[string]any {
-	if input.Send == nil {
-		return nil
-	}
-
-	send := map[string]any{
-		"asset": input.Send.Asset,
-		"value": input.Send.Value,
-	}
-
-	// Add Source if present
-	if input.Send.Source != nil {
-		send["source"] = input.sourceToMap()
-	}
-
-	// Add Distribute if present
-	if input.Send.Distribute != nil {
-		send["distribute"] = input.distributeToMap()
-	}
-
-	return send
-}
-
-// sourceToMap converts DSLSource to a map for API requests
-func (input *TransactionDSLInput) sourceToMap() map[string]any {
-	if input.Send.Source == nil {
-		return nil
-	}
-
-	source := map[string]any{}
-
-	// Add Remaining if present
-	if input.Send.Source.Remaining != "" {
-		source["remaining"] = input.Send.Source.Remaining
-	}
-
-	// Convert From accounts
-	if len(input.Send.Source.From) > 0 {
-		fromList := make([]map[string]any, 0, len(input.Send.Source.From))
-
-		for _, from := range input.Send.Source.From {
-			fromMap := fromToToMap(from)
-			fromList = append(fromList, fromMap)
-		}
-
-		source["from"] = fromList
-	}
-
-	return source
-}
-
-// distributeToMap converts DSLDistribute to a map for API requests
-func (input *TransactionDSLInput) distributeToMap() map[string]any {
-	if input.Send.Distribute == nil {
-		return nil
-	}
-
-	distribute := map[string]any{}
-
-	// Add Remaining if present
-	if input.Send.Distribute.Remaining != "" {
-		distribute["remaining"] = input.Send.Distribute.Remaining
-	}
-
-	// Convert To accounts
-	if len(input.Send.Distribute.To) > 0 {
-		toList := make([]map[string]any, 0, len(input.Send.Distribute.To))
-
-		for _, to := range input.Send.Distribute.To {
-			toMap := fromToToMap(to)
-			toList = append(toList, toMap)
-		}
-
-		distribute["to"] = toList
-	}
-
-	return distribute
-}
-
-// fromToToMap converts a DSLFromTo to a map for API requests
-func fromToToMap(from DSLFromTo) map[string]any {
-	fromMap := map[string]any{
-		"account": from.Account,
-	}
-
-	// Add Amount if present
-	if from.Amount != nil {
-		fromMap["amount"] = map[string]any{
-			"asset": from.Amount.Asset,
-			"value": from.Amount.Value,
-		}
-	}
-
-	// Add other fields if present
-	if from.Remaining != "" {
-		fromMap["remaining"] = from.Remaining
-	}
-
-	if from.Description != "" {
-		fromMap["description"] = from.Description
-	}
-
-	if from.ChartOfAccounts != "" {
-		fromMap["chartOfAccounts"] = from.ChartOfAccounts
-	}
-
-	if from.Metadata != nil {
-		fromMap["metadata"] = from.Metadata
-	}
-
-	// Add Share if present
-	if from.Share != nil {
-		fromMap["share"] = map[string]any{
-			"percentage":             from.Share.Percentage,
-			"percentageOfPercentage": from.Share.PercentageOfPercentage,
-		}
-	}
-
-	// Add Rate if present
-	if from.Rate != nil {
-		fromMap["rate"] = map[string]any{
-			"from":       from.Rate.From,
-			"to":         from.Rate.To,
-			"value":      from.Rate.Value,
-			"externalId": from.Rate.ExternalID,
-		}
-	}
-
-	return fromMap
-}
-
-// FromTransactionMap converts a map from the API to a TransactionDSLInput.
-// This replaces the previous direct lib-commons conversion.
-func FromTransactionMap(data map[string]any) *TransactionDSLInput {
-	if data == nil {
-		return nil
-	}
-
-	// Extract basic fields
-	input := &TransactionDSLInput{
-		ChartOfAccountsGroupName: getStringFromMap(data, "chartOfAccountsGroupName"),
-		Description:              getStringFromMap(data, "description"),
-		Code:                     getStringFromMap(data, "code"),
-		Metadata:                 getMetadataFromMap(data),
-	}
-
-	// Extract pending flag
-	if pendingVal, ok := data["pending"].(bool); ok {
-		input.Pending = pendingVal
-	}
-
-	// Extract Send information
-	if sendMap, ok := data["send"].(map[string]any); ok {
-		input.Send = extractSend(sendMap)
-	}
-
-	return input
-}
-
-// extractSend converts a map to DSLSend
-func extractSend(data map[string]any) *DSLSend {
-	if data == nil {
-		return nil
-	}
-
-	send := &DSLSend{}
-
-	// Extract basic fields
-	send.Asset = getStringFromMap(data, "asset")
-
-	// Extract numeric values
-	if value, ok := data["value"].(string); ok {
-		send.Value = value
-	} else if value, ok := data["value"].(float64); ok {
-		send.Value = fmt.Sprintf("%.2f", value)
-	}
-
-	// Extract Source
-	if sourceMap, ok := data["source"].(map[string]any); ok {
-		send.Source = extractSource(sourceMap)
-	}
-
-	// Extract Distribute
-	if distMap, ok := data["distribute"].(map[string]any); ok {
-		send.Distribute = extractDistribute(distMap)
-	}
-
-	return send
-}
-
-// extractSource converts a map to DSLSource
-func extractSource(data map[string]any) *DSLSource {
-	if data == nil {
-		return nil
-	}
-
-	source := &DSLSource{
-		Remaining: getStringFromMap(data, "remaining"),
-		From:      []DSLFromTo{},
-	}
-
-	// Extract From entries
-	if fromList, ok := data["from"].([]any); ok {
-		for _, item := range fromList {
-			if fromMap, ok := item.(map[string]any); ok {
-				fromEntry := extractFromTo(fromMap)
-				source.From = append(source.From, fromEntry)
-			}
-		}
-	}
-
-	return source
-}
-
-// extractDistribute converts a map to DSLDistribute
-func extractDistribute(data map[string]any) *DSLDistribute {
-	if data == nil {
-		return nil
-	}
-
-	distribute := &DSLDistribute{
-		Remaining: getStringFromMap(data, "remaining"),
-		To:        []DSLFromTo{},
-	}
-
-	// Extract To entries
-	if toList, ok := data["to"].([]any); ok {
-		for _, item := range toList {
-			if toMap, ok := item.(map[string]any); ok {
-				toEntry := extractFromTo(toMap)
-				distribute.To = append(distribute.To, toEntry)
-			}
-		}
-	}
-
-	return distribute
-}
-
-// extractFromTo converts a map to DSLFromTo
-func extractFromTo(data map[string]any) DSLFromTo {
-	if data == nil {
-		return DSLFromTo{}
-	}
-
-	from := DSLFromTo{
-		Account:         getStringFromMap(data, "account"),
-		Remaining:       getStringFromMap(data, "remaining"),
-		Description:     getStringFromMap(data, "description"),
-		ChartOfAccounts: getStringFromMap(data, "chartOfAccounts"),
-		Metadata:        getMetadataFromMap(data),
-	}
-
-	// Extract Amount
-	if amountMap, ok := data["amount"].(map[string]any); ok {
-		amount := &DSLAmount{
-			Asset: getStringFromMap(amountMap, "asset"),
-		}
-
-		// Extract numeric values
-		if value, ok := amountMap["value"].(string); ok {
-			amount.Value = value
-		} else if value, ok := amountMap["value"].(float64); ok {
-			amount.Value = fmt.Sprintf("%.2f", value)
-		}
-
-		from.Amount = amount
-	}
-
-	// Extract Share
-	if shareMap, ok := data["share"].(map[string]any); ok {
-		share := &Share{}
-
-		if percentage, ok := shareMap["percentage"].(float64); ok {
-			share.Percentage = int64(percentage)
-		}
-
-		if percentageOfPercentage, ok := shareMap["percentageOfPercentage"].(float64); ok {
-			share.PercentageOfPercentage = int64(percentageOfPercentage)
-		}
-
-		from.Share = share
-	}
-
-	// Extract Rate
-	if rateMap, ok := data["rate"].(map[string]any); ok {
-		rate := &Rate{
-			From:       getStringFromMap(rateMap, "from"),
-			To:         getStringFromMap(rateMap, "to"),
-			ExternalID: getStringFromMap(rateMap, "externalId"),
-		}
-
-		if value, ok := rateMap["value"].(float64); ok {
-			rate.Value = fmt.Sprintf("%.2f", value)
-		}
-
-		from.Rate = rate
-	}
-
-	return from
-}
-
-// Helper functions for extracting values from maps
-
-// getStringFromMap safely extracts a string value from a map
-func getStringFromMap(m map[string]any, key string) string {
-	if val, ok := m[key].(string); ok {
-		return val
-	}
-
-	return ""
-}
-
-// getMetadataFromMap safely extracts metadata from a map
-func getMetadataFromMap(m map[string]any) map[string]any {
-	if val, ok := m["metadata"].(map[string]any); ok {
-		return val
-	}
-
-	return nil
+// DecimalStringFromAny converts common numeric response values to exact decimal strings.
+func DecimalStringFromAny(value any) string {
+	return decimalStringFromAny(value)
 }
 
 // CreateTransactionInput is the input for creating a transaction.
@@ -867,27 +262,16 @@ func getMetadataFromMap(m map[string]any) map[string]any {
 //	    return &s
 //	}
 type CreateTransactionInput struct {
-	// Template is an optional identifier for the transaction template to use
-	// Templates can be used to create standardized transactions with predefined
-	// structures and validation rules
-	// Note: This is used for SDK logic but not sent in the API request
-	Template string
+	// Template is retained for backwards compatibility with the pre-send API.
+	Template string `json:"template,omitempty"`
 
-	// Amount is the numeric value of the transaction as a decimal string
-	// This represents the total value of the transaction (e.g., "100.50" for $100.50)
-	// Note: This is used for validation but sent within the Send structure
-	Amount string
+	// Amount is retained for backwards compatibility with operation-based callers.
+	// Prefer Send.Value for new integrations.
+	Amount string `json:"amount,omitempty"`
 
-	// AssetCode identifies the currency or asset type for this transaction
-	// Common examples include "USD", "EUR", "BTC", etc.
-	// Note: This is used for validation but sent within the Send structure
-	AssetCode string
-
-	// Operations contains the individual debit and credit operations
-	// Each operation represents a single accounting entry (debit or credit)
-	// The sum of all operations for each asset must balance to zero
-	// Note: Operations are an alternative to Send and should not be serialized when Send is used
-	Operations []CreateOperationInput
+	// AssetCode is retained for backwards compatibility with operation-based callers.
+	// Prefer Send.Asset for new integrations.
+	AssetCode string `json:"assetCode,omitempty"`
 
 	// ChartOfAccountsGroupName is REQUIRED by the API specification
 	// This categorizes the transaction under a specific chart of accounts group
@@ -901,19 +285,26 @@ type CreateTransactionInput struct {
 	// Pending transactions require explicit commitment before affecting account balances
 	Pending bool `json:"pending,omitempty"`
 
+	// Code is a transaction reference code.
+	Code string `json:"code,omitempty"`
+
 	// Route is the transaction route identifier (optional)
 	// This defines the overall flow of the transaction structure
 	Route string `json:"route,omitempty"`
+
+	// RouteID is the UUID transaction route identifier.
+	RouteID string `json:"routeId,omitempty"`
+
+	// TransactionDate is the effective date/time for the transaction.
+	TransactionDate string `json:"transactionDate,omitempty"`
 
 	// Metadata contains additional custom data for the transaction
 	// This can be used to store application-specific information
 	// such as references to external systems, tags, or other contextual data
 	Metadata map[string]any `json:"metadata,omitempty"`
 
-	// ExternalID is an optional identifier for linking to external systems
-	// This can be used to correlate transactions with records in other systems
-	// and to prevent duplicate transactions
-	// Note: This is handled separately, not in request body for Send format
+	// ExternalID is retained for backward compatibility but is not part of the
+	// current Midaz CreateTransaction contract.
 	ExternalID string
 
 	// IdempotencyKey is a client-generated key to ensure transaction uniqueness
@@ -922,10 +313,11 @@ type CreateTransactionInput struct {
 	// Note: This is sent as a header (X-Idempotency), not in the request body
 	IdempotencyKey string
 
-	// Send contains the source and distribution information for the transaction (REQUIRED by API)
-	// This is an alternative to using Operations and provides a more structured way
-	// to define the transaction flow
+	// Send contains the source and distribution information for the transaction.
 	Send *SendInput `json:"send"`
+
+	// Operations is retained for backwards compatibility with the pre-send API.
+	Operations []CreateOperationInput `json:"operations,omitempty"`
 }
 
 // SendInput represents the send information for a transaction.
@@ -934,8 +326,8 @@ type SendInput struct {
 	// Asset identifies the currency or asset type for this transaction
 	Asset string `json:"asset"`
 
-	// Value is the numeric value of the transaction as a decimal string
-	Value string `json:"value"`
+	// Value is the exact decimal value of the transaction.
+	Value any `json:"value"`
 
 	// Source contains the source accounts for the transaction
 	Source *SourceInput `json:"source"`
@@ -961,7 +353,8 @@ type DistributeInput struct {
 // FromToInput represents a single source or destination account in a transaction.
 // This structure contains the account and amount details.
 type FromToInput struct {
-	// Account identifies the account affected by this operation
+	// Account identifies the account affected by this operation. It is mapped to
+	// accountAlias for Midaz transaction requests.
 	Account string `json:"account"`
 
 	// Amount specifies the amount details for this operation
@@ -970,6 +363,21 @@ type FromToInput struct {
 	// Route is the operation route identifier for this operation (optional)
 	// This links the operation to a specific routing rule
 	Route string `json:"route,omitempty"`
+
+	// RouteID is the operation route UUID used by canonical Midaz route validation.
+	RouteID *string `json:"routeId,omitempty"`
+
+	// BalanceKey targets a non-default balance for this entry.
+	BalanceKey string `json:"balanceKey,omitempty"`
+
+	// Share specifies proportional distribution semantics.
+	Share *Share `json:"share,omitempty"`
+
+	// Remaining specifies the remaining-account token for split transactions.
+	Remaining string `json:"remaining,omitempty"`
+
+	// Rate specifies exchange-rate information for multi-asset flows.
+	Rate *Rate `json:"rate,omitempty"`
 
 	// Description provides additional context for this operation (optional)
 	Description string `json:"description,omitempty"`
@@ -990,56 +398,142 @@ type AmountInput struct {
 	// Asset identifies the currency or asset type for this amount
 	Asset string `json:"asset"`
 
-	// Value is the numeric value of the amount as a decimal string
-	Value string `json:"value"`
+	// Value is the exact decimal value of the amount.
+	Value any `json:"value"`
+}
+
+var transactionDateFormats = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.000Z",
+	"2006-01-02T15:04:05Z",
+	"2006-01-02T15:04:05",
+	"2006-01-02",
 }
 
 // Validate checks that the CreateTransactionInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *CreateTransactionInput) Validate() error {
-	if input.Amount == "" || input.Amount == "0" {
-		return errors.New("amount must be greater than zero")
+	if input == nil {
+		return errors.New("input is required")
 	}
 
-	if input.AssetCode == "" {
-		return errors.New("assetCode is required")
-	}
+	input.ensureSendFromLegacyOperations()
 
-	// Validate asset code
-	if err := core.ValidateAssetCode(input.AssetCode); err != nil {
+	if err := validateTransactionCreateCommon(input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, input.Pending); err != nil {
 		return err
 	}
 
-	if len(input.Operations) == 0 && input.Send == nil {
-		return errors.New("either operations or send must be provided")
+	if input.Send == nil {
+		return errors.New("send is required")
 	}
 
-	// If Operations is provided, validate each operation
-	if len(input.Operations) > 0 {
-		// Validate operations
-		for i, op := range input.Operations {
-			if err := op.Validate(); err != nil {
-				return fmt.Errorf("invalid operation at index %d: %w", i, err)
-			}
+	if err := input.Send.Validate(); err != nil {
+		return fmt.Errorf("invalid send: %w", err)
+	}
+
+	return nil
+}
+
+func validateTransactionCreateCommon(description, code string, metadata map[string]any, route, routeID, transactionDate string, pending bool) error {
+	if len(description) > 256 {
+		return errors.New("description must be at most 256 characters")
+	}
+
+	if len(code) > 100 {
+		return errors.New("code must be at most 100 characters")
+	}
+
+	if route != "" && len(route) > 250 {
+		return errors.New("route must be at most 250 characters")
+	}
+
+	if routeID != "" && !validation.IsValidUUID(routeID) {
+		return errors.New("routeId must be a valid UUID")
+	}
+
+	if transactionDate != "" {
+		parsedDate, err := parseTransactionDate(transactionDate)
+		if err != nil {
+			return err
+		}
+
+		if parsedDate.After(time.Now()) {
+			return errors.New("transactionDate cannot be in the future")
+		}
+
+		if pending {
+			return errors.New("pending transactions cannot have a custom transactionDate")
 		}
 	}
 
-	// If Send is provided, validate it
-	if input.Send != nil {
-		if err := input.Send.Validate(); err != nil {
-			return fmt.Errorf("invalid send: %w", err)
+	if len(metadata) > 0 {
+		if err := core.ValidateMetadata(metadata); err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
 		}
 	}
 
 	return nil
 }
 
-// NewCreateTransactionInput creates a new CreateTransactionInput with required fields.
-// This constructor ensures that all mandatory fields are provided when creating a transaction input.
-func NewCreateTransactionInput(assetCode string, amount string) *CreateTransactionInput {
+func parseTransactionDate(value string) (time.Time, error) {
+	for _, format := range transactionDateFormats {
+		if parsed, err := time.Parse(format, value); err == nil {
+			return parsed, nil
+		}
+	}
+
+	return time.Time{}, errors.New("transactionDate must be ISO 8601 date or date-time")
+}
+
+func transactionCommonMap(chartOfAccountsGroupName, description, code string, metadata map[string]any, route, routeID, transactionDate string, pending bool) map[string]any {
+	tx := map[string]any{}
+	if chartOfAccountsGroupName != "" {
+		tx["chartOfAccountsGroupName"] = chartOfAccountsGroupName
+	}
+
+	if description != "" {
+		tx["description"] = description
+	}
+
+	if code != "" {
+		tx["code"] = code
+	}
+
+	if pending {
+		tx["pending"] = pending
+	}
+
+	if len(metadata) > 0 {
+		tx["metadata"] = metadata
+	}
+
+	if route != "" {
+		tx["route"] = route
+	}
+
+	if routeID != "" {
+		tx["routeId"] = routeID
+	}
+
+	if transactionDate != "" {
+		tx["transactionDate"] = transactionDate
+	}
+
+	return tx
+}
+
+// NewCreateTransactionInput creates a new CreateTransactionInput with the send asset/value initialized.
+func NewCreateTransactionInput(assetCode string, amount any) *CreateTransactionInput {
+	amountValue := decimalStringFromAny(amount)
+
 	return &CreateTransactionInput{
 		AssetCode: assetCode,
-		Amount:    amount,
+		Amount:    amountValue,
+		Send: &SendInput{
+			Asset: assetCode,
+			Value: amountValue,
+		},
 	}
 }
 
@@ -1059,15 +553,27 @@ func (input *CreateTransactionInput) WithMetadata(metadata map[string]any) *Crea
 
 // WithExternalID sets the external ID.
 // This links the transaction to external systems.
+// Deprecated: externalId is not sent in the current Midaz CreateTransaction contract.
 func (input *CreateTransactionInput) WithExternalID(externalID string) *CreateTransactionInput {
 	input.ExternalID = externalID
 	return input
 }
 
-// WithOperations sets the operations list.
-// This defines the individual debit and credit operations.
-func (input *CreateTransactionInput) WithOperations(operations []CreateOperationInput) *CreateTransactionInput {
-	input.Operations = operations
+// WithRouteID sets the route UUID.
+func (input *CreateTransactionInput) WithRouteID(routeID string) *CreateTransactionInput {
+	input.RouteID = routeID
+	return input
+}
+
+// WithTransactionDate sets the transaction effective date/time.
+func (input *CreateTransactionInput) WithTransactionDate(transactionDate string) *CreateTransactionInput {
+	input.TransactionDate = transactionDate
+	return input
+}
+
+// WithPending sets whether the transaction should be created in pending state.
+func (input *CreateTransactionInput) WithPending(pending bool) *CreateTransactionInput {
+	input.Pending = pending
 	return input
 }
 
@@ -1078,17 +584,30 @@ func (input *CreateTransactionInput) WithSend(send *SendInput) *CreateTransactio
 	return input
 }
 
+// WithOperations sets legacy operation inputs and adapts them to the canonical send payload.
+func (input *CreateTransactionInput) WithOperations(operations []CreateOperationInput) *CreateTransactionInput {
+	input.Operations = operations
+	input.Send = nil
+	input.ensureSendFromLegacyOperations()
+
+	return input
+}
+
 // Validate checks that the SendInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *SendInput) Validate() error {
+	if input == nil {
+		return errors.New("send is required")
+	}
+
 	// Validate asset code
 	if input.Asset == "" {
 		return errors.New("asset is required")
 	}
 
 	// Validate value
-	if input.Value == "" || input.Value == "0" {
-		return errors.New("value must be greater than zero")
+	if err := validatePositiveDecimalString(input.Value, "value"); err != nil {
+		return err
 	}
 
 	// Validate source
@@ -1115,6 +634,10 @@ func (input *SendInput) Validate() error {
 // Validate checks that the SourceInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *SourceInput) Validate() error {
+	if input == nil {
+		return errors.New("source is required")
+	}
+
 	// Validate from
 	if len(input.From) == 0 {
 		return errors.New("from is required")
@@ -1133,6 +656,10 @@ func (input *SourceInput) Validate() error {
 // Validate checks that the DistributeInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *DistributeInput) Validate() error {
+	if input == nil {
+		return errors.New("distribute is required")
+	}
+
 	// Validate to
 	if len(input.To) == 0 {
 		return errors.New("to is required")
@@ -1151,8 +678,12 @@ func (input *DistributeInput) Validate() error {
 // Validate checks that the FromToInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *FromToInput) Validate() error {
+	if input == nil {
+		return errors.New("from/to entry is required")
+	}
+
 	// Validate account
-	if input.Account == "" {
+	if input.Account == "" && input.AccountAlias == "" {
 		return errors.New("account is required")
 	}
 
@@ -1161,23 +692,34 @@ func (input *FromToInput) Validate() error {
 		return fmt.Errorf("invalid amount: %w", err)
 	}
 
+	if input.RouteID != nil && strings.TrimSpace(*input.RouteID) != "" {
+		if !validation.IsValidUUID(*input.RouteID) {
+			return errors.New("routeId must be a valid UUID")
+		}
+	}
+
+	if len(input.Metadata) > 0 {
+		if err := core.ValidateMetadata(input.Metadata); err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // Validate checks that the AmountInput meets all validation requirements.
 // It returns an error if any of the validation checks fail.
 func (input *AmountInput) Validate() error {
+	if input == nil {
+		return errors.New("amount is required")
+	}
+
 	// Validate asset
 	if input.Asset == "" {
 		return errors.New("asset is required")
 	}
 
-	// Validate value
-	if input.Value == "" || input.Value == "0" {
-		return errors.New("value must be greater than zero")
-	}
-
-	return nil
+	return validatePositiveDecimalString(input.Value, "value")
 }
 
 // ToLibTransaction converts a CreateTransactionInput to a lib-commons transaction.
@@ -1186,6 +728,8 @@ func (input *CreateTransactionInput) ToLibTransaction() map[string]any {
 	if input == nil {
 		return nil
 	}
+
+	input.ensureSendFromLegacyOperations()
 
 	// Create a map to hold the transaction data
 	tx := map[string]any{}
@@ -1205,9 +749,21 @@ func (input *CreateTransactionInput) ToLibTransaction() map[string]any {
 		tx["pending"] = input.Pending
 	}
 
+	if input.Code != "" {
+		tx["code"] = input.Code
+	}
+
 	// Add route if provided
 	if input.Route != "" {
 		tx["route"] = input.Route
+	}
+
+	if input.RouteID != "" {
+		tx["routeId"] = input.RouteID
+	}
+
+	if input.TransactionDate != "" {
+		tx["transactionDate"] = input.TransactionDate
 	}
 
 	// Add send information if present (required by API)
@@ -1223,6 +779,52 @@ func (input *CreateTransactionInput) ToLibTransaction() map[string]any {
 	return tx
 }
 
+func (input *CreateTransactionInput) ensureSendFromLegacyOperations() {
+	if input == nil || input.Send != nil || len(input.Operations) == 0 {
+		return
+	}
+
+	asset := input.AssetCode
+	if asset == "" && len(input.Operations) > 0 {
+		asset = input.Operations[0].AssetCode
+	}
+
+	send := &SendInput{
+		Asset:      asset,
+		Value:      input.Amount,
+		Source:     &SourceInput{},
+		Distribute: &DistributeInput{},
+	}
+
+	for _, operation := range input.Operations {
+		entry := FromToInput{
+			Account: operation.AccountID,
+			Amount: AmountInput{
+				Asset: operation.AssetCode,
+				Value: operation.Amount,
+			},
+			Route: operation.Route,
+		}
+		if entry.Amount.Asset == "" {
+			entry.Amount.Asset = asset
+		}
+
+		if operation.AccountAlias != nil && *operation.AccountAlias != "" {
+			entry.Account = *operation.AccountAlias
+			entry.AccountAlias = *operation.AccountAlias
+		}
+
+		switch strings.ToLower(operation.Type) {
+		case "debit", "source":
+			send.Source.From = append(send.Source.From, entry)
+		case "credit", "destination":
+			send.Distribute.To = append(send.Distribute.To, entry)
+		}
+	}
+
+	input.Send = send
+}
+
 // ToMap converts a SendInput to a map.
 // This is used internally by the SDK to convert the input to the format expected by the backend.
 func (input *SendInput) ToMap() map[string]any {
@@ -1232,7 +834,7 @@ func (input *SendInput) ToMap() map[string]any {
 
 	send := map[string]any{
 		"asset": input.Asset,
-		"value": input.Value, // API expects value as string
+		"value": decimalStringFromAny(input.Value),
 	}
 
 	// Add source information if present
@@ -1295,16 +897,53 @@ func (input *DistributeInput) ToMap() map[string]any {
 // ToMap converts a FromToInput to a map.
 // This is used internally by the SDK to convert the input to the format expected by the backend.
 func (input FromToInput) ToMap() map[string]any {
-	fromTo := map[string]any{
-		"accountAlias": input.Account,
+	accountAlias := input.AccountAlias
+	if accountAlias == "" {
+		accountAlias = input.Account
 	}
 
-	// Add amount information
-	fromTo["amount"] = input.Amount.ToMap()
+	fromTo := map[string]any{
+		"accountAlias": accountAlias,
+	}
 
-	// Add route information if provided
+	if input.BalanceKey != "" {
+		fromTo["balanceKey"] = input.BalanceKey
+	}
+
+	if amount := input.Amount.ToMap(); amount != nil {
+		fromTo["amount"] = amount
+	}
+
+	if input.Share != nil {
+		fromTo["share"] = input.Share
+	}
+
+	if input.Remaining != "" {
+		fromTo["remaining"] = input.Remaining
+	}
+
+	if input.Rate != nil {
+		fromTo["rate"] = input.Rate
+	}
+
+	if input.Description != "" {
+		fromTo["description"] = input.Description
+	}
+
+	if input.ChartOfAccounts != "" {
+		fromTo["chartOfAccounts"] = input.ChartOfAccounts
+	}
+
+	if len(input.Metadata) > 0 {
+		fromTo["metadata"] = input.Metadata
+	}
+
 	if input.Route != "" {
 		fromTo["route"] = input.Route
+	}
+
+	if input.RouteID != nil && *input.RouteID != "" {
+		fromTo["routeId"] = *input.RouteID
 	}
 
 	return fromTo
@@ -1313,9 +952,13 @@ func (input FromToInput) ToMap() map[string]any {
 // ToMap converts an AmountInput to a map.
 // This is used internally by the SDK to convert the input to the format expected by the backend.
 func (input *AmountInput) ToMap() map[string]any {
+	if input == nil || (input.Asset == "" && input.Value == "") {
+		return nil
+	}
+
 	return map[string]any{
 		"asset": input.Asset,
-		"value": input.Value, // API expects value as string
+		"value": decimalStringFromAny(input.Value),
 	}
 }
 
@@ -1347,17 +990,17 @@ func (t *Transaction) ToTransactionMap() map[string]any {
 
 	// Convert Operations
 	for _, op := range t.Operations {
-		entry := map[string]any{
-			"account": op.AccountID,
-			"amount": map[string]any{
-				"value": op.Amount,
-				"asset": op.AssetCode,
-			},
+		accountAlias := op.AccountAlias
+		if accountAlias == "" {
+			accountAlias = op.AccountID
 		}
 
-		// Add alias as description if present
-		if op.AccountAlias != "" {
-			entry["description"] = op.AccountAlias
+		entry := map[string]any{
+			"accountAlias": accountAlias,
+			"amount": map[string]any{
+				"value": op.Amount.Value,
+				"asset": op.AssetCode,
+			},
 		}
 
 		// Add to appropriate list based on operation type
@@ -1421,9 +1064,9 @@ type UpdateTransactionInput struct {
 	// This should provide context about the purpose or nature of the transaction
 	Description string `json:"description,omitempty"`
 
-	// ExternalID is an optional identifier for linking to external systems
-	// This can be used to correlate transactions with records in other systems
-	ExternalID string `json:"externalId,omitempty"`
+	// ExternalID is retained for backward compatibility but is not part of the
+	// current Midaz UpdateTransaction contract.
+	ExternalID string `json:"-"`
 }
 
 // Validate checks if the UpdateTransactionInput meets the validation requirements.
@@ -1432,14 +1075,13 @@ type UpdateTransactionInput struct {
 // Returns:
 //   - error: An error if the input is invalid, nil otherwise
 func (input *UpdateTransactionInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
 	// Validate description length if provided
 	if input.Description != "" && len(input.Description) > 256 {
 		return errors.New("description must not exceed 256 characters")
-	}
-
-	// Validate external ID if provided
-	if input.ExternalID != "" && len(input.ExternalID) > 64 {
-		return errors.New("externalId must not exceed 64 characters")
 	}
 
 	// Validate metadata if provided
@@ -1490,6 +1132,7 @@ func (input *UpdateTransactionInput) WithDescription(description string) *Update
 
 // WithExternalID sets the external ID.
 // This method allows setting or updating the external system identifier for the transaction.
+// Deprecated: externalId is not sent in the current Midaz UpdateTransaction contract.
 //
 // Parameters:
 //   - externalID: The external identifier for linking to other systems
@@ -1519,6 +1162,12 @@ type CreateInflowInput struct {
 	// Route is the transaction route identifier
 	Route string `json:"route,omitempty"`
 
+	// RouteID is the UUID transaction route identifier.
+	RouteID string `json:"routeId,omitempty"`
+
+	// TransactionDate is the effective date/time for the transaction.
+	TransactionDate string `json:"transactionDate,omitempty"`
+
 	// Send contains the asset, value, and distribution details
 	Send *SendInflowInput `json:"send"`
 }
@@ -1528,19 +1177,19 @@ type SendInflowInput struct {
 	// Asset is the asset code being transferred
 	Asset string `json:"asset"`
 
-	// Value is the amount being transferred
-	Value string `json:"value"`
+	// Value is the exact decimal amount being transferred.
+	Value any `json:"value"`
 
 	// Distribute contains the destination accounts
 	Distribute *DistributeInput `json:"distribute"`
 }
 
 // NewCreateInflowInput creates a new CreateInflowInput with the required fields.
-func NewCreateInflowInput(asset, value string, distribute *DistributeInput) *CreateInflowInput {
+func NewCreateInflowInput(asset string, value any, distribute *DistributeInput) *CreateInflowInput {
 	return &CreateInflowInput{
 		Send: &SendInflowInput{
 			Asset:      asset,
-			Value:      value,
+			Value:      decimalStringFromAny(value),
 			Distribute: distribute,
 		},
 	}
@@ -1576,25 +1225,72 @@ func (input *CreateInflowInput) WithRoute(route string) *CreateInflowInput {
 	return input
 }
 
+// WithRouteID sets the route UUID.
+func (input *CreateInflowInput) WithRouteID(routeID string) *CreateInflowInput {
+	input.RouteID = routeID
+	return input
+}
+
+// WithTransactionDate sets the transaction effective date/time.
+func (input *CreateInflowInput) WithTransactionDate(transactionDate string) *CreateInflowInput {
+	input.TransactionDate = transactionDate
+	return input
+}
+
 // Validate checks that the CreateInflowInput meets all validation requirements.
 func (input *CreateInflowInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
 	if input.Send == nil {
 		return errors.New("send is required")
+	}
+
+	if err := validateTransactionCreateCommon(input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, false); err != nil {
+		return err
 	}
 
 	if input.Send.Asset == "" {
 		return errors.New("asset is required")
 	}
 
-	if input.Send.Value == "" || input.Send.Value == "0" {
-		return errors.New("value must be greater than zero")
+	if err := validatePositiveDecimalString(input.Send.Value, "value"); err != nil {
+		return err
 	}
 
 	if input.Send.Distribute == nil || len(input.Send.Distribute.To) == 0 {
 		return errors.New("distribute.to is required")
 	}
 
+	if err := input.Send.Distribute.Validate(); err != nil {
+		return fmt.Errorf("invalid distribute: %w", err)
+	}
+
 	return nil
+}
+
+// ToMap converts a CreateInflowInput to a map for API requests.
+func (input *CreateInflowInput) ToMap() map[string]any {
+	if input == nil {
+		return nil
+	}
+
+	tx := transactionCommonMap(input.ChartOfAccountsGroupName, input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, false)
+	if input.Send != nil {
+		send := map[string]any{
+			"asset": input.Send.Asset,
+			"value": decimalStringFromAny(input.Send.Value),
+		}
+
+		if input.Send.Distribute != nil {
+			send["distribute"] = input.Send.Distribute.ToMap()
+		}
+
+		tx["send"] = send
+	}
+
+	return tx
 }
 
 // CreateOutflowInput represents input for creating an outflow transaction.
@@ -1615,6 +1311,15 @@ type CreateOutflowInput struct {
 	// Route is the transaction route identifier
 	Route string `json:"route,omitempty"`
 
+	// RouteID is the UUID transaction route identifier.
+	RouteID string `json:"routeId,omitempty"`
+
+	// Pending indicates whether the transaction should be created in a pending state.
+	Pending bool `json:"pending,omitempty"`
+
+	// TransactionDate is the effective date/time for the transaction.
+	TransactionDate string `json:"transactionDate,omitempty"`
+
 	// Send contains the asset, value, and source details
 	Send *SendOutflowInput `json:"send"`
 }
@@ -1624,19 +1329,19 @@ type SendOutflowInput struct {
 	// Asset is the asset code being transferred
 	Asset string `json:"asset"`
 
-	// Value is the amount being transferred
-	Value string `json:"value"`
+	// Value is the exact decimal amount being transferred.
+	Value any `json:"value"`
 
 	// Source contains the source accounts
 	Source *SourceInput `json:"source"`
 }
 
 // NewCreateOutflowInput creates a new CreateOutflowInput with the required fields.
-func NewCreateOutflowInput(asset, value string, source *SourceInput) *CreateOutflowInput {
+func NewCreateOutflowInput(asset string, value any, source *SourceInput) *CreateOutflowInput {
 	return &CreateOutflowInput{
 		Send: &SendOutflowInput{
 			Asset:  asset,
-			Value:  value,
+			Value:  decimalStringFromAny(value),
 			Source: source,
 		},
 	}
@@ -1672,73 +1377,98 @@ func (input *CreateOutflowInput) WithRoute(route string) *CreateOutflowInput {
 	return input
 }
 
+// WithRouteID sets the route UUID.
+func (input *CreateOutflowInput) WithRouteID(routeID string) *CreateOutflowInput {
+	input.RouteID = routeID
+	return input
+}
+
+// WithTransactionDate sets the transaction effective date/time.
+func (input *CreateOutflowInput) WithTransactionDate(transactionDate string) *CreateOutflowInput {
+	input.TransactionDate = transactionDate
+	return input
+}
+
 // Validate checks that the CreateOutflowInput meets all validation requirements.
 func (input *CreateOutflowInput) Validate() error {
+	if input == nil {
+		return errors.New("input is required")
+	}
+
 	if input.Send == nil {
 		return errors.New("send is required")
+	}
+
+	if err := validateTransactionCreateCommon(input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, input.Pending); err != nil {
+		return err
 	}
 
 	if input.Send.Asset == "" {
 		return errors.New("asset is required")
 	}
 
-	if input.Send.Value == "" || input.Send.Value == "0" {
-		return errors.New("value must be greater than zero")
+	if err := validatePositiveDecimalString(input.Send.Value, "value"); err != nil {
+		return err
 	}
 
 	if input.Send.Source == nil || len(input.Send.Source.From) == 0 {
 		return errors.New("source.from is required")
 	}
 
+	if err := input.Send.Source.Validate(); err != nil {
+		return fmt.Errorf("invalid source: %w", err)
+	}
+
 	return nil
 }
 
-// CreateAnnotationInput represents input for creating an annotation transaction.
-// Annotation transactions do not affect balances - they are used for adding metadata/notes to the ledger.
-type CreateAnnotationInput struct {
-	// ChartOfAccountsGroupName for accounting purposes
-	ChartOfAccountsGroupName string `json:"chartOfAccountsGroupName,omitempty"`
+// ToMap converts a CreateOutflowInput to a map for API requests.
+func (input *CreateOutflowInput) ToMap() map[string]any {
+	if input == nil {
+		return nil
+	}
 
-	// Description provides a human-readable explanation (required for annotations)
-	Description string `json:"description"`
+	tx := transactionCommonMap(input.ChartOfAccountsGroupName, input.Description, input.Code, input.Metadata, input.Route, input.RouteID, input.TransactionDate, input.Pending)
+	if input.Send != nil {
+		send := map[string]any{
+			"asset": input.Send.Asset,
+			"value": decimalStringFromAny(input.Send.Value),
+		}
 
-	// Code is a transaction reference code
-	Code string `json:"code,omitempty"`
+		if input.Send.Source != nil {
+			send["source"] = input.Send.Source.ToMap()
+		}
 
-	// Metadata contains custom key-value data
-	Metadata map[string]any `json:"metadata,omitempty"`
+		tx["send"] = send
+	}
+
+	return tx
 }
 
-// NewCreateAnnotationInput creates a new CreateAnnotationInput with the required fields.
-func NewCreateAnnotationInput(description string) *CreateAnnotationInput {
-	return &CreateAnnotationInput{
+// CreateAnnotationInput reuses the Ledger CreateTransactionInput contract.
+type CreateAnnotationInput = CreateTransactionInput
+
+// NewCreateAnnotationInput creates a new CreateAnnotationInput.
+func NewCreateAnnotationInput(description string, send ...*SendInput) *CreateAnnotationInput {
+	var sendInput *SendInput
+	if len(send) > 0 {
+		sendInput = send[0]
+	}
+
+	return &CreateTransactionInput{
 		Description: description,
+		Send:        sendInput,
 	}
 }
 
-// WithCode sets the code.
-func (input *CreateAnnotationInput) WithCode(code string) *CreateAnnotationInput {
+// WithCode sets the transaction code.
+func (input *CreateTransactionInput) WithCode(code string) *CreateTransactionInput {
 	input.Code = code
 	return input
 }
 
-// WithMetadata sets the metadata.
-func (input *CreateAnnotationInput) WithMetadata(metadata map[string]any) *CreateAnnotationInput {
-	input.Metadata = metadata
+// WithPending sets the pending flag.
+func (input *CreateOutflowInput) WithPending(pending bool) *CreateOutflowInput {
+	input.Pending = pending
 	return input
-}
-
-// WithChartOfAccountsGroupName sets the chart of accounts group name.
-func (input *CreateAnnotationInput) WithChartOfAccountsGroupName(name string) *CreateAnnotationInput {
-	input.ChartOfAccountsGroupName = name
-	return input
-}
-
-// Validate checks that the CreateAnnotationInput meets all validation requirements.
-func (input *CreateAnnotationInput) Validate() error {
-	if input.Description == "" {
-		return errors.New("description is required for annotation transactions")
-	}
-
-	return nil
 }

--- a/models/transaction_dsl.go
+++ b/models/transaction_dsl.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -1024,12 +1025,12 @@ func extractFromTo(data map[string]any) DSLFromTo {
 	if shareMap, ok := data["share"].(map[string]any); ok {
 		share := &Share{}
 
-		if percentage, ok := shareMap["percentage"].(float64); ok {
-			share.Percentage = int64(percentage)
+		if percentage, ok := int64FromAny(shareMap["percentage"]); ok {
+			share.Percentage = percentage
 		}
 
-		if percentageOfPercentage, ok := shareMap["percentageOfPercentage"].(float64); ok {
-			share.PercentageOfPercentage = int64(percentageOfPercentage)
+		if percentageOfPercentage, ok := int64FromAny(shareMap["percentageOfPercentage"]); ok {
+			share.PercentageOfPercentage = percentageOfPercentage
 		}
 
 		from.Share = share
@@ -1049,6 +1050,37 @@ func extractFromTo(data map[string]any) DSLFromTo {
 	}
 
 	return from
+}
+
+func int64FromAny(value any) (int64, bool) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case float64:
+		return int64(v), true
+	case json.Number:
+		parsed, err := v.Int64()
+		if err == nil {
+			return parsed, true
+		}
+
+		decimalValue, err := strconv.ParseFloat(v.String(), 64)
+
+		return int64(decimalValue), err == nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err == nil {
+			return parsed, true
+		}
+
+		decimalValue, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+
+		return int64(decimalValue), err == nil
+	default:
+		return 0, false
+	}
 }
 
 // Helper functions for extracting values from maps

--- a/models/transaction_dsl.go
+++ b/models/transaction_dsl.go
@@ -1,0 +1,1082 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation"
+	"github.com/LerianStudio/midaz-sdk-golang/v2/pkg/validation/core"
+	"github.com/shopspring/decimal"
+)
+
+// DSLAmount represents an amount with a value and asset code for DSL transactions.
+// This is aligned with the lib-commons Amount structure.
+type DSLAmount struct {
+	// Value is the exact decimal value of the amount.
+	Value any `json:"value"`
+
+	// Asset is the asset code for the amount
+	Asset string `json:"asset,omitempty"`
+}
+
+// DSLFromTo represents a source or destination in a DSL transaction.
+// This is aligned with the lib-commons FromTo structure.
+type DSLFromTo struct {
+	// Account is the identifier of the account
+	Account string `json:"account"`
+
+	// Amount specifies the amount details if applicable
+	Amount *DSLAmount `json:"amount,omitempty"`
+
+	// Share is the sharing configuration
+	Share *Share `json:"share,omitempty"`
+
+	// Remaining is an optional remaining account
+	Remaining string `json:"remaining,omitempty"`
+
+	// Rate is the exchange rate configuration
+	Rate *Rate `json:"rate,omitempty"`
+
+	// Description is a human-readable description
+	Description string `json:"description,omitempty"`
+
+	// ChartOfAccounts is the chart of accounts code
+	ChartOfAccounts string `json:"chartOfAccounts,omitempty"`
+
+	// Metadata contains additional custom data
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// DSLSource represents the source of a DSL transaction.
+// This is aligned with the lib-commons Source structure.
+type DSLSource struct {
+	// Remaining is an optional remaining account
+	Remaining string `json:"remaining,omitempty"`
+
+	// From is a collection of source accounts and amounts
+	From []DSLFromTo `json:"from"`
+}
+
+// DSLDistribute represents the distribution of a DSL transaction.
+// This is aligned with the lib-commons Distribute structure.
+type DSLDistribute struct {
+	// Remaining is an optional remaining account
+	Remaining string `json:"remaining,omitempty"`
+
+	// To is a collection of destination accounts and amounts
+	To []DSLFromTo `json:"to"`
+}
+
+// DSLSend represents the send operation in a DSL transaction.
+// This is aligned with the lib-commons Send structure.
+type DSLSend struct {
+	// Asset identifies the currency or asset type for this transaction
+	Asset string `json:"asset"`
+
+	// Value is the exact decimal value of the transaction.
+	Value any `json:"value"`
+
+	// Source specifies where the funds come from
+	Source *DSLSource `json:"source,omitempty"`
+
+	// Distribute specifies where the funds go to
+	Distribute *DSLDistribute `json:"distribute,omitempty"`
+}
+
+// TransactionDSLInput represents the input for creating a transaction using DSL.
+// This is aligned with the lib-commons Transaction structure.
+type TransactionDSLInput struct {
+	// ChartOfAccountsGroupName specifies the chart of accounts group to use
+	ChartOfAccountsGroupName string `json:"chartOfAccountsGroupName,omitempty"`
+
+	// Description provides a human-readable description of the transaction
+	Description string `json:"description,omitempty"`
+
+	// Send contains the sending configuration
+	Send *DSLSend `json:"send,omitempty"`
+
+	// Metadata contains additional custom data for the transaction
+	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Code is a custom transaction code for categorization
+	Code string `json:"code,omitempty"`
+
+	// Pending indicates whether the transaction requires explicit commitment
+	Pending bool `json:"pending,omitempty"`
+}
+
+// DSLAccountRef is a helper struct to implement the AccountReference interface
+type DSLAccountRef struct {
+	Account string
+}
+
+// GetAccount returns the account identifier
+func (ref *DSLAccountRef) GetAccount() string {
+	if ref == nil {
+		return ""
+	}
+
+	return ref.Account
+}
+
+// GetAsset returns the asset code for the transaction
+func (input *TransactionDSLInput) GetAsset() string {
+	if input == nil || input.Send == nil {
+		return ""
+	}
+
+	return input.Send.Asset
+}
+
+// GetValue returns the amount value for the transaction
+func (input *TransactionDSLInput) GetValue() float64 {
+	if input == nil || input.Send == nil {
+		return 0
+	}
+
+	value, err := decimal.NewFromString(decimalStringFromAny(input.Send.Value))
+	if err != nil {
+		return 0
+	}
+
+	floatValue, _ := value.Float64()
+
+	return floatValue
+}
+
+// GetSourceAccounts returns the source accounts for the transaction
+func (input *TransactionDSLInput) GetSourceAccounts() []validation.AccountReference {
+	var accounts []validation.AccountReference
+
+	if input != nil && input.Send != nil && input.Send.Source != nil {
+		for _, from := range input.Send.Source.From {
+			accounts = append(accounts, &DSLAccountRef{Account: from.Account})
+		}
+	}
+
+	return accounts
+}
+
+// GetDestinationAccounts returns the destination accounts for the transaction
+func (input *TransactionDSLInput) GetDestinationAccounts() []validation.AccountReference {
+	var accounts []validation.AccountReference
+
+	if input != nil && input.Send != nil && input.Send.Distribute != nil {
+		for _, to := range input.Send.Distribute.To {
+			accounts = append(accounts, &DSLAccountRef{Account: to.Account})
+		}
+	}
+
+	return accounts
+}
+
+// GetMetadata returns the metadata for the transaction
+func (input *TransactionDSLInput) GetMetadata() map[string]any {
+	if input == nil {
+		return nil
+	}
+
+	return input.Metadata
+}
+
+// Share represents the sharing configuration for a transaction.
+type Share struct {
+	Percentage             int64 `json:"percentage"`
+	PercentageOfPercentage int64 `json:"percentageOfPercentage,omitempty"`
+}
+
+// Rate represents an exchange rate configuration.
+type Rate struct {
+	From       string `json:"from"`
+	To         string `json:"to"`
+	Value      any    `json:"value"`
+	ExternalID string `json:"externalId"`
+}
+
+// Validate checks that the DSLSend meets all validation requirements.
+func (send *DSLSend) Validate() error {
+	if send == nil {
+		return errors.New("send is required")
+	}
+
+	// Validate required fields
+	if send.Asset == "" {
+		return errors.New("asset is required")
+	}
+
+	// Validate asset code
+	if err := core.ValidateAssetCode(send.Asset); err != nil {
+		return err
+	}
+
+	if err := validatePositiveDecimalString(send.Value, "value"); err != nil {
+		return err
+	}
+
+	// Validate source
+	if err := send.validateSource(); err != nil {
+		return err
+	}
+
+	// Validate distribute
+	return send.validateDistribute()
+}
+
+// validateSource validates the source part of a DSLSend
+func (send *DSLSend) validateSource() error {
+	if send.Source == nil || len(send.Source.From) == 0 {
+		return errors.New("source.from must contain at least one entry")
+	}
+
+	for i, from := range send.Source.From {
+		if from.Account == "" {
+			return fmt.Errorf("source.from[%d].account is required", i)
+		}
+
+		if err := send.validateExternalAccount(from.Account, i, "source.from"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateDistribute validates the distribute part of a DSLSend
+func (send *DSLSend) validateDistribute() error {
+	if send.Distribute == nil || len(send.Distribute.To) == 0 {
+		return errors.New("distribute.to must contain at least one entry")
+	}
+
+	for i, to := range send.Distribute.To {
+		if to.Account == "" {
+			return fmt.Errorf("distribute.to[%d].account is required", i)
+		}
+
+		if err := send.validateExternalAccount(to.Account, i, "distribute.to"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateExternalAccount validates an external account reference
+func (send *DSLSend) validateExternalAccount(account string, index int, location string) error {
+	if account == "" || account[0] != '@' {
+		return nil
+	}
+
+	// For external accounts, check if they match the expected format
+	if !core.ExternalAccountPattern.MatchString(account) {
+		return fmt.Errorf("invalid external account format in %s[%d]: %s", location, index, account)
+	}
+
+	// Check if the asset code in the external account matches the transaction asset
+	matches := core.ExternalAccountPattern.FindStringSubmatch(account)
+	if len(matches) > 1 && matches[1] != send.Asset {
+		return fmt.Errorf("asset code mismatch in %s[%d]: transaction uses %s but external account uses %s",
+			location, index, send.Asset, matches[1])
+	}
+
+	return nil
+}
+
+// Validate checks if the TransactionDSLInput meets the validation requirements.
+// It returns an error if any of the validation checks fail.
+func (input *TransactionDSLInput) Validate() error {
+	if input == nil {
+		return errors.New("transaction DSL input is required")
+	}
+
+	if strings.TrimSpace(input.ChartOfAccountsGroupName) == "" {
+		return errors.New("chartOfAccountsGroupName is required")
+	}
+
+	// Validate send
+	if input.Send == nil {
+		return errors.New("send is required")
+	}
+
+	// Validate send operation
+	if err := input.Send.Validate(); err != nil {
+		return fmt.Errorf("invalid send operation: %w", err)
+	}
+
+	// Validate string length constraints
+	if len(input.ChartOfAccountsGroupName) > 256 {
+		return errors.New("chartOfAccountsGroupName must be at most 256 characters")
+	}
+
+	if len(input.Description) > 256 {
+		return errors.New("description must be at most 256 characters")
+	}
+
+	// Validate transaction code
+	if input.Code != "" {
+		if err := core.ValidateTransactionCode(input.Code); err != nil {
+			return err
+		}
+	}
+
+	// Validate metadata if present
+	if input.Metadata != nil {
+		if err := core.ValidateMetadata(input.Metadata); err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ToTransactionMap converts a TransactionDSLInput to a map that can be used for API requests.
+// This replaces the previous direct lib-commons conversion.
+func (input *TransactionDSLInput) ToTransactionMap() map[string]any {
+	if input == nil {
+		return nil
+	}
+
+	// Create base transaction map
+	transaction := map[string]any{
+		"description": input.Description,
+		"metadata":    input.Metadata,
+	}
+
+	// Add optional fields if present
+	if input.ChartOfAccountsGroupName != "" {
+		transaction["chartOfAccountsGroupName"] = input.ChartOfAccountsGroupName
+	}
+
+	if input.Code != "" {
+		transaction["code"] = input.Code
+	}
+
+	if input.Pending {
+		transaction["pending"] = input.Pending
+	}
+
+	// Add Send information if present
+	if input.Send != nil {
+		transaction["send"] = input.sendToMap()
+	}
+
+	return transaction
+}
+
+// RenderDSL renders the transaction input to Midaz DSL syntax.
+func (input *TransactionDSLInput) RenderDSL() ([]byte, error) {
+	if input == nil {
+		return nil, errors.New("transaction DSL input is required")
+	}
+
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	var builder strings.Builder
+	builder.WriteString("(transaction V1")
+
+	if input.ChartOfAccountsGroupName != "" {
+		if err := validateDSLToken("chartOfAccountsGroupName", input.ChartOfAccountsGroupName); err != nil {
+			return nil, err
+		}
+
+		builder.WriteString(" (chart-of-accounts-group-name ")
+		builder.WriteString(input.ChartOfAccountsGroupName)
+		builder.WriteString(")")
+	}
+
+	if input.Description != "" {
+		builder.WriteString(" (description ")
+		builder.WriteString(quoteDSLString(input.Description))
+		builder.WriteString(")")
+	}
+
+	if input.Code != "" {
+		if err := validateDSLToken("code", input.Code); err != nil {
+			return nil, err
+		}
+
+		builder.WriteString(" (code ")
+		builder.WriteString(input.Code)
+		builder.WriteString(")")
+	}
+
+	if input.Pending {
+		builder.WriteString(" (pending true)")
+	}
+
+	if len(input.Metadata) > 0 {
+		metadataDSL, err := renderDSLMetadata(input.Metadata)
+		if err != nil {
+			return nil, err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(metadataDSL)
+	}
+
+	sendDSL, err := renderDSLSend(input.Send)
+	if err != nil {
+		return nil, err
+	}
+
+	builder.WriteByte(' ')
+	builder.WriteString(sendDSL)
+	builder.WriteByte(')')
+
+	return []byte(builder.String()), nil
+}
+
+func renderDSLSend(send *DSLSend) (string, error) {
+	if err := validateDSLToken("send.asset", send.Asset); err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	builder.WriteString("(send ")
+	builder.WriteString(send.Asset)
+	builder.WriteByte(' ')
+
+	value, err := formatDSLDecimal(decimalStringFromAny(send.Value))
+	if err != nil {
+		return "", fmt.Errorf("invalid send.value: %w", err)
+	}
+
+	builder.WriteString(value)
+
+	if send.Source != nil {
+		sourceDSL, err := renderDSLSource(send.Source)
+		if err != nil {
+			return "", err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(sourceDSL)
+	}
+
+	if send.Distribute != nil {
+		distributeDSL, err := renderDSLDistribute(send.Distribute)
+		if err != nil {
+			return "", err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(distributeDSL)
+	}
+
+	builder.WriteByte(')')
+
+	return builder.String(), nil
+}
+
+func renderDSLSource(source *DSLSource) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("(source")
+
+	if source.Remaining != "" {
+		if err := validateDSLToken("source.remaining", source.Remaining); err != nil {
+			return "", err
+		}
+
+		builder.WriteString(" :")
+		builder.WriteString(source.Remaining)
+	}
+
+	for _, from := range source.From {
+		entryDSL, err := renderDSLFromTo("from", from)
+		if err != nil {
+			return "", err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(entryDSL)
+	}
+
+	builder.WriteByte(')')
+
+	return builder.String(), nil
+}
+
+func renderDSLDistribute(distribute *DSLDistribute) (string, error) {
+	var builder strings.Builder
+	builder.WriteString("(distribute")
+
+	if distribute.Remaining != "" {
+		if err := validateDSLToken("distribute.remaining", distribute.Remaining); err != nil {
+			return "", err
+		}
+
+		builder.WriteString(" :")
+		builder.WriteString(distribute.Remaining)
+	}
+
+	for _, to := range distribute.To {
+		entryDSL, err := renderDSLFromTo("to", to)
+		if err != nil {
+			return "", err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(entryDSL)
+	}
+
+	builder.WriteByte(')')
+
+	return builder.String(), nil
+}
+
+func renderDSLFromTo(kind string, entry DSLFromTo) (string, error) {
+	if err := validateDSLToken(kind+".account", entry.Account); err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	builder.WriteByte('(')
+	builder.WriteString(kind)
+	builder.WriteByte(' ')
+	builder.WriteString(entry.Account)
+
+	if err := renderDSLFromToValue(&builder, kind, entry); err != nil {
+		return "", err
+	}
+
+	if err := renderDSLRate(&builder, kind, entry.Rate); err != nil {
+		return "", err
+	}
+
+	if entry.Description != "" {
+		builder.WriteString(" (description ")
+		builder.WriteString(quoteDSLString(entry.Description))
+		builder.WriteByte(')')
+	}
+
+	if entry.ChartOfAccounts != "" {
+		if err := validateDSLToken(kind+".chartOfAccounts", entry.ChartOfAccounts); err != nil {
+			return "", err
+		}
+
+		builder.WriteString(" (chart-of-accounts ")
+		builder.WriteString(entry.ChartOfAccounts)
+		builder.WriteByte(')')
+	}
+
+	if len(entry.Metadata) > 0 {
+		metadataDSL, err := renderDSLMetadata(entry.Metadata)
+		if err != nil {
+			return "", err
+		}
+
+		builder.WriteByte(' ')
+		builder.WriteString(metadataDSL)
+	}
+
+	builder.WriteByte(')')
+
+	return builder.String(), nil
+}
+
+func renderDSLFromToValue(builder *strings.Builder, kind string, entry DSLFromTo) error {
+	switch {
+	case entry.Amount != nil:
+		return renderDSLAmount(builder, kind, entry.Amount)
+	case entry.Share != nil:
+		renderDSLShare(builder, entry.Share)
+	case entry.Remaining != "":
+		return renderDSLRemaining(builder, kind, entry.Remaining)
+	}
+
+	return nil
+}
+
+func renderDSLAmount(builder *strings.Builder, kind string, amount *DSLAmount) error {
+	if err := validateDSLToken(kind+".amount.asset", amount.Asset); err != nil {
+		return err
+	}
+
+	builder.WriteString(" :amount ")
+	builder.WriteString(amount.Asset)
+	builder.WriteByte(' ')
+
+	value, err := formatDSLDecimal(decimalStringFromAny(amount.Value))
+	if err != nil {
+		return fmt.Errorf("invalid %s.amount.value: %w", kind, err)
+	}
+
+	builder.WriteString(value)
+
+	return nil
+}
+
+func renderDSLShare(builder *strings.Builder, share *Share) {
+	builder.WriteString(" :share ")
+	builder.WriteString(strconv.FormatInt(share.Percentage, 10))
+
+	if share.PercentageOfPercentage > 0 {
+		builder.WriteString(" :of ")
+		builder.WriteString(strconv.FormatInt(share.PercentageOfPercentage, 10))
+	}
+}
+
+func renderDSLRemaining(builder *strings.Builder, kind, remaining string) error {
+	if err := validateDSLToken(kind+".remaining", remaining); err != nil {
+		return err
+	}
+
+	builder.WriteString(" :")
+	builder.WriteString(remaining)
+
+	return nil
+}
+
+func renderDSLRate(builder *strings.Builder, kind string, rate *Rate) error {
+	if rate == nil {
+		return nil
+	}
+
+	if err := validateDSLRateTokens(kind, rate); err != nil {
+		return err
+	}
+
+	builder.WriteString(" (rate ")
+	builder.WriteString(rate.ExternalID)
+	builder.WriteByte(' ')
+	builder.WriteString(rate.From)
+	builder.WriteString(" -> ")
+	builder.WriteString(rate.To)
+	builder.WriteByte(' ')
+
+	value, err := formatDSLDecimal(decimalStringFromAny(rate.Value))
+	if err != nil {
+		return fmt.Errorf("invalid %s.rate.value: %w", kind, err)
+	}
+
+	builder.WriteString(value)
+	builder.WriteByte(')')
+
+	return nil
+}
+
+func validateDSLRateTokens(kind string, rate *Rate) error {
+	if err := validateDSLToken(kind+".rate.externalId", rate.ExternalID); err != nil {
+		return err
+	}
+
+	if err := validateDSLToken(kind+".rate.from", rate.From); err != nil {
+		return err
+	}
+
+	return validateDSLToken(kind+".rate.to", rate.To)
+}
+
+func renderDSLMetadata(metadata map[string]any) (string, error) {
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	var builder strings.Builder
+	builder.WriteString("(metadata")
+
+	for _, key := range keys {
+		if err := validateDSLToken("metadata key", key); err != nil {
+			return "", err
+		}
+
+		valueToken, err := formatDSLMetadataValue(metadata[key])
+		if err != nil {
+			return "", fmt.Errorf("invalid metadata value for %q: %w", key, err)
+		}
+
+		builder.WriteString(" (")
+		builder.WriteString(key)
+		builder.WriteByte(' ')
+		builder.WriteString(valueToken)
+		builder.WriteByte(')')
+	}
+
+	builder.WriteByte(')')
+
+	return builder.String(), nil
+}
+
+func formatDSLMetadataValue(value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		if strings.ContainsAny(v, "()\" \t\n\r") {
+			return "", errors.New("string metadata values for DSL cannot contain whitespace, quotes, or parentheses")
+		}
+
+		if v == "" {
+			return "", errors.New("empty metadata value")
+		}
+
+		return v, nil
+	case bool:
+		return strconv.FormatBool(v), nil
+	case int:
+		return strconv.Itoa(v), nil
+	case int64:
+		return strconv.FormatInt(v, 10), nil
+	case float64:
+		return formatDSLDecimal(strconv.FormatFloat(v, 'f', -1, 64))
+	default:
+		return "", fmt.Errorf("unsupported metadata type %T", value)
+	}
+}
+
+func quoteDSLString(value string) string {
+	escaped := strings.ReplaceAll(value, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
+
+	return "\"" + escaped + "\""
+}
+
+func formatDSLDecimal(value string) (string, error) {
+	parsed, err := decimal.NewFromString(strings.TrimSpace(value))
+	if err != nil {
+		return "", errors.New("value must be a valid decimal")
+	}
+
+	if !parsed.Equal(parsed.Truncate(0)) {
+		return "", errors.New("fractional DSL values are not supported by the current Midaz DSL parser")
+	}
+
+	return parsed.StringFixed(0) + "|0", nil
+}
+
+func validateDSLToken(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s cannot be empty", field)
+	}
+
+	if strings.ContainsAny(value, "()\"' \t\n\r") {
+		return fmt.Errorf("%s contains characters that cannot be safely rendered in DSL", field)
+	}
+
+	return nil
+}
+
+// sendToMap converts the DSLSend to a map for API requests
+func (input *TransactionDSLInput) sendToMap() map[string]any {
+	if input.Send == nil {
+		return nil
+	}
+
+	send := map[string]any{
+		"asset": input.Send.Asset,
+		"value": decimalStringFromAny(input.Send.Value),
+	}
+
+	// Add Source if present
+	if input.Send.Source != nil {
+		send["source"] = input.sourceToMap()
+	}
+
+	// Add Distribute if present
+	if input.Send.Distribute != nil {
+		send["distribute"] = input.distributeToMap()
+	}
+
+	return send
+}
+
+// sourceToMap converts DSLSource to a map for API requests
+func (input *TransactionDSLInput) sourceToMap() map[string]any {
+	if input.Send.Source == nil {
+		return nil
+	}
+
+	source := map[string]any{}
+
+	// Add Remaining if present
+	if input.Send.Source.Remaining != "" {
+		source["remaining"] = input.Send.Source.Remaining
+	}
+
+	// Convert From accounts
+	if len(input.Send.Source.From) > 0 {
+		fromList := make([]map[string]any, 0, len(input.Send.Source.From))
+
+		for _, from := range input.Send.Source.From {
+			fromMap := fromToToMap(from)
+			fromList = append(fromList, fromMap)
+		}
+
+		source["from"] = fromList
+	}
+
+	return source
+}
+
+// distributeToMap converts DSLDistribute to a map for API requests
+func (input *TransactionDSLInput) distributeToMap() map[string]any {
+	if input.Send.Distribute == nil {
+		return nil
+	}
+
+	distribute := map[string]any{}
+
+	// Add Remaining if present
+	if input.Send.Distribute.Remaining != "" {
+		distribute["remaining"] = input.Send.Distribute.Remaining
+	}
+
+	// Convert To accounts
+	if len(input.Send.Distribute.To) > 0 {
+		toList := make([]map[string]any, 0, len(input.Send.Distribute.To))
+
+		for _, to := range input.Send.Distribute.To {
+			toMap := fromToToMap(to)
+			toList = append(toList, toMap)
+		}
+
+		distribute["to"] = toList
+	}
+
+	return distribute
+}
+
+// fromToToMap converts a DSLFromTo to a map for API requests
+func fromToToMap(from DSLFromTo) map[string]any {
+	fromMap := map[string]any{
+		"accountAlias": from.Account,
+	}
+
+	// Add Amount if present
+	if from.Amount != nil {
+		fromMap["amount"] = map[string]any{
+			"asset": from.Amount.Asset,
+			"value": decimalStringFromAny(from.Amount.Value),
+		}
+	}
+
+	// Add other fields if present
+	if from.Remaining != "" {
+		fromMap["remaining"] = from.Remaining
+	}
+
+	if from.Description != "" {
+		fromMap["description"] = from.Description
+	}
+
+	if from.ChartOfAccounts != "" {
+		fromMap["chartOfAccounts"] = from.ChartOfAccounts
+	}
+
+	if from.Metadata != nil {
+		fromMap["metadata"] = from.Metadata
+	}
+
+	// Add Share if present
+	if from.Share != nil {
+		fromMap["share"] = map[string]any{
+			"percentage":             from.Share.Percentage,
+			"percentageOfPercentage": from.Share.PercentageOfPercentage,
+		}
+	}
+
+	// Add Rate if present
+	if from.Rate != nil {
+		fromMap["rate"] = map[string]any{
+			"from":       from.Rate.From,
+			"to":         from.Rate.To,
+			"value":      decimalStringFromAny(from.Rate.Value),
+			"externalId": from.Rate.ExternalID,
+		}
+	}
+
+	return fromMap
+}
+
+// FromTransactionMap converts a map from the API to a TransactionDSLInput.
+// This replaces the previous direct lib-commons conversion.
+func FromTransactionMap(data map[string]any) *TransactionDSLInput {
+	if data == nil {
+		return nil
+	}
+
+	// Extract basic fields
+	input := &TransactionDSLInput{
+		ChartOfAccountsGroupName: getStringFromMap(data, "chartOfAccountsGroupName"),
+		Description:              getStringFromMap(data, "description"),
+		Code:                     getStringFromMap(data, "code"),
+		Metadata:                 getMetadataFromMap(data),
+	}
+
+	// Extract pending flag
+	if pendingVal, ok := data["pending"].(bool); ok {
+		input.Pending = pendingVal
+	}
+
+	// Extract Send information
+	if sendMap, ok := data["send"].(map[string]any); ok {
+		input.Send = extractSend(sendMap)
+	}
+
+	return input
+}
+
+// extractSend converts a map to DSLSend
+func extractSend(data map[string]any) *DSLSend {
+	if data == nil {
+		return nil
+	}
+
+	send := &DSLSend{}
+
+	// Extract basic fields
+	send.Asset = getStringFromMap(data, "asset")
+
+	send.Value = decimalStringFromAny(data["value"])
+
+	// Extract Source
+	if sourceMap, ok := data["source"].(map[string]any); ok {
+		send.Source = extractSource(sourceMap)
+	}
+
+	// Extract Distribute
+	if distMap, ok := data["distribute"].(map[string]any); ok {
+		send.Distribute = extractDistribute(distMap)
+	}
+
+	return send
+}
+
+// extractSource converts a map to DSLSource
+func extractSource(data map[string]any) *DSLSource {
+	if data == nil {
+		return nil
+	}
+
+	source := &DSLSource{
+		Remaining: getStringFromMap(data, "remaining"),
+		From:      []DSLFromTo{},
+	}
+
+	// Extract From entries
+	if fromList, ok := data["from"].([]any); ok {
+		for _, item := range fromList {
+			if fromMap, ok := item.(map[string]any); ok {
+				fromEntry := extractFromTo(fromMap)
+				source.From = append(source.From, fromEntry)
+			}
+		}
+	}
+
+	return source
+}
+
+// extractDistribute converts a map to DSLDistribute
+func extractDistribute(data map[string]any) *DSLDistribute {
+	if data == nil {
+		return nil
+	}
+
+	distribute := &DSLDistribute{
+		Remaining: getStringFromMap(data, "remaining"),
+		To:        []DSLFromTo{},
+	}
+
+	// Extract To entries
+	if toList, ok := data["to"].([]any); ok {
+		for _, item := range toList {
+			if toMap, ok := item.(map[string]any); ok {
+				toEntry := extractFromTo(toMap)
+				distribute.To = append(distribute.To, toEntry)
+			}
+		}
+	}
+
+	return distribute
+}
+
+// extractFromTo converts a map to DSLFromTo
+func extractFromTo(data map[string]any) DSLFromTo {
+	if data == nil {
+		return DSLFromTo{}
+	}
+
+	from := DSLFromTo{
+		Account:         firstStringFromMap(data, "accountAlias", "account"),
+		Remaining:       getStringFromMap(data, "remaining"),
+		Description:     getStringFromMap(data, "description"),
+		ChartOfAccounts: getStringFromMap(data, "chartOfAccounts"),
+		Metadata:        getMetadataFromMap(data),
+	}
+
+	// Extract Amount
+	if amountMap, ok := data["amount"].(map[string]any); ok {
+		amount := &DSLAmount{
+			Asset: getStringFromMap(amountMap, "asset"),
+		}
+
+		amount.Value = decimalStringFromAny(amountMap["value"])
+
+		from.Amount = amount
+	}
+
+	// Extract Share
+	if shareMap, ok := data["share"].(map[string]any); ok {
+		share := &Share{}
+
+		if percentage, ok := shareMap["percentage"].(float64); ok {
+			share.Percentage = int64(percentage)
+		}
+
+		if percentageOfPercentage, ok := shareMap["percentageOfPercentage"].(float64); ok {
+			share.PercentageOfPercentage = int64(percentageOfPercentage)
+		}
+
+		from.Share = share
+	}
+
+	// Extract Rate
+	if rateMap, ok := data["rate"].(map[string]any); ok {
+		rate := &Rate{
+			From:       getStringFromMap(rateMap, "from"),
+			To:         getStringFromMap(rateMap, "to"),
+			ExternalID: getStringFromMap(rateMap, "externalId"),
+		}
+
+		rate.Value = decimalStringFromAny(rateMap["value"])
+
+		from.Rate = rate
+	}
+
+	return from
+}
+
+// Helper functions for extracting values from maps
+
+// getStringFromMap safely extracts a string value from a map
+func getStringFromMap(m map[string]any, key string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+
+	return ""
+}
+
+func firstStringFromMap(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := getStringFromMap(m, key); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+// getMetadataFromMap safely extracts metadata from a map
+func getMetadataFromMap(m map[string]any) map[string]any {
+	if val, ok := m["metadata"].(map[string]any); ok {
+		return val
+	}
+
+	return nil
+}

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -1384,8 +1384,6 @@ func TestNewCreateAnnotationInput_BackwardCompatibleWithoutSend(t *testing.T) {
 
 func TestCreateTransactionInput_ValidateTransactionDate(t *testing.T) {
 	validDates := []string{
-		"2021-01-01",
-		"2021-01-01T00:00:00",
 		"2021-01-01T00:00:00Z",
 		"2021-01-01T00:00:00.000Z",
 		"2021-01-01T00:00:00.000000001Z",
@@ -1406,7 +1404,15 @@ func TestCreateTransactionInput_ValidateTransactionDate(t *testing.T) {
 			WithSend(newValidSendInput(1)).
 			WithTransactionDate("2021-01-01 00:00:00")
 
-		require.ErrorContains(t, input.Validate(), "transactionDate must be ISO 8601")
+		require.ErrorContains(t, input.Validate(), "transactionDate must be RFC3339")
+	})
+
+	t.Run("rejects timezone naive date", func(t *testing.T) {
+		input := NewCreateTransactionInput("USD", 1).
+			WithSend(newValidSendInput(1)).
+			WithTransactionDate("2021-01-01")
+
+		require.ErrorContains(t, input.Validate(), "transactionDate must be RFC3339")
 	})
 
 	t.Run("rejects future date", func(t *testing.T) {
@@ -1458,6 +1464,13 @@ func TestCreateAnnotationInput_Validate(t *testing.T) {
 			input: &CreateAnnotationInput{
 				Description: "",
 				Send:        newValidSendInput(1),
+			},
+			wantErr: false,
+		},
+		{
+			name: "send is optional",
+			input: &CreateAnnotationInput{
+				Description: "Annotation-only note",
 			},
 			wantErr: false,
 		},
@@ -1892,7 +1905,7 @@ func TestDSLSend_Validate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "value must be greater than 0",
+			errMsg:  "value must be greater than zero",
 		},
 		{
 			name: "zero value",
@@ -1907,7 +1920,7 @@ func TestDSLSend_Validate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "value must be greater than 0",
+			errMsg:  "value must be greater than zero",
 		},
 		{
 			name: "missing source",

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -15,6 +15,23 @@ func newDecimal(value string) decimal.Decimal {
 	return d
 }
 
+func newValidSendInput(value float64) *SendInput {
+	asset := "USD"
+
+	return &SendInput{
+		Asset: asset,
+		Value: value,
+		Source: &SourceInput{From: []FromToInput{{
+			Account: "source-account",
+			Amount:  AmountInput{Asset: asset, Value: value},
+		}}},
+		Distribute: &DistributeInput{To: []FromToInput{{
+			Account: "dest-account",
+			Amount:  AmountInput{Asset: asset, Value: value},
+		}}},
+	}
+}
+
 // =============================================================================
 // CreateTransactionInput Tests
 // =============================================================================
@@ -23,62 +40,45 @@ func TestNewCreateTransactionInput(t *testing.T) {
 	tests := []struct {
 		name      string
 		assetCode string
-		amount    string
+		amount    float64
 		wantAsset string
-		wantAmt   string
+		wantAmt   float64
 	}{
 		{
 			name:      "valid USD transaction",
 			assetCode: "USD",
-			amount:    "100.50",
+			amount:    100.50,
 			wantAsset: "USD",
-			wantAmt:   "100.50",
+			wantAmt:   100.50,
 		},
 		{
 			name:      "valid BRL transaction",
 			assetCode: "BRL",
-			amount:    "1000",
+			amount:    1000,
 			wantAsset: "BRL",
-			wantAmt:   "1000",
+			wantAmt:   1000,
 		},
 		{
 			name:      "valid BTC transaction",
 			assetCode: "BTC",
-			amount:    "0.00001",
+			amount:    0.00001,
 			wantAsset: "BTC",
-			wantAmt:   "0.00001",
+			wantAmt:   0.00001,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := NewCreateTransactionInput(tt.assetCode, tt.amount)
-			assert.Equal(t, tt.wantAsset, input.AssetCode)
-			assert.Equal(t, tt.wantAmt, input.Amount)
+			require.NotNil(t, input.Send)
+			assert.Equal(t, tt.wantAsset, input.Send.Asset)
+			assert.Equal(t, decimalStringFromAny(tt.wantAmt), input.Send.Value)
 		})
 	}
 }
 
 func TestCreateTransactionInput_Validate(t *testing.T) {
-	validSend := &SendInput{
-		Asset: "USD",
-		Value: "100",
-		Source: &SourceInput{
-			From: []FromToInput{
-				{Account: "source-account", Amount: AmountInput{Asset: "USD", Value: "100"}},
-			},
-		},
-		Distribute: &DistributeInput{
-			To: []FromToInput{
-				{Account: "dest-account", Amount: AmountInput{Asset: "USD", Value: "100"}},
-			},
-		},
-	}
-
-	validOperations := []CreateOperationInput{
-		{AccountID: "acc-1", Type: "DEBIT", Amount: "100", AssetCode: "USD"},
-		{AccountID: "acc-2", Type: "CREDIT", Amount: "100", AssetCode: "USD"},
-	}
+	validSend := newValidSendInput(100)
 
 	tests := []struct {
 		name    string
@@ -89,78 +89,71 @@ func TestCreateTransactionInput_Validate(t *testing.T) {
 		{
 			name: "valid with send",
 			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "100",
-				Send:      validSend,
+				Send: validSend,
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid with operations",
+			name: "valid with optional fields",
 			input: &CreateTransactionInput{
-				AssetCode:  "USD",
-				Amount:     "100",
-				Operations: validOperations,
+				Description:              "Payment",
+				ChartOfAccountsGroupName: "ASSETS",
+				Metadata:                 map[string]any{"key": "value"},
+				Send:                     validSend,
 			},
 			wantErr: false,
 		},
 		{
-			name: "missing amount",
-			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "",
-				Send:      validSend,
-			},
+			name:    "missing send",
+			input:   &CreateTransactionInput{Description: "No send"},
 			wantErr: true,
-			errMsg:  "amount must be greater than zero",
+			errMsg:  "send is required",
 		},
 		{
-			name: "zero amount",
+			name: "invalid send - zero value",
 			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "0",
-				Send:      validSend,
+				Send: &SendInput{
+					Asset:      "USD",
+					Value:      0,
+					Source:     validSend.Source,
+					Distribute: validSend.Distribute,
+				},
 			},
 			wantErr: true,
-			errMsg:  "amount must be greater than zero",
+			errMsg:  "value must be greater than zero",
 		},
 		{
-			name: "missing asset code",
+			name: "invalid send - missing asset",
 			input: &CreateTransactionInput{
-				AssetCode: "",
-				Amount:    "100",
-				Send:      validSend,
+				Send: &SendInput{
+					Asset:      "",
+					Value:      100,
+					Source:     validSend.Source,
+					Distribute: validSend.Distribute,
+				},
 			},
 			wantErr: true,
-			errMsg:  "assetCode is required",
-		},
-		{
-			name: "invalid asset code format",
-			input: &CreateTransactionInput{
-				AssetCode: "us",
-				Amount:    "100",
-				Send:      validSend,
-			},
-			wantErr: true,
-			errMsg:  "invalid asset code format",
-		},
-		{
-			name: "missing both send and operations",
-			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "100",
-			},
-			wantErr: true,
-			errMsg:  "either operations or send must be provided",
+			errMsg:  "asset is required",
 		},
 		{
 			name: "invalid send - missing source",
 			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "100",
 				Send: &SendInput{
 					Asset:      "USD",
-					Value:      "100",
+					Value:      100,
+					Source:     nil,
+					Distribute: validSend.Distribute,
+				},
+			},
+			wantErr: true,
+			errMsg:  "source is required",
+		},
+		{
+			name: "invalid send - missing source",
+			input: &CreateTransactionInput{
+				Send: &SendInput{
+					Asset:      "USD",
+					Value:      100,
 					Source:     nil,
 					Distribute: validSend.Distribute,
 				},
@@ -188,14 +181,14 @@ func TestCreateTransactionInput_Validate(t *testing.T) {
 
 func TestCreateTransactionInput_WithMethods(t *testing.T) {
 	t.Run("WithDescription", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100")
+		input := NewCreateTransactionInput("USD", 100)
 		result := input.WithDescription("Test payment")
 		assert.Equal(t, "Test payment", result.Description)
 		assert.Same(t, input, result)
 	})
 
 	t.Run("WithMetadata", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100")
+		input := NewCreateTransactionInput("USD", 100)
 		metadata := map[string]any{"key": "value", "number": 42}
 		result := input.WithMetadata(metadata)
 		assert.Equal(t, metadata, result.Metadata)
@@ -203,37 +196,36 @@ func TestCreateTransactionInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithExternalID", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100")
+		input := NewCreateTransactionInput("USD", 100)
 		result := input.WithExternalID("ext-123")
 		assert.Equal(t, "ext-123", result.ExternalID)
 		assert.Same(t, input, result)
 	})
 
-	t.Run("WithOperations", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100")
-		ops := []CreateOperationInput{
-			{AccountID: "acc-1", Type: "DEBIT", Amount: "100", AssetCode: "USD"},
-		}
-		result := input.WithOperations(ops)
-		assert.Equal(t, ops, result.Operations)
+	t.Run("WithCode", func(t *testing.T) {
+		input := NewCreateTransactionInput("USD", 100)
+		result := input.WithCode("TX-001")
+		assert.Equal(t, "TX-001", result.Code)
 		assert.Same(t, input, result)
 	})
 
 	t.Run("WithSend", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100")
-		send := &SendInput{Asset: "USD", Value: "100"}
+		input := NewCreateTransactionInput("USD", 100)
+		send := newValidSendInput(100)
 		result := input.WithSend(send)
 		assert.Equal(t, send, result.Send)
 		assert.Same(t, input, result)
 	})
 
 	t.Run("chained methods", func(t *testing.T) {
-		input := NewCreateTransactionInput("USD", "100").
+		input := NewCreateTransactionInput("USD", 100).
 			WithDescription("Payment").
+			WithCode("TX-CHAIN").
 			WithExternalID("ext-1").
 			WithMetadata(map[string]any{"ref": "123"})
 
 		assert.Equal(t, "Payment", input.Description)
+		assert.Equal(t, "TX-CHAIN", input.Code)
 		assert.Equal(t, "ext-1", input.ExternalID)
 		assert.Equal(t, map[string]any{"ref": "123"}, input.Metadata)
 	})
@@ -269,15 +261,15 @@ func TestCreateTransactionInput_ToLibTransaction(t *testing.T) {
 			Description: "With send",
 			Send: &SendInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &SourceInput{
 					From: []FromToInput{
-						{Account: "source", Amount: AmountInput{Asset: "USD", Value: "100"}},
+						{Account: "source", Amount: AmountInput{Asset: "USD", Value: 100}},
 					},
 				},
 				Distribute: &DistributeInput{
 					To: []FromToInput{
-						{Account: "dest", Amount: AmountInput{Asset: "USD", Value: "100"}},
+						{Account: "dest", Amount: AmountInput{Asset: "USD", Value: 100}},
 					},
 				},
 			},
@@ -317,13 +309,13 @@ func TestCreateTransactionInput_ToLibTransaction(t *testing.T) {
 func TestSendInput_Validate(t *testing.T) {
 	validSource := &SourceInput{
 		From: []FromToInput{
-			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
 	validDistribute := &DistributeInput{
 		To: []FromToInput{
-			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
@@ -337,7 +329,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "valid send",
 			input: &SendInput{
 				Asset:      "USD",
-				Value:      "100",
+				Value:      100,
 				Source:     validSource,
 				Distribute: validDistribute,
 			},
@@ -347,7 +339,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "missing asset",
 			input: &SendInput{
 				Asset:      "",
-				Value:      "100",
+				Value:      100,
 				Source:     validSource,
 				Distribute: validDistribute,
 			},
@@ -358,7 +350,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "missing value",
 			input: &SendInput{
 				Asset:      "USD",
-				Value:      "",
+				Value:      0,
 				Source:     validSource,
 				Distribute: validDistribute,
 			},
@@ -369,7 +361,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "zero value",
 			input: &SendInput{
 				Asset:      "USD",
-				Value:      "0",
+				Value:      0,
 				Source:     validSource,
 				Distribute: validDistribute,
 			},
@@ -380,7 +372,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "missing source",
 			input: &SendInput{
 				Asset:      "USD",
-				Value:      "100",
+				Value:      100,
 				Source:     nil,
 				Distribute: validDistribute,
 			},
@@ -391,7 +383,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "missing distribute",
 			input: &SendInput{
 				Asset:      "USD",
-				Value:      "100",
+				Value:      100,
 				Source:     validSource,
 				Distribute: nil,
 			},
@@ -402,7 +394,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "invalid source",
 			input: &SendInput{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &SourceInput{
 					From: []FromToInput{},
 				},
@@ -415,7 +407,7 @@ func TestSendInput_Validate(t *testing.T) {
 			name: "invalid distribute",
 			input: &SendInput{
 				Asset:  "USD",
-				Value:  "100",
+				Value:  100,
 				Source: validSource,
 				Distribute: &DistributeInput{
 					To: []FromToInput{},
@@ -453,15 +445,15 @@ func TestSendInput_ToMap(t *testing.T) {
 	t.Run("complete send", func(t *testing.T) {
 		input := &SendInput{
 			Asset: "USD",
-			Value: "100",
+			Value: 100,
 			Source: &SourceInput{
 				From: []FromToInput{
-					{Account: "source", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "source", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			Distribute: &DistributeInput{
 				To: []FromToInput{
-					{Account: "dest", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "dest", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 		}
@@ -489,7 +481,7 @@ func TestSourceInput_Validate(t *testing.T) {
 			name: "valid source",
 			input: &SourceInput{
 				From: []FromToInput{
-					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			wantErr: false,
@@ -498,8 +490,8 @@ func TestSourceInput_Validate(t *testing.T) {
 			name: "multiple from entries",
 			input: &SourceInput{
 				From: []FromToInput{
-					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "50"}},
-					{Account: "acc-2", Amount: AmountInput{Asset: "USD", Value: "50"}},
+					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 50}},
+					{Account: "acc-2", Amount: AmountInput{Asset: "USD", Value: 50}},
 				},
 			},
 			wantErr: false,
@@ -516,7 +508,7 @@ func TestSourceInput_Validate(t *testing.T) {
 			name: "invalid from entry",
 			input: &SourceInput{
 				From: []FromToInput{
-					{Account: "", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			wantErr: true,
@@ -551,7 +543,7 @@ func TestSourceInput_ToMap(t *testing.T) {
 	t.Run("with from entries", func(t *testing.T) {
 		input := &SourceInput{
 			From: []FromToInput{
-				{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "100"}},
+				{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 100}},
 			},
 		}
 		result := input.ToMap()
@@ -587,7 +579,7 @@ func TestDistributeInput_Validate(t *testing.T) {
 			name: "valid distribute",
 			input: &DistributeInput{
 				To: []FromToInput{
-					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			wantErr: false,
@@ -596,8 +588,8 @@ func TestDistributeInput_Validate(t *testing.T) {
 			name: "multiple to entries",
 			input: &DistributeInput{
 				To: []FromToInput{
-					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "50"}},
-					{Account: "acc-2", Amount: AmountInput{Asset: "USD", Value: "50"}},
+					{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 50}},
+					{Account: "acc-2", Amount: AmountInput{Asset: "USD", Value: 50}},
 				},
 			},
 			wantErr: false,
@@ -614,7 +606,7 @@ func TestDistributeInput_Validate(t *testing.T) {
 			name: "invalid to entry",
 			input: &DistributeInput{
 				To: []FromToInput{
-					{Account: "", Amount: AmountInput{Asset: "USD", Value: "100"}},
+					{Account: "", Amount: AmountInput{Asset: "USD", Value: 100}},
 				},
 			},
 			wantErr: true,
@@ -649,7 +641,7 @@ func TestDistributeInput_ToMap(t *testing.T) {
 	t.Run("with to entries", func(t *testing.T) {
 		input := &DistributeInput{
 			To: []FromToInput{
-				{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: "100"}},
+				{Account: "acc-1", Amount: AmountInput{Asset: "USD", Value: 100}},
 			},
 		}
 		result := input.ToMap()
@@ -675,7 +667,7 @@ func TestFromToInput_Validate(t *testing.T) {
 			name: "valid from/to",
 			input: &FromToInput{
 				Account: "acc-123",
-				Amount:  AmountInput{Asset: "USD", Value: "100"},
+				Amount:  AmountInput{Asset: "USD", Value: 100},
 			},
 			wantErr: false,
 		},
@@ -683,7 +675,7 @@ func TestFromToInput_Validate(t *testing.T) {
 			name: "with optional fields",
 			input: &FromToInput{
 				Account:         "acc-123",
-				Amount:          AmountInput{Asset: "USD", Value: "100"},
+				Amount:          AmountInput{Asset: "USD", Value: 100},
 				Route:           "route-1",
 				Description:     "Test description",
 				ChartOfAccounts: "ASSETS",
@@ -696,7 +688,7 @@ func TestFromToInput_Validate(t *testing.T) {
 			name: "missing account",
 			input: &FromToInput{
 				Account: "",
-				Amount:  AmountInput{Asset: "USD", Value: "100"},
+				Amount:  AmountInput{Asset: "USD", Value: 100},
 			},
 			wantErr: true,
 			errMsg:  "account is required",
@@ -705,7 +697,7 @@ func TestFromToInput_Validate(t *testing.T) {
 			name: "invalid amount - missing asset",
 			input: &FromToInput{
 				Account: "acc-123",
-				Amount:  AmountInput{Asset: "", Value: "100"},
+				Amount:  AmountInput{Asset: "", Value: 100},
 			},
 			wantErr: true,
 			errMsg:  "asset is required",
@@ -714,7 +706,7 @@ func TestFromToInput_Validate(t *testing.T) {
 			name: "invalid amount - missing value",
 			input: &FromToInput{
 				Account: "acc-123",
-				Amount:  AmountInput{Asset: "USD", Value: ""},
+				Amount:  AmountInput{Asset: "USD", Value: 0},
 			},
 			wantErr: true,
 			errMsg:  "value must be greater than zero",
@@ -741,7 +733,7 @@ func TestFromToInput_ToMap(t *testing.T) {
 	t.Run("basic input", func(t *testing.T) {
 		input := FromToInput{
 			Account: "acc-123",
-			Amount:  AmountInput{Asset: "USD", Value: "100"},
+			Amount:  AmountInput{Asset: "USD", Value: 100},
 		}
 		result := input.ToMap()
 
@@ -752,7 +744,7 @@ func TestFromToInput_ToMap(t *testing.T) {
 	t.Run("with route", func(t *testing.T) {
 		input := FromToInput{
 			Account: "acc-123",
-			Amount:  AmountInput{Asset: "USD", Value: "100"},
+			Amount:  AmountInput{Asset: "USD", Value: 100},
 			Route:   "main-route",
 		}
 		result := input.ToMap()
@@ -774,29 +766,29 @@ func TestAmountInput_Validate(t *testing.T) {
 	}{
 		{
 			name:    "valid amount",
-			input:   &AmountInput{Asset: "USD", Value: "100"},
+			input:   &AmountInput{Asset: "USD", Value: 100},
 			wantErr: false,
 		},
 		{
 			name:    "valid decimal amount",
-			input:   &AmountInput{Asset: "USD", Value: "100.50"},
+			input:   &AmountInput{Asset: "USD", Value: 100.50},
 			wantErr: false,
 		},
 		{
 			name:    "missing asset",
-			input:   &AmountInput{Asset: "", Value: "100"},
+			input:   &AmountInput{Asset: "", Value: 100},
 			wantErr: true,
 			errMsg:  "asset is required",
 		},
 		{
 			name:    "missing value",
-			input:   &AmountInput{Asset: "USD", Value: ""},
+			input:   &AmountInput{Asset: "USD", Value: 0},
 			wantErr: true,
 			errMsg:  "value must be greater than zero",
 		},
 		{
 			name:    "zero value",
-			input:   &AmountInput{Asset: "USD", Value: "0"},
+			input:   &AmountInput{Asset: "USD", Value: 0},
 			wantErr: true,
 			errMsg:  "value must be greater than zero",
 		},
@@ -819,11 +811,11 @@ func TestAmountInput_Validate(t *testing.T) {
 }
 
 func TestAmountInput_ToMap(t *testing.T) {
-	input := &AmountInput{Asset: "USD", Value: "100.50"}
+	input := &AmountInput{Asset: "USD", Value: 100.50}
 	result := input.ToMap()
 
 	assert.Equal(t, "USD", result["asset"])
-	assert.Equal(t, "100.50", result["value"])
+	assert.Equal(t, "100.5", result["value"])
 }
 
 // =============================================================================
@@ -880,12 +872,11 @@ func TestUpdateTransactionInput_Validate(t *testing.T) {
 			errMsg:  "description must not exceed 256 characters",
 		},
 		{
-			name: "external ID too long",
+			name: "external ID is ignored for validation",
 			input: &UpdateTransactionInput{
 				ExternalID: strings.Repeat("a", 65),
 			},
-			wantErr: true,
-			errMsg:  "externalId must not exceed 64 characters",
+			wantErr: false,
 		},
 		{
 			name: "invalid metadata - empty key",
@@ -958,11 +949,11 @@ func TestUpdateTransactionInput_WithMethods(t *testing.T) {
 func TestNewCreateInflowInput(t *testing.T) {
 	distribute := &DistributeInput{
 		To: []FromToInput{
-			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
-	input := NewCreateInflowInput("USD", "100", distribute)
+	input := NewCreateInflowInput("USD", 100, distribute)
 
 	assert.NotNil(t, input)
 	assert.NotNil(t, input.Send)
@@ -974,7 +965,7 @@ func TestNewCreateInflowInput(t *testing.T) {
 func TestCreateInflowInput_Validate(t *testing.T) {
 	validDistribute := &DistributeInput{
 		To: []FromToInput{
-			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "dest-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
@@ -989,7 +980,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset:      "USD",
-					Value:      "100",
+					Value:      100,
 					Distribute: validDistribute,
 				},
 			},
@@ -1006,7 +997,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset:      "",
-					Value:      "100",
+					Value:      100,
 					Distribute: validDistribute,
 				},
 			},
@@ -1018,7 +1009,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset:      "USD",
-					Value:      "",
+					Value:      0,
 					Distribute: validDistribute,
 				},
 			},
@@ -1030,7 +1021,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset:      "USD",
-					Value:      "0",
+					Value:      0,
 					Distribute: validDistribute,
 				},
 			},
@@ -1042,7 +1033,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset:      "USD",
-					Value:      "100",
+					Value:      100,
 					Distribute: nil,
 				},
 			},
@@ -1054,7 +1045,7 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 			input: &CreateInflowInput{
 				Send: &SendInflowInput{
 					Asset: "USD",
-					Value: "100",
+					Value: 100,
 					Distribute: &DistributeInput{
 						To: []FromToInput{},
 					},
@@ -1084,12 +1075,12 @@ func TestCreateInflowInput_Validate(t *testing.T) {
 func TestCreateInflowInput_WithMethods(t *testing.T) {
 	distribute := &DistributeInput{
 		To: []FromToInput{
-			{Account: "acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
 	t.Run("WithDescription", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute)
+		input := NewCreateInflowInput("USD", 100, distribute)
 		result := input.WithDescription("Deposit")
 
 		assert.Equal(t, "Deposit", result.Description)
@@ -1097,7 +1088,7 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithCode", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute)
+		input := NewCreateInflowInput("USD", 100, distribute)
 		result := input.WithCode("DEP-001")
 
 		assert.Equal(t, "DEP-001", result.Code)
@@ -1105,7 +1096,7 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithMetadata", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute)
+		input := NewCreateInflowInput("USD", 100, distribute)
 		metadata := map[string]any{"source": "bank"}
 		result := input.WithMetadata(metadata)
 
@@ -1114,7 +1105,7 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithChartOfAccountsGroupName", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute)
+		input := NewCreateInflowInput("USD", 100, distribute)
 		result := input.WithChartOfAccountsGroupName("ASSETS")
 
 		assert.Equal(t, "ASSETS", result.ChartOfAccountsGroupName)
@@ -1122,7 +1113,7 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithRoute", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute)
+		input := NewCreateInflowInput("USD", 100, distribute)
 		result := input.WithRoute("deposit-route")
 
 		assert.Equal(t, "deposit-route", result.Route)
@@ -1130,7 +1121,7 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("chained methods", func(t *testing.T) {
-		input := NewCreateInflowInput("USD", "100", distribute).
+		input := NewCreateInflowInput("USD", 100, distribute).
 			WithDescription("Test deposit").
 			WithCode("DEP-002").
 			WithChartOfAccountsGroupName("ASSETS").
@@ -1152,11 +1143,11 @@ func TestCreateInflowInput_WithMethods(t *testing.T) {
 func TestNewCreateOutflowInput(t *testing.T) {
 	source := &SourceInput{
 		From: []FromToInput{
-			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
-	input := NewCreateOutflowInput("USD", "100", source)
+	input := NewCreateOutflowInput("USD", 100, source)
 
 	assert.NotNil(t, input)
 	assert.NotNil(t, input.Send)
@@ -1168,7 +1159,7 @@ func TestNewCreateOutflowInput(t *testing.T) {
 func TestCreateOutflowInput_Validate(t *testing.T) {
 	validSource := &SourceInput{
 		From: []FromToInput{
-			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "source-acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
@@ -1183,7 +1174,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset:  "USD",
-					Value:  "100",
+					Value:  100,
 					Source: validSource,
 				},
 			},
@@ -1200,7 +1191,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset:  "",
-					Value:  "100",
+					Value:  100,
 					Source: validSource,
 				},
 			},
@@ -1212,7 +1203,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset:  "USD",
-					Value:  "",
+					Value:  0,
 					Source: validSource,
 				},
 			},
@@ -1224,7 +1215,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset:  "USD",
-					Value:  "0",
+					Value:  0,
 					Source: validSource,
 				},
 			},
@@ -1236,7 +1227,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset:  "USD",
-					Value:  "100",
+					Value:  100,
 					Source: nil,
 				},
 			},
@@ -1248,7 +1239,7 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 			input: &CreateOutflowInput{
 				Send: &SendOutflowInput{
 					Asset: "USD",
-					Value: "100",
+					Value: 100,
 					Source: &SourceInput{
 						From: []FromToInput{},
 					},
@@ -1278,12 +1269,12 @@ func TestCreateOutflowInput_Validate(t *testing.T) {
 func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	source := &SourceInput{
 		From: []FromToInput{
-			{Account: "acc", Amount: AmountInput{Asset: "USD", Value: "100"}},
+			{Account: "acc", Amount: AmountInput{Asset: "USD", Value: 100}},
 		},
 	}
 
 	t.Run("WithDescription", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source)
+		input := NewCreateOutflowInput("USD", 100, source)
 		result := input.WithDescription("Withdrawal")
 
 		assert.Equal(t, "Withdrawal", result.Description)
@@ -1291,7 +1282,7 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithCode", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source)
+		input := NewCreateOutflowInput("USD", 100, source)
 		result := input.WithCode("WTH-001")
 
 		assert.Equal(t, "WTH-001", result.Code)
@@ -1299,7 +1290,7 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithMetadata", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source)
+		input := NewCreateOutflowInput("USD", 100, source)
 		metadata := map[string]any{"destination": "bank"}
 		result := input.WithMetadata(metadata)
 
@@ -1308,7 +1299,7 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithChartOfAccountsGroupName", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source)
+		input := NewCreateOutflowInput("USD", 100, source)
 		result := input.WithChartOfAccountsGroupName("LIABILITIES")
 
 		assert.Equal(t, "LIABILITIES", result.ChartOfAccountsGroupName)
@@ -1316,7 +1307,7 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithRoute", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source)
+		input := NewCreateOutflowInput("USD", 100, source)
 		result := input.WithRoute("withdrawal-route")
 
 		assert.Equal(t, "withdrawal-route", result.Route)
@@ -1324,7 +1315,7 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("chained methods", func(t *testing.T) {
-		input := NewCreateOutflowInput("USD", "100", source).
+		input := NewCreateOutflowInput("USD", 100, source).
 			WithDescription("Test withdrawal").
 			WithCode("WTH-002").
 			WithChartOfAccountsGroupName("LIABILITIES").
@@ -1344,10 +1335,63 @@ func TestCreateOutflowInput_WithMethods(t *testing.T) {
 // =============================================================================
 
 func TestNewCreateAnnotationInput(t *testing.T) {
+	input := NewCreateAnnotationInput("Test annotation", newValidSendInput(1))
+
+	assert.NotNil(t, input)
+	assert.Equal(t, "Test annotation", input.Description)
+}
+
+func TestNewCreateAnnotationInput_BackwardCompatibleWithoutSend(t *testing.T) {
 	input := NewCreateAnnotationInput("Test annotation")
 
 	assert.NotNil(t, input)
 	assert.Equal(t, "Test annotation", input.Description)
+	assert.Nil(t, input.Send)
+}
+
+func TestCreateTransactionInput_ValidateTransactionDate(t *testing.T) {
+	validDates := []string{
+		"2021-01-01",
+		"2021-01-01T00:00:00",
+		"2021-01-01T00:00:00Z",
+		"2021-01-01T00:00:00.000Z",
+		"2021-01-01T00:00:00.000000001Z",
+	}
+
+	for _, transactionDate := range validDates {
+		t.Run(transactionDate, func(t *testing.T) {
+			input := NewCreateTransactionInput("USD", 1).
+				WithSend(newValidSendInput(1)).
+				WithTransactionDate(transactionDate)
+
+			require.NoError(t, input.Validate())
+		})
+	}
+
+	t.Run("rejects unsupported space separated date", func(t *testing.T) {
+		input := NewCreateTransactionInput("USD", 1).
+			WithSend(newValidSendInput(1)).
+			WithTransactionDate("2021-01-01 00:00:00")
+
+		require.ErrorContains(t, input.Validate(), "transactionDate must be ISO 8601")
+	})
+
+	t.Run("rejects future date", func(t *testing.T) {
+		input := NewCreateTransactionInput("USD", 1).
+			WithSend(newValidSendInput(1)).
+			WithTransactionDate("2999-01-01T00:00:00Z")
+
+		require.ErrorContains(t, input.Validate(), "transactionDate cannot be in the future")
+	})
+
+	t.Run("rejects pending custom date", func(t *testing.T) {
+		input := NewCreateTransactionInput("USD", 1).
+			WithSend(newValidSendInput(1)).
+			WithPending(true).
+			WithTransactionDate("2021-01-01T00:00:00Z")
+
+		require.ErrorContains(t, input.Validate(), "pending transactions cannot have a custom transactionDate")
+	})
 }
 
 func TestCreateAnnotationInput_Validate(t *testing.T) {
@@ -1361,6 +1405,7 @@ func TestCreateAnnotationInput_Validate(t *testing.T) {
 			name: "valid annotation",
 			input: &CreateAnnotationInput{
 				Description: "Monthly reconciliation note",
+				Send:        newValidSendInput(1),
 			},
 			wantErr: false,
 		},
@@ -1371,16 +1416,17 @@ func TestCreateAnnotationInput_Validate(t *testing.T) {
 				ChartOfAccountsGroupName: "NOTES",
 				Code:                     "ANN-001",
 				Metadata:                 map[string]any{"author": "system"},
+				Send:                     newValidSendInput(1),
 			},
 			wantErr: false,
 		},
 		{
-			name: "missing description",
+			name: "missing description is allowed",
 			input: &CreateAnnotationInput{
 				Description: "",
+				Send:        newValidSendInput(1),
 			},
-			wantErr: true,
-			errMsg:  "description is required for annotation transactions",
+			wantErr: false,
 		},
 	}
 
@@ -1402,7 +1448,7 @@ func TestCreateAnnotationInput_Validate(t *testing.T) {
 
 func TestCreateAnnotationInput_WithMethods(t *testing.T) {
 	t.Run("WithCode", func(t *testing.T) {
-		input := NewCreateAnnotationInput("Test")
+		input := NewCreateAnnotationInput("Test", newValidSendInput(1))
 		result := input.WithCode("ANN-001")
 
 		assert.Equal(t, "ANN-001", result.Code)
@@ -1410,7 +1456,7 @@ func TestCreateAnnotationInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithMetadata", func(t *testing.T) {
-		input := NewCreateAnnotationInput("Test")
+		input := NewCreateAnnotationInput("Test", newValidSendInput(1))
 		metadata := map[string]any{"note_type": "audit"}
 		result := input.WithMetadata(metadata)
 
@@ -1419,18 +1465,19 @@ func TestCreateAnnotationInput_WithMethods(t *testing.T) {
 	})
 
 	t.Run("WithChartOfAccountsGroupName", func(t *testing.T) {
-		input := NewCreateAnnotationInput("Test")
-		result := input.WithChartOfAccountsGroupName("ANNOTATIONS")
+		input := NewCreateAnnotationInput("Test", newValidSendInput(1))
+		input.ChartOfAccountsGroupName = "ANNOTATIONS"
+		result := input
 
 		assert.Equal(t, "ANNOTATIONS", result.ChartOfAccountsGroupName)
 		assert.Same(t, input, result)
 	})
 
 	t.Run("chained methods", func(t *testing.T) {
-		input := NewCreateAnnotationInput("Audit note").
+		input := NewCreateAnnotationInput("Audit note", newValidSendInput(1)).
 			WithCode("AUD-001").
-			WithChartOfAccountsGroupName("AUDIT").
 			WithMetadata(map[string]any{"auditor": "external"})
+		input.ChartOfAccountsGroupName = "AUDIT"
 
 		assert.Equal(t, "Audit note", input.Description)
 		assert.Equal(t, "AUD-001", input.Code)
@@ -1446,7 +1493,7 @@ func TestCreateAnnotationInput_WithMethods(t *testing.T) {
 func TestTransactionDSLInput_Validate(t *testing.T) {
 	validSend := &DSLSend{
 		Asset: "USD",
-		Value: "100",
+		Value: 100,
 		Source: &DSLSource{
 			From: []DSLFromTo{
 				{Account: "source-acc"},
@@ -1468,7 +1515,8 @@ func TestTransactionDSLInput_Validate(t *testing.T) {
 		{
 			name: "valid DSL input",
 			input: &TransactionDSLInput{
-				Send: validSend,
+				ChartOfAccountsGroupName: "TRANSFERS",
+				Send:                     validSend,
 			},
 			wantErr: false,
 		},
@@ -1486,15 +1534,22 @@ func TestTransactionDSLInput_Validate(t *testing.T) {
 		},
 		{
 			name:    "missing send",
-			input:   &TransactionDSLInput{},
+			input:   &TransactionDSLInput{ChartOfAccountsGroupName: "TRANSFERS"},
 			wantErr: true,
 			errMsg:  "send is required",
 		},
 		{
+			name:    "missing chart of accounts group name",
+			input:   &TransactionDSLInput{Send: validSend},
+			wantErr: true,
+			errMsg:  "chartOfAccountsGroupName is required",
+		},
+		{
 			name: "description too long",
 			input: &TransactionDSLInput{
-				Description: strings.Repeat("a", 257),
-				Send:        validSend,
+				ChartOfAccountsGroupName: "TRANSFERS",
+				Description:              strings.Repeat("a", 257),
+				Send:                     validSend,
 			},
 			wantErr: true,
 			errMsg:  "description must be at most 256 characters",
@@ -1511,8 +1566,9 @@ func TestTransactionDSLInput_Validate(t *testing.T) {
 		{
 			name: "invalid transaction code",
 			input: &TransactionDSLInput{
-				Code: "invalid code with spaces!",
-				Send: validSend,
+				ChartOfAccountsGroupName: "TRANSFERS",
+				Code:                     "invalid code with spaces!",
+				Send:                     validSend,
 			},
 			wantErr: true,
 			errMsg:  "invalid transaction code format",
@@ -1520,8 +1576,9 @@ func TestTransactionDSLInput_Validate(t *testing.T) {
 		{
 			name: "invalid metadata",
 			input: &TransactionDSLInput{
-				Metadata: map[string]any{"": "empty key"},
-				Send:     validSend,
+				ChartOfAccountsGroupName: "TRANSFERS",
+				Metadata:                 map[string]any{"": "empty key"},
+				Send:                     validSend,
 			},
 			wantErr: true,
 			errMsg:  "metadata keys cannot be empty",
@@ -1544,6 +1601,52 @@ func TestTransactionDSLInput_Validate(t *testing.T) {
 	}
 }
 
+func TestTransactionDSLInput_RenderDSL(t *testing.T) {
+	validSend := &DSLSend{
+		Asset: "USD",
+		Value: 100,
+		Source: &DSLSource{From: []DSLFromTo{{
+			Account: "source-acc",
+			Amount:  &DSLAmount{Asset: "USD", Value: 100},
+		}}},
+		Distribute: &DSLDistribute{To: []DSLFromTo{{
+			Account: "dest-acc",
+			Amount:  &DSLAmount{Asset: "USD", Value: 100},
+		}}},
+	}
+
+	input := &TransactionDSLInput{
+		ChartOfAccountsGroupName: "TRANSFERS",
+		Send:                     validSend,
+	}
+
+	rendered, err := input.RenderDSL()
+	require.NoError(t, err)
+	assert.Equal(t, `(transaction V1 (chart-of-accounts-group-name TRANSFERS) (send USD 100|0 (source (from source-acc :amount USD 100|0)) (distribute (to dest-acc :amount USD 100|0))))`, string(rendered))
+}
+
+func TestTransactionDSLInput_RenderDSL_RejectsFractionalValues(t *testing.T) {
+	input := &TransactionDSLInput{
+		ChartOfAccountsGroupName: "TRANSFERS",
+		Send: &DSLSend{
+			Asset: "USD",
+			Value: "100.50",
+			Source: &DSLSource{From: []DSLFromTo{{
+				Account: "source-acc",
+				Amount:  &DSLAmount{Asset: "USD", Value: 100},
+			}}},
+			Distribute: &DSLDistribute{To: []DSLFromTo{{
+				Account: "dest-acc",
+				Amount:  &DSLAmount{Asset: "USD", Value: 100},
+			}}},
+		},
+	}
+
+	_, err := input.RenderDSL()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fractional DSL values are not supported")
+}
+
 func TestTransactionDSLInput_GetMethods(t *testing.T) {
 	t.Run("GetAsset with nil Send", func(t *testing.T) {
 		input := &TransactionDSLInput{}
@@ -1564,14 +1667,14 @@ func TestTransactionDSLInput_GetMethods(t *testing.T) {
 
 	t.Run("GetValue with valid Send", func(t *testing.T) {
 		input := &TransactionDSLInput{
-			Send: &DSLSend{Value: "100.50"},
+			Send: &DSLSend{Value: 100.50},
 		}
 		assert.InDelta(t, 100.50, input.GetValue(), 0.001)
 	})
 
-	t.Run("GetValue with invalid value", func(t *testing.T) {
+	t.Run("GetValue with zero value", func(t *testing.T) {
 		input := &TransactionDSLInput{
-			Send: &DSLSend{Value: "invalid"},
+			Send: &DSLSend{Value: 0},
 		}
 		assert.InDelta(t, float64(0), input.GetValue(), 0.001)
 	})
@@ -1646,7 +1749,7 @@ func TestTransactionDSLInput_ToTransactionMap(t *testing.T) {
 			Metadata:                 map[string]any{"ref": "123"},
 			Send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					Remaining: "remaining-acc",
 					From: []DSLFromTo{
@@ -1703,7 +1806,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "valid send",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1717,7 +1820,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "missing asset",
 			send: &DSLSend{
 				Asset: "",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1732,7 +1835,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "invalid asset format",
 			send: &DSLSend{
 				Asset: "invalid",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1747,7 +1850,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "missing value",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "",
+				Value: 0,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1762,7 +1865,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "zero value",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "0",
+				Value: 0,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1777,7 +1880,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "missing source",
 			send: &DSLSend{
 				Asset:  "USD",
-				Value:  "100",
+				Value:  100,
 				Source: nil,
 				Distribute: &DSLDistribute{
 					To: []DSLFromTo{{Account: "acc-2"}},
@@ -1790,7 +1893,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "empty source from",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{},
 				},
@@ -1805,7 +1908,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "missing distribute",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1818,7 +1921,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "empty distribute to",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1833,7 +1936,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "source from missing account",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: ""}},
 				},
@@ -1848,7 +1951,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "distribute to missing account",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "acc-1"}},
 				},
@@ -1863,7 +1966,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "valid external account in source",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "@external/USD"}},
 				},
@@ -1877,7 +1980,7 @@ func TestDSLSend_Validate(t *testing.T) {
 			name: "external account asset mismatch",
 			send: &DSLSend{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 				Source: &DSLSource{
 					From: []DSLFromTo{{Account: "@external/EUR"}},
 				},
@@ -1913,6 +2016,19 @@ func TestDSLSend_Validate(t *testing.T) {
 func TestDSLAccountRef_GetAccount(t *testing.T) {
 	ref := &DSLAccountRef{Account: "test-account"}
 	assert.Equal(t, "test-account", ref.GetAccount())
+
+	var nilRef *DSLAccountRef
+	assert.Empty(t, nilRef.GetAccount())
+}
+
+func TestTransactionDSLInput_NilReceiverHelpers(t *testing.T) {
+	var input *TransactionDSLInput
+
+	assert.Empty(t, input.GetAsset())
+	assert.Zero(t, input.GetValue())
+	assert.Empty(t, input.GetSourceAccounts())
+	assert.Empty(t, input.GetDestinationAccounts())
+	assert.Nil(t, input.GetMetadata())
 }
 
 // =============================================================================
@@ -1947,9 +2063,9 @@ func TestFromTransactionMap(t *testing.T) {
 					"remaining": "rem-acc",
 					"from": []any{
 						map[string]any{
-							"account":     "source-acc",
-							"remaining":   "rem-1",
-							"description": "Source description",
+							"accountAlias": "source-acc",
+							"remaining":    "rem-1",
+							"description":  "Source description",
 							"amount": map[string]any{
 								"asset": "USD",
 								"value": "100.50",
@@ -1971,7 +2087,7 @@ func TestFromTransactionMap(t *testing.T) {
 					"remaining": "dist-rem",
 					"to": []any{
 						map[string]any{
-							"account": "dest-acc",
+							"accountAlias": "dest-acc",
 						},
 					},
 				},
@@ -2026,7 +2142,7 @@ func TestFromTransactionMap(t *testing.T) {
 
 		result := FromTransactionMap(data)
 		require.NotNil(t, result.Send)
-		assert.Equal(t, "100.50", result.Send.Value)
+		assert.Equal(t, "100.5", result.Send.Value)
 	})
 }
 
@@ -2070,15 +2186,16 @@ func TestTransaction_ToTransactionMap(t *testing.T) {
 		fromList, ok := source["from"].([]map[string]any)
 		require.True(t, ok)
 		assert.Len(t, fromList, 1)
-		assert.Equal(t, "acc-1", fromList[0]["account"])
-		assert.Equal(t, "alias-1", fromList[0]["description"])
+		assert.Equal(t, "alias-1", fromList[0]["accountAlias"])
+		assert.NotContains(t, fromList[0], "account")
 
 		distribute, ok := send["distribute"].(map[string]any)
 		require.True(t, ok)
 		toList, ok := distribute["to"].([]map[string]any)
 		require.True(t, ok)
 		assert.Len(t, toList, 1)
-		assert.Equal(t, "acc-2", toList[0]["account"])
+		assert.Equal(t, "alias-2", toList[0]["accountAlias"])
+		assert.NotContains(t, toList[0], "account")
 	})
 }
 
@@ -2163,7 +2280,8 @@ func TestFromToToMap(t *testing.T) {
 		}
 		result := fromToToMap(from)
 
-		assert.Equal(t, "acc-123", result["account"])
+		assert.Equal(t, "acc-123", result["accountAlias"])
+		assert.NotContains(t, result, "account")
 	})
 
 	t.Run("with amount", func(t *testing.T) {
@@ -2171,7 +2289,7 @@ func TestFromToToMap(t *testing.T) {
 			Account: "acc-123",
 			Amount: &DSLAmount{
 				Asset: "USD",
-				Value: "100",
+				Value: 100,
 			},
 		}
 		result := fromToToMap(from)
@@ -2204,7 +2322,7 @@ func TestFromToToMap(t *testing.T) {
 			Rate: &Rate{
 				From:       "USD",
 				To:         "EUR",
-				Value:      "0.85",
+				Value:      0.85,
 				ExternalID: "rate-1",
 			},
 		}
@@ -2241,10 +2359,7 @@ func TestFromToToMap(t *testing.T) {
 
 func TestEdgeCases(t *testing.T) {
 	t.Run("empty strings in CreateTransactionInput", func(t *testing.T) {
-		input := &CreateTransactionInput{
-			AssetCode: "",
-			Amount:    "",
-		}
+		input := &CreateTransactionInput{}
 		err := input.Validate()
 		require.Error(t, err)
 	})
@@ -2271,7 +2386,7 @@ func TestEdgeCases(t *testing.T) {
 		}
 		input := NewUpdateTransactionInput().WithMetadata(metadata)
 		err := input.Validate()
-		require.NoError(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("metadata with various types", func(t *testing.T) {
@@ -2281,8 +2396,6 @@ func TestEdgeCases(t *testing.T) {
 			"float":  3.14,
 			"bool":   true,
 			"null":   nil,
-			"array":  []any{"a", "b"},
-			"nested": map[string]any{"key": "value"},
 		}
 		input := NewUpdateTransactionInput().WithMetadata(metadata)
 		err := input.Validate()
@@ -2310,7 +2423,7 @@ func TestEdgeCases(t *testing.T) {
 		overLength := strings.Repeat("a", 65)
 		input2 := NewUpdateTransactionInput().WithExternalID(overLength)
 		err2 := input2.Validate()
-		require.Error(t, err2)
+		require.NoError(t, err2)
 	})
 }
 
@@ -2318,7 +2431,7 @@ func TestEdgeCases(t *testing.T) {
 // Operation Validation Tests (within CreateTransactionInput)
 // =============================================================================
 
-func TestCreateTransactionInput_OperationsValidation(t *testing.T) {
+func TestCreateTransactionInput_SendValidation(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   *CreateTransactionInput
@@ -2326,28 +2439,30 @@ func TestCreateTransactionInput_OperationsValidation(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid operations",
+			name: "valid send",
 			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "100",
-				Operations: []CreateOperationInput{
-					{AccountID: "acc-1", Type: "DEBIT", Amount: "100", AssetCode: "USD"},
-					{AccountID: "acc-2", Type: "CREDIT", Amount: "100", AssetCode: "USD"},
-				},
+				Send: newValidSendInput(100),
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid operation - missing account",
+			name: "invalid send - missing account",
 			input: &CreateTransactionInput{
-				AssetCode: "USD",
-				Amount:    "100",
-				Operations: []CreateOperationInput{
-					{AccountID: "", Type: "DEBIT", Amount: "100", AssetCode: "USD"},
+				Send: &SendInput{
+					Asset: "USD",
+					Value: 100,
+					Source: &SourceInput{From: []FromToInput{{
+						Account: "",
+						Amount:  AmountInput{Asset: "USD", Value: 100},
+					}}},
+					Distribute: &DistributeInput{To: []FromToInput{{
+						Account: "dest",
+						Amount:  AmountInput{Asset: "USD", Value: 100},
+					}}},
 				},
 			},
 			wantErr: true,
-			errMsg:  "invalid operation at index 0",
+			errMsg:  "invalid send",
 		},
 	}
 

--- a/models/transaction_test.go
+++ b/models/transaction_test.go
@@ -300,6 +300,39 @@ func TestCreateTransactionInput_ToLibTransaction(t *testing.T) {
 		assert.False(t, hasMetadata)
 		assert.False(t, hasSend)
 	})
+
+	t.Run("normalizes legacy operation amount wrappers", func(t *testing.T) {
+		value := decimal.NewFromInt(50)
+		input := &CreateTransactionInput{
+			AssetCode: "USD",
+			Amount:    "50",
+			Operations: []CreateOperationInput{
+				{Type: "debit", AccountID: "source", Amount: Amount{Value: &value}, AssetCode: "USD"},
+				{Type: "credit", AccountID: "dest", Amount: &Amount{Value: &value}, AssetCode: "USD"},
+			},
+		}
+
+		result := input.ToLibTransaction()
+		send, ok := result["send"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "50", send["value"])
+
+		source, ok := send["source"].(map[string]any)
+		require.True(t, ok)
+		from, ok := source["from"].([]map[string]any)
+		require.True(t, ok)
+		sourceAmount, ok := from[0]["amount"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "50", sourceAmount["value"])
+
+		distribute, ok := send["distribute"].(map[string]any)
+		require.True(t, ok)
+		to, ok := distribute["to"].([]map[string]any)
+		require.True(t, ok)
+		destinationAmount, ok := to[0]["amount"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "50", destinationAmount["value"])
+	})
 }
 
 // =============================================================================

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,6 +33,9 @@ const (
 
 	// ServiceTransaction represents the Transaction service.
 	ServiceTransaction ServiceType = "transaction"
+
+	// ServiceCRM represents the CRM service.
+	ServiceCRM ServiceType = "crm"
 )
 
 // Environment represents a deployment environment for the Midaz API.
@@ -55,13 +59,11 @@ const (
 	DefaultTimeout = 60
 
 	// Default URLs for each environment
-	DefaultLocalBaseURL         = "http://localhost"
-	DefaultDevelopmentBaseURL   = "https://api.dev.midaz.io"
-	DefaultProductionBaseURL    = "https://api.midaz.io"
-	DefaultOnboardingPort       = "3000"
-	DefaultTransactionPort      = "3001"
-	DefaultLocalOnboardingPath  = ""
-	DefaultLocalTransactionPath = ""
+	DefaultLocalLedgerBaseURL       = "http://localhost:3002"
+	DefaultLocalCRMBaseURL          = "http://localhost:4003"
+	DefaultDevelopmentLedgerBaseURL = "https://api.dev.midaz.io"
+	DefaultProductionLedgerBaseURL  = "https://api.midaz.io"
+	DefaultLedgerAPIVersionPath     = "/v1"
 
 	// Default retry configuration
 	DefaultMaxRetries   = 3
@@ -119,8 +121,10 @@ type Config struct {
 	EnableIdempotency bool
 
 	// TenantID is the default tenant identifier sent as X-Tenant-ID on every request.
-	// It can be set via the MIDAZ_TENANT_ID environment variable or the WithTenantID option.
-	// Per-request overrides via entities.WithTenantID(ctx, id) take precedence.
+	// It can be set via the WithTenantID option.
+	// Per-request overrides via entities.WithTenantID(ctx, id) take precedence. This
+	// is an optional compatibility header and may be ignored by deployments that derive
+	// tenant scope from authenticated claims.
 	TenantID string
 
 	// tenantIDSet tracks whether WithTenantID was explicitly called, allowing
@@ -199,6 +203,23 @@ func WithTransactionURL(transactionURL string) Option {
 	}
 }
 
+// WithCRMURL sets the base URL for the CRM API.
+func WithCRMURL(crmURL string) Option {
+	return func(c *Config) error {
+		if err := parseURL(crmURL); err != nil {
+			return fmt.Errorf("invalid crm URL: %w", err)
+		}
+
+		if c.ServiceURLs == nil {
+			c.ServiceURLs = make(map[ServiceType]string)
+		}
+
+		c.ServiceURLs[ServiceCRM] = crmURL
+
+		return nil
+	}
+}
+
 // WithBaseURL sets a common base URL that will be used for all services.
 // Service-specific ports and paths will be automatically added.
 // This is useful for connecting to custom deployments.
@@ -224,14 +245,19 @@ func WithBaseURL(baseURL string) Option {
 			c.ServiceURLs = make(map[ServiceType]string)
 		}
 
-		// Set the URLs for each service
-		if c.Environment == EnvironmentLocal {
-			c.ServiceURLs[ServiceOnboarding] = fmt.Sprintf("%s:%s%s", baseURL, DefaultOnboardingPort, DefaultLocalOnboardingPath)
-			c.ServiceURLs[ServiceTransaction] = fmt.Sprintf("%s:%s%s", baseURL, DefaultTransactionPort, DefaultLocalTransactionPath)
-		} else {
-			c.ServiceURLs[ServiceOnboarding] = fmt.Sprintf("%s/onboarding", baseURL)
-			c.ServiceURLs[ServiceTransaction] = fmt.Sprintf("%s/transaction", baseURL)
+		ledgerURL, err := buildLedgerServiceURL(baseURL)
+		if err != nil {
+			return fmt.Errorf("invalid ledger base URL: %w", err)
 		}
+
+		crmURL, err := buildCRMServiceURL(baseURL)
+		if err != nil {
+			return fmt.Errorf("invalid crm base URL: %w", err)
+		}
+
+		c.ServiceURLs[ServiceOnboarding] = ledgerURL
+		c.ServiceURLs[ServiceTransaction] = ledgerURL
+		c.ServiceURLs[ServiceCRM] = crmURL
 
 		return nil
 	}
@@ -390,7 +416,8 @@ func WithIdempotency(enable bool) Option {
 // WithTenantID sets the default tenant ID for all API requests.
 // The tenant ID is sent as the X-Tenant-ID header on every request.
 // Per-request overrides via entities.WithTenantID(ctx, tenantID) take precedence
-// over this configuration-level default.
+// over this configuration-level default. This header is best-effort compatibility
+// metadata rather than the sole tenant source of truth for the reference Midaz path.
 //
 // Parameters:
 //   - tenantID: The tenant identifier to use
@@ -433,12 +460,12 @@ func WithAccessManager(accessManager auth.AccessManager) Option {
 // - MIDAZ_USER_AGENT: The user agent string to use for HTTP requests
 // - MIDAZ_ONBOARDING_URL: The URL for the Onboarding API
 // - MIDAZ_TRANSACTION_URL: The URL for the Transaction API
+// - MIDAZ_CRM_URL: The URL for the CRM API
 // - MIDAZ_BASE_URL: The base URL for all services
 // - MIDAZ_TIMEOUT: The timeout in seconds for HTTP requests
 // - MIDAZ_DEBUG: Enable debug mode (true/false)
 // - MIDAZ_MAX_RETRIES: Maximum number of retries
 // - MIDAZ_IDEMPOTENCY: Enable idempotency (true/false)
-// - MIDAZ_TENANT_ID: Default tenant ID sent as X-Tenant-ID header
 //
 // Returns:
 //   - Option: A function that sets configuration from environment variables
@@ -529,6 +556,12 @@ func configureSpecificURLs(c *Config) error {
 		}
 	}
 
+	if crmURL := os.Getenv("MIDAZ_CRM_URL"); crmURL != "" {
+		if err := WithCRMURL(crmURL)(c); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -583,12 +616,6 @@ func configureOptionalSettings(c *Config) {
 
 	if idempotency := os.Getenv("MIDAZ_IDEMPOTENCY"); idempotency != "" {
 		c.EnableIdempotency = idempotency == boolTrue
-	}
-
-	if !c.tenantIDSet {
-		if tenantID := strings.TrimSpace(os.Getenv("MIDAZ_TENANT_ID")); tenantID != "" {
-			c.TenantID = tenantID
-		}
 	}
 }
 
@@ -659,17 +686,37 @@ func setDefaultServiceURLs(config *Config) error {
 	// Set default URLs based on environment
 	switch config.Environment {
 	case EnvironmentLocal:
-		baseURL := DefaultLocalBaseURL
-		config.ServiceURLs[ServiceOnboarding] = fmt.Sprintf("%s:%s%s", baseURL, DefaultOnboardingPort, DefaultLocalOnboardingPath)
-		config.ServiceURLs[ServiceTransaction] = fmt.Sprintf("%s:%s%s", baseURL, DefaultTransactionPort, DefaultLocalTransactionPath)
+		ledgerURL, err := buildLedgerServiceURL(DefaultLocalLedgerBaseURL)
+		if err != nil {
+			return err
+		}
+
+		crmURL, err := buildLedgerServiceURL(DefaultLocalCRMBaseURL)
+		if err != nil {
+			return err
+		}
+
+		config.ServiceURLs[ServiceOnboarding] = ledgerURL
+		config.ServiceURLs[ServiceTransaction] = ledgerURL
+		config.ServiceURLs[ServiceCRM] = crmURL
 	case EnvironmentDevelopment:
-		baseURL := DefaultDevelopmentBaseURL
-		config.ServiceURLs[ServiceOnboarding] = fmt.Sprintf("%s/onboarding", baseURL)
-		config.ServiceURLs[ServiceTransaction] = fmt.Sprintf("%s/transaction", baseURL)
+		ledgerURL, err := buildLedgerServiceURL(DefaultDevelopmentLedgerBaseURL)
+		if err != nil {
+			return err
+		}
+
+		config.ServiceURLs[ServiceOnboarding] = ledgerURL
+		config.ServiceURLs[ServiceTransaction] = ledgerURL
+		config.ServiceURLs[ServiceCRM] = ledgerURL
 	case EnvironmentProduction:
-		baseURL := DefaultProductionBaseURL
-		config.ServiceURLs[ServiceOnboarding] = fmt.Sprintf("%s/onboarding", baseURL)
-		config.ServiceURLs[ServiceTransaction] = fmt.Sprintf("%s/transaction", baseURL)
+		ledgerURL, err := buildLedgerServiceURL(DefaultProductionLedgerBaseURL)
+		if err != nil {
+			return err
+		}
+
+		config.ServiceURLs[ServiceOnboarding] = ledgerURL
+		config.ServiceURLs[ServiceTransaction] = ledgerURL
+		config.ServiceURLs[ServiceCRM] = ledgerURL
 	default:
 		return fmt.Errorf("unknown environment: %s", config.Environment)
 	}
@@ -743,19 +790,95 @@ func parseURL(rawURL string) error {
 		return errors.New("URL must include scheme and host")
 	}
 
-	// Warn about insecure HTTP connections (except for localhost/development)
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return errors.New("URL scheme must be http or https")
+	}
+
+	if parsedURL.User != nil {
+		return errors.New("URL must not include user information")
+	}
+
 	if parsedURL.Scheme == "http" && !isLocalhost(parsedURL.Host) {
-		fmt.Fprintf(os.Stderr, "[Midaz SDK Warning] Using insecure HTTP connection to %s. Consider using HTTPS for production.\n", parsedURL.Host)
+		return fmt.Errorf("insecure HTTP is only allowed for localhost targets: %s", parsedURL.Host)
 	}
 
 	return nil
 }
 
+func buildLedgerServiceURL(baseURL string) (string, error) {
+	parsedURL, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", errors.New("URL must include scheme and host")
+	}
+
+	if isLocalhost(parsedURL.Host) && parsedURL.Port() == "" {
+		parsedURL.Host = withPort(parsedURL.Hostname(), "3002")
+	}
+
+	return ensureAPIVersionPath(parsedURL), nil
+}
+
+func buildCRMServiceURL(baseURL string) (string, error) {
+	parsedURL, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return "", err
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", errors.New("URL must include scheme and host")
+	}
+
+	if isLocalhost(parsedURL.Host) && parsedURL.Port() == "" {
+		parsedURL.Host = withPort(parsedURL.Hostname(), "4003")
+	}
+
+	return ensureAPIVersionPath(parsedURL), nil
+}
+
+func ensureAPIVersionPath(parsedURL *url.URL) string {
+	cleanPath := strings.TrimSuffix(parsedURL.Path, "/")
+	if cleanPath == "" {
+		parsedURL.Path = DefaultLedgerAPIVersionPath
+		return parsedURL.String()
+	}
+
+	if cleanPath == DefaultLedgerAPIVersionPath {
+		parsedURL.Path = cleanPath
+		return parsedURL.String()
+	}
+
+	parsedURL.Path = cleanPath + DefaultLedgerAPIVersionPath
+
+	return parsedURL.String()
+}
+
+func withPort(hostname, port string) string {
+	if strings.Contains(hostname, ":") {
+		return "[" + hostname + "]:" + port
+	}
+
+	return hostname + ":" + port
+}
+
 // isLocalhost checks if the host is a localhost address (for development use).
 func isLocalhost(host string) bool {
-	// Remove port if present
-	hostname := strings.Split(host, ":")[0]
-	return hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1"
+	hostname := host
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		hostname = splitHost
+	}
+
+	hostname = strings.Trim(hostname, "[]")
+	if hostname == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(hostname)
+
+	return ip != nil && ip.IsLoopback()
 }
 
 // DefaultConfig creates a new Config with default values.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -53,13 +53,10 @@ func TestDefaultConstants(t *testing.T) {
 		expected any
 	}{
 		{"DefaultTimeout", DefaultTimeout, 60},
-		{"DefaultLocalBaseURL", DefaultLocalBaseURL, "http://localhost"},
-		{"DefaultDevelopmentBaseURL", DefaultDevelopmentBaseURL, "https://api.dev.midaz.io"},
-		{"DefaultProductionBaseURL", DefaultProductionBaseURL, "https://api.midaz.io"},
-		{"DefaultOnboardingPort", DefaultOnboardingPort, "3000"},
-		{"DefaultTransactionPort", DefaultTransactionPort, "3001"},
-		{"DefaultLocalOnboardingPath", DefaultLocalOnboardingPath, ""},
-		{"DefaultLocalTransactionPath", DefaultLocalTransactionPath, ""},
+		{"DefaultLocalLedgerBaseURL", DefaultLocalLedgerBaseURL, "http://localhost:3002"},
+		{"DefaultDevelopmentLedgerBaseURL", DefaultDevelopmentLedgerBaseURL, "https://api.dev.midaz.io"},
+		{"DefaultProductionLedgerBaseURL", DefaultProductionLedgerBaseURL, "https://api.midaz.io"},
+		{"DefaultLedgerAPIVersionPath", DefaultLedgerAPIVersionPath, "/v1"},
 		{"DefaultMaxRetries", DefaultMaxRetries, 3},
 		{"DefaultMinRetryWait", DefaultMinRetryWait, 1 * time.Second},
 		{"DefaultRetryWaitMax", DefaultRetryWaitMax, 30 * time.Second},
@@ -77,6 +74,27 @@ func TestDefaultConstants(t *testing.T) {
 func TestServiceTypeConstants(t *testing.T) {
 	assert.Equal(t, ServiceOnboarding, ServiceType("onboarding"))
 	assert.Equal(t, ServiceTransaction, ServiceType("transaction"))
+	assert.Equal(t, ServiceCRM, ServiceType("crm"))
+}
+
+func TestWithCRMURL(t *testing.T) {
+	cfg := DefaultConfig()
+	err := WithCRMURL("https://crm.example.com/v1")(cfg)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://crm.example.com/v1", cfg.ServiceURLs[ServiceCRM])
+}
+
+func TestConfigureURLsReadsCRMURL(t *testing.T) {
+	restore := saveEnv([]string{"MIDAZ_CRM_URL"})
+	defer restore()
+
+	require.NoError(t, os.Setenv("MIDAZ_CRM_URL", "https://crm.example.com/v1"))
+
+	cfg := DefaultConfig()
+	require.NoError(t, configureURLs(cfg))
+
+	assert.Equal(t, "https://crm.example.com/v1", cfg.ServiceURLs[ServiceCRM])
 }
 
 func TestEnvironmentConstants(t *testing.T) {
@@ -99,8 +117,8 @@ func TestNewConfig_Defaults(t *testing.T) {
 	assert.True(t, config.EnableIdempotency)
 	assert.False(t, config.Debug)
 	assert.NotNil(t, config.HTTPClient)
-	assert.Equal(t, "http://localhost:3000", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "http://localhost:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestNewConfig_WithAllOptions(t *testing.T) {
@@ -190,20 +208,20 @@ func TestWithEnvironment_WithBaseURL(t *testing.T) {
 		{
 			name:                   "development with base URL",
 			env:                    EnvironmentDevelopment,
-			expectedOnboardingURL:  "https://api.custom.io/onboarding",
-			expectedTransactionURL: "https://api.custom.io/transaction",
+			expectedOnboardingURL:  "https://api.custom.io/v1",
+			expectedTransactionURL: "https://api.custom.io/v1",
 		},
 		{
 			name:                   "production with base URL",
 			env:                    EnvironmentProduction,
-			expectedOnboardingURL:  "https://api.custom.io/onboarding",
-			expectedTransactionURL: "https://api.custom.io/transaction",
+			expectedOnboardingURL:  "https://api.custom.io/v1",
+			expectedTransactionURL: "https://api.custom.io/v1",
 		},
 		{
 			name:                   "local with base URL",
 			env:                    EnvironmentLocal,
-			expectedOnboardingURL:  "https://api.custom.io:3000",
-			expectedTransactionURL: "https://api.custom.io:3001",
+			expectedOnboardingURL:  "https://api.custom.io/v1",
+			expectedTransactionURL: "https://api.custom.io/v1",
 		},
 	}
 
@@ -322,8 +340,8 @@ func TestWithBaseURL_LocalEnvironment(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, "https://custom.example.com:3000", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "https://custom.example.com:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "https://custom.example.com/v1", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "https://custom.example.com/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestWithBaseURL_NonLocalEnvironment(t *testing.T) {
@@ -338,8 +356,8 @@ func TestWithBaseURL_NonLocalEnvironment(t *testing.T) {
 			env:     EnvironmentDevelopment,
 			baseURL: "https://custom.example.com",
 			expected: map[ServiceType]string{
-				ServiceOnboarding:  "https://custom.example.com/onboarding",
-				ServiceTransaction: "https://custom.example.com/transaction",
+				ServiceOnboarding:  "https://custom.example.com/v1",
+				ServiceTransaction: "https://custom.example.com/v1",
 			},
 		},
 		{
@@ -347,8 +365,8 @@ func TestWithBaseURL_NonLocalEnvironment(t *testing.T) {
 			env:     EnvironmentProduction,
 			baseURL: "https://api.prod.example.com",
 			expected: map[ServiceType]string{
-				ServiceOnboarding:  "https://api.prod.example.com/onboarding",
-				ServiceTransaction: "https://api.prod.example.com/transaction",
+				ServiceOnboarding:  "https://api.prod.example.com/v1",
+				ServiceTransaction: "https://api.prod.example.com/v1",
 			},
 		},
 	}
@@ -374,7 +392,7 @@ func TestWithBaseURL_TrailingSlash(t *testing.T) {
 		WithAccessManager(auth.AccessManager{Enabled: false}),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "https://api.example.com/onboarding", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "https://api.example.com/v1", config.ServiceURLs[ServiceOnboarding])
 }
 
 func TestWithBaseURL_Invalid(t *testing.T) {
@@ -916,7 +934,7 @@ func TestFromEnvironment_BaseURLOverriddenBySpecific(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://specific.example.com/onboarding", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "https://base.example.com:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "https://base.example.com/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestFromEnvironment_PluginAuthDisabled(t *testing.T) {
@@ -962,8 +980,8 @@ func TestDefaultConfig(t *testing.T) {
 	assert.True(t, config.EnableIdempotency)
 	assert.NotNil(t, config.HTTPClient)
 	assert.NotNil(t, config.ServiceURLs)
-	assert.Equal(t, "http://localhost:3000", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "http://localhost:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestNewLocalConfig(t *testing.T) {
@@ -972,8 +990,8 @@ func TestNewLocalConfig(t *testing.T) {
 
 	assert.Equal(t, EnvironmentLocal, config.Environment)
 	assert.False(t, config.AccessManager.Enabled)
-	assert.Equal(t, "http://localhost:3000", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "http://localhost:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "http://localhost:3002/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestNewLocalConfig_WithEnvVars(t *testing.T) {
@@ -1125,7 +1143,7 @@ func TestOptionOrderMatters(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://specific.example.com/onboarding", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "https://custom.example.com:3001", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "https://custom.example.com/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestIsLocalhost(t *testing.T) {
@@ -1252,18 +1270,18 @@ func TestSetDefaultServiceURLs_AllEnvironments(t *testing.T) {
 	}{
 		{
 			env:                    EnvironmentLocal,
-			expectedOnboardingURL:  "http://localhost:3000",
-			expectedTransactionURL: "http://localhost:3001",
+			expectedOnboardingURL:  "http://localhost:3002/v1",
+			expectedTransactionURL: "http://localhost:3002/v1",
 		},
 		{
 			env:                    EnvironmentDevelopment,
-			expectedOnboardingURL:  "https://api.dev.midaz.io/onboarding",
-			expectedTransactionURL: "https://api.dev.midaz.io/transaction",
+			expectedOnboardingURL:  "https://api.dev.midaz.io/v1",
+			expectedTransactionURL: "https://api.dev.midaz.io/v1",
 		},
 		{
 			env:                    EnvironmentProduction,
-			expectedOnboardingURL:  "https://api.midaz.io/onboarding",
-			expectedTransactionURL: "https://api.midaz.io/transaction",
+			expectedOnboardingURL:  "https://api.midaz.io/v1",
+			expectedTransactionURL: "https://api.midaz.io/v1",
 		},
 	}
 
@@ -1488,6 +1506,20 @@ func TestValidateConfig_Valid(t *testing.T) {
 		ServiceURLs: map[ServiceType]string{
 			ServiceOnboarding:  "https://api.example.com/onboarding",
 			ServiceTransaction: "https://api.example.com/transaction",
+			ServiceCRM:         "https://api.example.com/crm",
+		},
+		AccessManager: auth.AccessManager{Enabled: false},
+	}
+
+	err := validateConfig(config)
+	require.NoError(t, err)
+}
+
+func TestValidateConfig_CRMURLIsOptional(t *testing.T) {
+	config := &Config{
+		ServiceURLs: map[ServiceType]string{
+			ServiceOnboarding:  "https://api.example.com/onboarding",
+			ServiceTransaction: "https://api.example.com/transaction",
 		},
 		AccessManager: auth.AccessManager{Enabled: false},
 	}
@@ -1516,8 +1548,8 @@ func TestWithBaseURL_InitializesServiceURLsMap(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotNil(t, config.ServiceURLs)
-	assert.Equal(t, "https://api.example.com/onboarding", config.ServiceURLs[ServiceOnboarding])
-	assert.Equal(t, "https://api.example.com/transaction", config.ServiceURLs[ServiceTransaction])
+	assert.Equal(t, "https://api.example.com/v1", config.ServiceURLs[ServiceOnboarding])
+	assert.Equal(t, "https://api.example.com/v1", config.ServiceURLs[ServiceTransaction])
 }
 
 func TestWithOnboardingURL_InitializesServiceURLsMap(t *testing.T) {
@@ -1579,16 +1611,16 @@ func TestConfigWithTenantID(t *testing.T) {
 	}
 }
 
-func TestConfigTenantIDFromEnv(t *testing.T) {
+func TestConfigTenantIDIgnoresEnv(t *testing.T) {
 	tests := []struct {
 		name     string
 		envValue string
 		expected string
 	}{
 		{
-			name:     "picks up MIDAZ_TENANT_ID from environment",
+			name:     "ignores MIDAZ_TENANT_ID from environment",
 			envValue: "env-tenant-456",
-			expected: "env-tenant-456",
+			expected: "",
 		},
 		{
 			name:     "empty env var leaves TenantID unset",
@@ -1620,8 +1652,8 @@ func TestConfigTenantIDFromEnv(t *testing.T) {
 	}
 }
 
-func TestConfigTenantIDOptionOverridesEnv(t *testing.T) {
-	// Set env var, then override with explicit option
+func TestConfigTenantIDOptionWinsOverEnv(t *testing.T) {
+	// Environment defaults are intentionally ignored; explicit options remain supported.
 	t.Setenv("MIDAZ_TENANT_ID", "env-tenant")
 
 	cfg, err := NewConfig(
@@ -1631,7 +1663,6 @@ func TestConfigTenantIDOptionOverridesEnv(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// The explicit WithTenantID option should win since it's applied after FromEnvironment
 	assert.Equal(t, "option-tenant", cfg.TenantID)
 }
 

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -664,7 +664,6 @@ func TransactionWithOptions(tx *models.Transaction, opts ...TransactionOption) (
 	// Determine transaction type based on operations
 	txType := determineTransactionType(tx)
 
-	// Use the amount as-is since it's already formatted as a decimal string
 	amountStr := tx.Amount
 
 	// Build summary with optional ID prefix

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -72,17 +72,17 @@ func TestFormatTransaction(t *testing.T) {
 	// Test minimal transaction
 	tx := &models.Transaction{
 		ID:        "tx-123",
-		Amount:    "100.00",
+		Amount:    "100",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "COMPLETED"},
 	}
 	summary = format.FormatTransaction(tx)
-	assert.Equal(t, "Transaction: 100.00 USD (Completed)", summary)
+	assert.Equal(t, "Transaction: 100 USD (Completed)", summary)
 
 	// Test deposit transaction
 	depositTx := &models.Transaction{
 		ID:        "tx-deposit",
-		Amount:    "250.00",
+		Amount:    "250",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "COMPLETED"},
 		Operations: []models.Operation{
@@ -99,12 +99,12 @@ func TestFormatTransaction(t *testing.T) {
 		},
 	}
 	summary = format.FormatTransaction(depositTx)
-	assert.Equal(t, "Deposit: 250.00 USD from customer-account (Completed)", summary)
+	assert.Equal(t, "Deposit: 250 USD from customer-account (Completed)", summary)
 
 	// Test withdrawal transaction
 	withdrawalTx := &models.Transaction{
 		ID:        "tx-withdrawal",
-		Amount:    "50.00",
+		Amount:    "50",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "PENDING"},
 		Operations: []models.Operation{
@@ -121,12 +121,12 @@ func TestFormatTransaction(t *testing.T) {
 		},
 	}
 	summary = format.FormatTransaction(withdrawalTx)
-	assert.Equal(t, "Withdrawal: 50.00 USD from savings-account (Pending)", summary)
+	assert.Equal(t, "Withdrawal: 50 USD from savings-account (Pending)", summary)
 
 	// Test transfer transaction
 	transferTx := &models.Transaction{
 		ID:        "tx-transfer",
-		Amount:    "15.00",
+		Amount:    "15",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "COMPLETED"},
 		Operations: []models.Operation{
@@ -143,12 +143,12 @@ func TestFormatTransaction(t *testing.T) {
 		},
 	}
 	summary = format.FormatTransaction(transferTx)
-	assert.Equal(t, "Transfer: 15.00 USD from checking to savings (Completed)", summary)
+	assert.Equal(t, "Transfer: 15 USD from checking to savings (Completed)", summary)
 
 	// Test transaction with multiple sources/destinations
 	multiTx := &models.Transaction{
 		ID:        "tx-multi",
-		Amount:    "20.00",
+		Amount:    "20",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "COMPLETED"},
 		Operations: []models.Operation{
@@ -175,7 +175,7 @@ func TestFormatTransaction(t *testing.T) {
 		},
 	}
 	summary = format.FormatTransaction(multiTx)
-	assert.Equal(t, "Transfer: 20.00 USD from multiple accounts (2) to multiple accounts (2) (Completed)", summary)
+	assert.Equal(t, "Transfer: 20 USD from multiple accounts (2) to multiple accounts (2) (Completed)", summary)
 }
 
 func TestFormatDate(t *testing.T) {
@@ -409,7 +409,7 @@ func TestFormatAmountWithOptions(t *testing.T) {
 func TestFormatTransactionWithOptions(t *testing.T) {
 	tx := &models.Transaction{
 		ID:        "tx-123",
-		Amount:    "100.00",
+		Amount:    "100",
 		AssetCode: "USD",
 		Status:    models.Status{Code: "COMPLETED"},
 		CreatedAt: time.Date(2023, 5, 15, 10, 30, 45, 0, time.UTC),
@@ -430,17 +430,17 @@ func TestFormatTransactionWithOptions(t *testing.T) {
 	// Test with default options
 	result, err := format.FormatTransactionWithOptions(tx)
 	require.NoError(t, err)
-	assert.Equal(t, "Transfer: 100.00 USD from checking to savings (Completed)", result)
+	assert.Equal(t, "Transfer: 100 USD from checking to savings (Completed)", result)
 
 	// Test with include ID
 	result, err = format.FormatTransactionWithOptions(tx, format.WithTransactionID(true))
 	require.NoError(t, err)
-	assert.Equal(t, "tx-123 - Transfer: 100.00 USD from checking to savings (Completed)", result)
+	assert.Equal(t, "tx-123 - Transfer: 100 USD from checking to savings (Completed)", result)
 
 	// Test with include timestamp
 	result, err = format.FormatTransactionWithOptions(tx, format.WithTransactionTimestamp(true))
 	require.NoError(t, err)
-	assert.Equal(t, "2023-05-15 10:30:45 - Transfer: 100.00 USD from checking to savings (Completed)", result)
+	assert.Equal(t, "2023-05-15 10:30:45 - Transfer: 100 USD from checking to savings (Completed)", result)
 
 	// Test with custom status mapping
 	result, err = format.FormatTransactionWithOptions(tx,
@@ -449,7 +449,7 @@ func TestFormatTransactionWithOptions(t *testing.T) {
 			"PENDING":   "In Progress",
 		}))
 	require.NoError(t, err)
-	assert.Equal(t, "Transfer: 100.00 USD from checking to savings (Success)", result)
+	assert.Equal(t, "Transfer: 100 USD from checking to savings (Success)", result)
 
 	// Test with error
 	_, err = format.FormatTransactionWithOptions(tx,

--- a/pkg/generator/ledger_generator_test.go
+++ b/pkg/generator/ledger_generator_test.go
@@ -47,6 +47,14 @@ func (*mockLedgersService) DeleteLedger(_ context.Context, _, _ string) error {
 	return nil
 }
 
+func (*mockLedgersService) GetLedgerSettings(_ context.Context, _, _ string) (*models.LedgerSettings, error) {
+	return nil, errors.New("mock: GetLedgerSettings not implemented")
+}
+
+func (*mockLedgersService) UpdateLedgerSettings(_ context.Context, _, _ string, _ *models.UpdateLedgerSettingsInput) (*models.LedgerSettings, error) {
+	return nil, errors.New("mock: UpdateLedgerSettings not implemented")
+}
+
 func (*mockLedgersService) GetLedgersMetricsCount(_ context.Context, _ string) (*models.MetricsCount, error) {
 	return nil, errors.New("mock: GetLedgersMetricsCount not implemented")
 }

--- a/pkg/generator/org_generator.go
+++ b/pkg/generator/org_generator.go
@@ -43,7 +43,7 @@ func (g *orgGenerator) Generate(ctx context.Context, template data.OrgTemplate) 
 		return nil, errors.New("entity organizations service not initialized")
 	}
 
-	input := models.NewCreateOrganizationInput(template.LegalName).
+	input := models.NewCreateOrganizationInput(template.LegalName, template.TaxID).
 		WithDoingBusinessAs(template.TradeName).
 		WithLegalDocument(template.TaxID).
 		WithStatus(template.Status).

--- a/pkg/generator/transaction_generator_test.go
+++ b/pkg/generator/transaction_generator_test.go
@@ -46,6 +46,10 @@ func (*mockTransactionsService) ListTransactions(_ context.Context, _, _ string,
 	return nil, errors.New("mock: ListTransactions not implemented")
 }
 
+func (*mockTransactionsService) GetTransactionsMetricsCount(_ context.Context, _, _ string, _ *models.ListOptions) (*models.MetricsCount, error) {
+	return nil, errors.New("mock: GetTransactionsMetricsCount not implemented")
+}
+
 func (*mockTransactionsService) UpdateTransaction(_ context.Context, _, _, _ string, _ any) (*models.Transaction, error) {
 	return nil, errors.New("mock: UpdateTransaction not implemented")
 }
@@ -68,6 +72,10 @@ func (m *mockTransactionsService) RevertTransaction(ctx context.Context, orgID, 
 
 func (*mockTransactionsService) CancelTransaction(_ context.Context, _, _, _ string) error {
 	return nil
+}
+
+func (*mockTransactionsService) CancelTransactionWithResponse(_ context.Context, _, _, _ string) (*models.Transaction, error) {
+	return &models.Transaction{}, nil
 }
 
 func (*mockTransactionsService) CreateTransactionWithDSL(_ context.Context, _, _ string, _ *models.TransactionDSLInput) (*models.Transaction, error) {

--- a/pkg/generator/transaction_routes_generator_test.go
+++ b/pkg/generator/transaction_routes_generator_test.go
@@ -100,7 +100,7 @@ func TestTransactionRouteGenerator_Generate_Success(t *testing.T) {
 	input := models.NewCreateTransactionRouteInput(
 		"Payment Flow",
 		"Customer pays merchant",
-		[]string{"op-route-1", "op-route-2"},
+		[]string{uuid.NewString(), uuid.NewString()},
 	).WithMetadata(map[string]any{"pattern": "payment"})
 
 	result, err := gen.Generate(context.Background(), "org-123", "ledger-123", input)
@@ -124,7 +124,7 @@ func TestTransactionRouteGenerator_Generate_Error(t *testing.T) {
 	input := models.NewCreateTransactionRouteInput(
 		"Test Route",
 		"Test description",
-		[]string{"op-route-1"},
+		[]string{uuid.NewString()},
 	)
 
 	result, err := gen.Generate(context.Background(), "org-123", "ledger-123", input)
@@ -256,7 +256,7 @@ func TestTransactionRouteGenerator_Generate_VerifyIDs(t *testing.T) {
 	input := models.NewCreateTransactionRouteInput(
 		"Test Route",
 		"Test description",
-		[]string{"op-route-1"},
+		[]string{uuid.NewString()},
 	)
 
 	_, err := gen.Generate(context.Background(), "test-org", "test-ledger", input)

--- a/pkg/integrity/checker_test.go
+++ b/pkg/integrity/checker_test.go
@@ -137,6 +137,10 @@ func (s *testBalancesService) GetBalance(ctx context.Context, orgID, ledgerID, b
 	return nil, errors.New("mock: GetBalance not implemented")
 }
 
+func (*testBalancesService) GetBalanceHistory(context.Context, string, string, string, string) (*models.BalanceHistory, error) {
+	return nil, errors.New("mock: GetBalanceHistory not implemented")
+}
+
 func (s *testBalancesService) UpdateBalance(ctx context.Context, orgID, ledgerID, balanceID string, input *models.UpdateBalanceInput) (*models.Balance, error) {
 	if s.updateBalanceFn != nil {
 		return s.updateBalanceFn(ctx, orgID, ledgerID, balanceID, input)
@@ -175,6 +179,10 @@ func (s *testBalancesService) ListBalancesByExternalCode(ctx context.Context, or
 	}
 
 	return nil, errors.New("mock: ListBalancesByExternalCode not implemented")
+}
+
+func (*testBalancesService) GetAccountBalancesHistory(context.Context, string, string, string, string) ([]models.BalanceHistory, error) {
+	return nil, errors.New("mock: GetAccountBalancesHistory not implemented")
 }
 
 // testAccountsService implements entities.AccountsService for testing

--- a/pkg/performance/json.go
+++ b/pkg/performance/json.go
@@ -64,17 +64,11 @@ import (
 // occasional large JSON operations consuming excessive pool memory.
 const maxBufferSize = 1 << 20 // 1MB
 
-// JSONPool provides a pool of JSON encoders and decoders to reduce allocations.
-// This is particularly useful for high-throughput applications that make many API calls.
-//
-// Performance Impact:
-// - Reduces memory allocations by reusing encoder/decoder objects
-// - Decreases garbage collection pressure in high-frequency JSON operations
-// - Improves throughput for applications processing many small JSON documents
+// JSONPool provides pooled buffers for JSON encoding/decoding workflows.
+// The standard library encoders/decoders themselves are still created per use,
+// because they cannot be safely rebound to a new reader/writer.
 type JSONPool struct {
-	encoderPool sync.Pool
-	decoderPool sync.Pool
-	bufferPool  sync.Pool
+	bufferPool sync.Pool
 }
 
 // NewJSONPool creates a new JSONPool with initialized pools.
@@ -89,16 +83,6 @@ type JSONPool struct {
 //	jsonData, err := reportingPool.Marshal(reportData)
 func NewJSONPool() *JSONPool {
 	return &JSONPool{
-		encoderPool: sync.Pool{
-			New: func() any {
-				return json.NewEncoder(nil)
-			},
-		},
-		decoderPool: sync.Pool{
-			New: func() any {
-				return json.NewDecoder(nil)
-			},
-		},
 		bufferPool: sync.Pool{
 			New: func() any {
 				return new(bytes.Buffer)

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -92,6 +92,27 @@ type Options struct {
 	JitterFactor float64
 }
 
+type nonRetryableError struct {
+	err error
+}
+
+func (e nonRetryableError) Error() string {
+	return e.err.Error()
+}
+
+func (e nonRetryableError) Unwrap() error {
+	return e.err
+}
+
+// AsNonRetryable marks an error so the retry engine will stop immediately.
+func AsNonRetryable(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return nonRetryableError{err: err}
+}
+
 // DefaultRetryableErrors is a list of common error strings that should trigger a retry
 var DefaultRetryableErrors = []string{
 	"connection reset by peer",
@@ -462,6 +483,11 @@ func doWithOptions(ctx context.Context, fn func() error, options *Options) error
 //	}
 func IsRetryableError(err error, options *Options) bool {
 	if err == nil {
+		return false
+	}
+
+	var nonRetryable nonRetryableError
+	if errors.As(err, &nonRetryable) {
 		return false
 	}
 

--- a/pkg/security/http_request.go
+++ b/pkg/security/http_request.go
@@ -28,5 +28,14 @@ func ValidateOutboundRequest(req *http.Request) error {
 		return fmt.Errorf("unsupported URL scheme: %s", req.URL.Scheme)
 	}
 
+	if scheme == "http" && !isLocalhost(req.URL.Hostname()) {
+		return fmt.Errorf("insecure HTTP is only allowed for localhost targets: %s", req.URL.Host)
+	}
+
 	return nil
+}
+
+func isLocalhost(hostname string) bool {
+	hostname = strings.TrimSpace(strings.ToLower(hostname))
+	return hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1"
 }

--- a/pkg/security/http_request_test.go
+++ b/pkg/security/http_request_test.go
@@ -60,6 +60,13 @@ func TestValidateOutboundRequest(t *testing.T) {
 			},
 			errContain: "",
 		},
+		{
+			name: "InsecureRemoteHTTP",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "api.example.com"},
+			},
+			errContain: "insecure HTTP is only allowed for localhost targets",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/transaction/helpers.go
+++ b/pkg/transaction/helpers.go
@@ -100,14 +100,11 @@ func Transfer(
 		idempotencyKey = uuid.New().String()
 	}
 
-	// Convert amount to string with scale
-	amountStr := formatAmount(amount, scale)
+	amountValue := formatAmount(amount, scale)
 
 	// Create the transaction input
 	transferInput := &models.CreateTransactionInput{
 		Description:              opts.Description,
-		Amount:                   amountStr,
-		AssetCode:                assetCode,
 		Metadata:                 opts.Metadata,
 		Pending:                  opts.Pending,
 		IdempotencyKey:           idempotencyKey,
@@ -115,14 +112,14 @@ func Transfer(
 		ChartOfAccountsGroupName: opts.ChartOfAccountsGroupName,
 		Send: &models.SendInput{
 			Asset: assetCode,
-			Value: amountStr,
+			Value: amountValue,
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
 						Account: fromAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -133,7 +130,7 @@ func Transfer(
 						Account: toAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -223,13 +220,11 @@ func Deposit(
 	}
 
 	// Convert amount to string with scale
-	amountStr := formatAmount(amount, scale)
+	amountValue := formatAmount(amount, scale)
 
 	// Create the transaction input
 	depositInput := &models.CreateTransactionInput{
 		Description:              opts.Description,
-		Amount:                   amountStr,
-		AssetCode:                assetCode,
 		Metadata:                 opts.Metadata,
 		Pending:                  opts.Pending,
 		IdempotencyKey:           idempotencyKey,
@@ -237,14 +232,14 @@ func Deposit(
 		ChartOfAccountsGroupName: opts.ChartOfAccountsGroupName,
 		Send: &models.SendInput{
 			Asset: assetCode,
-			Value: amountStr,
+			Value: amountValue,
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
 						Account: externalAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -255,7 +250,7 @@ func Deposit(
 						Account: toAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -345,13 +340,11 @@ func Withdrawal(
 	}
 
 	// Convert amount to string with scale
-	amountStr := formatAmount(amount, scale)
+	amountValue := formatAmount(amount, scale)
 
 	// Create the transaction input
 	withdrawalInput := &models.CreateTransactionInput{
 		Description:              opts.Description,
-		Amount:                   amountStr,
-		AssetCode:                assetCode,
 		Metadata:                 opts.Metadata,
 		Pending:                  opts.Pending,
 		IdempotencyKey:           idempotencyKey,
@@ -359,14 +352,14 @@ func Withdrawal(
 		ChartOfAccountsGroupName: opts.ChartOfAccountsGroupName,
 		Send: &models.SendInput{
 			Asset: assetCode,
-			Value: amountStr,
+			Value: amountValue,
 			Source: &models.SourceInput{
 				From: []models.FromToInput{
 					{
 						Account: fromAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -377,7 +370,7 @@ func Withdrawal(
 						Account: externalAccountID,
 						Amount: models.AmountInput{
 							Asset: assetCode,
-							Value: amountStr,
+							Value: amountValue,
 						},
 					},
 				},
@@ -513,12 +506,12 @@ func buildAccountInputList(accounts map[string]int64, scale int64, assetCode, ac
 			return nil, 0, fmt.Errorf("amount for %s account %s must be positive", accountType, accountID)
 		}
 
-		amountStr := formatAmount(amount, scale)
+		amountValue := formatAmount(amount, scale)
 		inputList = append(inputList, models.FromToInput{
 			Account: accountID,
 			Amount: models.AmountInput{
 				Asset: assetCode,
-				Value: amountStr,
+				Value: amountValue,
 			},
 		})
 
@@ -541,12 +534,10 @@ func validateMultiTransferAmounts(sourceSum, destSum, totalAmount int64) error {
 }
 
 func buildMultiTransferInput(opts *MultiTransferOptions, idempotencyKey string, totalAmount, scale int64, assetCode string, fromList, toList []models.FromToInput) *models.CreateTransactionInput {
-	totalAmountStr := formatAmount(totalAmount, scale)
+	totalAmountValue := formatAmount(totalAmount, scale)
 
 	return &models.CreateTransactionInput{
 		Description:              opts.Description,
-		Amount:                   totalAmountStr,
-		AssetCode:                assetCode,
 		Metadata:                 opts.Metadata,
 		Pending:                  opts.Pending,
 		IdempotencyKey:           idempotencyKey,
@@ -554,7 +545,7 @@ func buildMultiTransferInput(opts *MultiTransferOptions, idempotencyKey string, 
 		ChartOfAccountsGroupName: opts.ChartOfAccountsGroupName,
 		Send: &models.SendInput{
 			Asset: assetCode,
-			Value: totalAmountStr,
+			Value: totalAmountValue,
 			Source: &models.SourceInput{
 				From: fromList,
 			},
@@ -634,20 +625,18 @@ func CreateFromTemplate(
 	mergedMetadata["timestamp"] = time.Now().Unix()
 
 	// Convert amount to string with scale
-	amountStr := formatAmount(amount, template.Scale)
+	amountValue := formatAmount(amount, template.Scale)
 
 	// Create the transaction input
 	input := &models.CreateTransactionInput{
 		Description:              template.Description,
-		Amount:                   amountStr,
-		AssetCode:                template.AssetCode,
 		Metadata:                 mergedMetadata,
 		Pending:                  template.Pending,
 		IdempotencyKey:           idempotencyKey,
 		ChartOfAccountsGroupName: template.ChartOfAccountsGroupName,
 		Send: &models.SendInput{
 			Asset: template.AssetCode,
-			Value: amountStr,
+			Value: amountValue,
 			Source: &models.SourceInput{
 				From: template.BuildSources(amount),
 			},
@@ -752,17 +741,31 @@ func CancelPendingTransaction(
 	entity *entities.Entity,
 	orgID, ledgerID, transactionID string,
 ) (*models.Transaction, error) {
-	// Use dedicated cancel endpoint, which returns no body in our Entities implementation.
-	if err := entity.Transactions.CancelTransaction(ctx, orgID, ledgerID, transactionID); err != nil {
+	if entity == nil {
+		return nil, errors.New("entity is required")
+	}
+
+	if entity.Transactions == nil {
+		return nil, errors.New("transactions service is not initialized")
+	}
+
+	tx, err := entity.Transactions.CancelTransactionWithResponse(ctx, orgID, ledgerID, transactionID)
+	if err != nil {
 		return nil, fmt.Errorf("failed to cancel transaction: %w", err)
 	}
 
-	// Fetch the transaction to return its final state (best-effort).
-	// Error is intentionally ignored: the cancel operation succeeded above,
-	// and this fetch is supplementary to provide the final transaction state.
-	// If the fetch fails, we still return success since cancellation worked.
-	//nolint:errcheck // best-effort fetch after successful cancellation
-	tx, _ := entity.Transactions.GetTransaction(ctx, orgID, ledgerID, transactionID)
+	if tx != nil {
+		return tx, nil
+	}
 
-	return tx, nil
+	fetchedTx, fetchErr := entity.Transactions.GetTransaction(ctx, orgID, ledgerID, transactionID)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("transaction canceled but final state could not be fetched: %w", fetchErr)
+	}
+
+	if fetchedTx == nil {
+		return nil, errors.New("transaction canceled but final state was empty")
+	}
+
+	return fetchedTx, nil
 }

--- a/pkg/validation/core/core.go
+++ b/pkg/validation/core/core.go
@@ -249,6 +249,14 @@ func ValidateMetadata(metadata map[string]any) error {
 			return errors.New("metadata keys cannot be empty")
 		}
 
+		if len(key) > 100 {
+			return fmt.Errorf("metadata key '%s' must be at most 100 characters", key)
+		}
+
+		if strings.Contains(key, ".") || strings.HasPrefix(key, "$") {
+			return fmt.Errorf("metadata key '%s' cannot contain dots or start with '$'", key)
+		}
+
 		if err := validateMetadataValue(key, value); err != nil {
 			return err
 		}
@@ -257,42 +265,14 @@ func ValidateMetadata(metadata map[string]any) error {
 	return nil
 }
 
-// validateMetadataValue validates a single metadata value and handles nested structures
+// validateMetadataValue validates a single flat metadata value.
 func validateMetadataValue(key string, value any) error {
 	if !isValidMetadataValueType(value) {
 		return fmt.Errorf("invalid metadata value type for key '%s': %T (must be string, number, boolean, or nil)", key, value)
 	}
 
-	// Check for nested maps
-	if nestedMap, ok := value.(map[string]any); ok {
-		if err := ValidateMetadata(nestedMap); err != nil {
-			return fmt.Errorf("invalid nested metadata at key '%s': %w", key, err)
-		}
-	}
-
-	// Check for arrays
-	if array, ok := value.([]any); ok {
-		if err := validateMetadataArray(key, array); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// validateMetadataArray validates an array of metadata values
-func validateMetadataArray(key string, array []any) error {
-	for i, item := range array {
-		if !isValidMetadataValueType(item) {
-			return fmt.Errorf("invalid metadata array item type at index %d for key '%s': %T (must be string, number, boolean, or nil)", i, key, item)
-		}
-
-		// Check for nested maps in arrays
-		if nestedMap, ok := item.(map[string]any); ok {
-			if err := ValidateMetadata(nestedMap); err != nil {
-				return fmt.Errorf("invalid nested metadata in array at key '%s', index %d: %w", key, i, err)
-			}
-		}
+	if len(fmt.Sprint(value)) > 2000 {
+		return fmt.Errorf("metadata value for key '%s' must be at most 2000 characters", key)
 	}
 
 	return nil
@@ -301,7 +281,7 @@ func validateMetadataArray(key string, array []any) error {
 // isValidMetadataValueType checks if a value is of a type supported in metadata
 func isValidMetadataValueType(value any) bool {
 	switch value.(type) {
-	case string, int, int32, int64, float32, float64, bool, nil, map[string]any, []any:
+	case string, int, int32, int64, float32, float64, bool, nil:
 		return true
 	default:
 		return false

--- a/pkg/validation/core/core_test.go
+++ b/pkg/validation/core/core_test.go
@@ -229,21 +229,23 @@ func TestValidateMetadata(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Valid metadata with nested map",
+			name: "Invalid metadata with nested map",
 			metadata: map[string]any{
 				"customer": map[string]any{
 					"id":   "cust123",
 					"name": "John Doe",
 				},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'customer': map[string]interface {} (must be string, number, boolean, or nil)",
 		},
 		{
-			name: "Valid metadata with array",
+			name: "Invalid metadata with array",
 			metadata: map[string]any{
 				"items": []any{"item1", "item2", "item3"},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'items': []interface {} (must be string, number, boolean, or nil)",
 		},
 		{
 			name: "Empty key",
@@ -911,7 +913,7 @@ func TestValidateMetadataWithNestedStructures(t *testing.T) {
 		errMsg   string
 	}{
 		{
-			name: "Valid nested map",
+			name: "Invalid nested map",
 			metadata: map[string]any{
 				"customer": map[string]any{
 					"id":   "cust123",
@@ -919,24 +921,27 @@ func TestValidateMetadataWithNestedStructures(t *testing.T) {
 					"age":  30,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'customer'",
 		},
 		{
-			name: "Valid array",
+			name: "Invalid array",
 			metadata: map[string]any{
 				"items": []any{"item1", "item2", "item3"},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'items'",
 		},
 		{
-			name: "Valid array with mixed types",
+			name: "Invalid array with mixed types",
 			metadata: map[string]any{
 				"mixed": []any{"string", 123, 45.67, true, nil},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'mixed'",
 		},
 		{
-			name: "Valid deeply nested map",
+			name: "Invalid deeply nested map",
 			metadata: map[string]any{
 				"level1": map[string]any{
 					"level2": map[string]any{
@@ -944,10 +949,11 @@ func TestValidateMetadataWithNestedStructures(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'level1'",
 		},
 		{
-			name: "Valid array with nested map",
+			name: "Invalid array with nested map",
 			metadata: map[string]any{
 				"items": []any{
 					map[string]any{
@@ -960,7 +966,8 @@ func TestValidateMetadataWithNestedStructures(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr: true,
+			errMsg:  "invalid metadata value type for key 'items'",
 		},
 		{
 			name: "Valid metadata with int32",
@@ -991,7 +998,7 @@ func TestValidateMetadataWithNestedStructures(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			errMsg:  "metadata keys cannot be empty",
+			errMsg:  "invalid metadata value type for key 'customer'",
 		},
 		{
 			name: "Invalid array with unsupported type",

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -55,7 +55,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "",
+					Value: 0,
 				},
 			},
 			expectedError: true,
@@ -66,7 +66,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "-1.00",
+					Value: -1.00,
 				},
 			},
 			expectedError: true,
@@ -77,7 +77,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset:  "USD",
-					Value:  "1.00",
+					Value:  1.00,
 					Source: &models.DSLSource{},
 				},
 			},
@@ -89,7 +89,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "@external/INV@LID"},
@@ -110,7 +110,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "account1"},
@@ -127,7 +127,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "account1"},
@@ -148,7 +148,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "account1"},
@@ -169,7 +169,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "account1"},
@@ -193,7 +193,7 @@ func TestValidateTransactionDSL(t *testing.T) {
 			input: &models.TransactionDSLInput{
 				Send: &models.DSLSend{
 					Asset: "USD",
-					Value: "1.00",
+					Value: 1.00,
 					Source: &models.DSLSource{
 						From: []models.DSLFromTo{
 							{Account: "account1"},


### PR DESCRIPTION
## Summary
- Adds CRM Holder and Alias SDK services plus MetadataIndexes support.
- Enhances transaction APIs with metrics count, cancel response handling, and extracted DSL model types.
- Refreshes HTTP client configuration propagation, model/config/retry/validation utilities, examples, and documentation.

## Testing
- Not run in this session; PR created from the existing clean `develop` branch.