### PR TITLE
fix(config): add WithAllowInsecureHTTP opt-in for non-localhost HTTP targets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,15 @@ MIDAZ_CLIENT_SECRET=
 # Local development only — leave false in any deployed environment.
 MIDAZ_ACCESS_MANAGER_ALLOW_INSECURE_HTTP=false
 
+# Allow plain HTTP (instead of HTTPS) when reaching the Ledger / CRM service
+# URLs (MIDAZ_LEDGER_URL / MIDAZ_CRM_URL / MIDAZ_BASE_URL). Intended for
+# Kubernetes cluster-internal services reached over the cluster mesh
+# (e.g. http://midaz-ledger.<ns>.svc.cluster.local:3000) and dev/test
+# deployments behind a controlled network boundary. Loaded before the URL
+# env vars so MIDAZ_LEDGER_URL pointing at a *.svc.cluster.local target
+# is accepted automatically. Leave false for public-internet deployments.
+MIDAZ_ALLOW_INSECURE_HTTP=false
+
 # Example-specific configuration
 CONCURRENT_CUSTOMER_TO_MERCHANT_TXS=1000
 CONCURRENT_MERCHANT_TO_CUSTOMER_TXS="1000"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Midaz Go SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Added
+- **`WithAllowInsecureHTTP` config option**: opt-in that permits plain `http://` Ledger and CRM service URLs for non-loopback hosts, both at config build time (`parseURL` / `WithLedgerURL` / `WithCRMURL` / `WithBaseURL`) and at every outbound request (`security.ValidateOutboundRequestWithInsecureHTTP`). DEFAULT IS FALSE — strict behavior is preserved for every existing caller. Intended for Kubernetes cluster-internal services reached over the cluster mesh (e.g. `http://midaz-ledger.midaz-mt.svc.cluster.local:3000`) and dev/test deployments behind a controlled network boundary. Independent from `WithAllowInsecureAccessManagerHTTP` (auth plane). Equivalent env var: `MIDAZ_ALLOW_INSECURE_HTTP=true` (loaded before URL env vars by `FromEnvironment` so ordering is automatic). Production environment rejects the flag at `Validate()` time. Public companion helpers: `pkg/config.WithAllowInsecureHTTP`, `pkg/config.Config.AllowInsecureHTTP`, `pkg/config.Config.GetAllowInsecureHTTP`, `pkg/security.ValidateOutboundRequestWithInsecureHTTP`, `entities.HTTPClient.SetAllowInsecureHTTP` / `AllowInsecureHTTP`. The redirect policy installed by the data-plane HTTPClient is automatically swapped to the permissive `ValidateRedirectWithInsecureHTTP` variant when the flag is on.
+
+### 🐛 Bug Fixes
+- **Config build fails for cluster-internal `http://*.svc.cluster.local` Ledger/CRM URLs**: downstream plugins running in Kubernetes multi-tenant staging (e.g. `plugin-br-bank-transfer`) configured `MIDAZ_LEDGER_URL=http://midaz-ledger.midaz-mt.svc.cluster.local:3000` and hit `build midaz sdk config: invalid transaction URL: insecure HTTP is only allowed for localhost targets`. The new `WithAllowInsecureHTTP` opt-in (and matching `MIDAZ_ALLOW_INSECURE_HTTP` env var) unblocks this canonical in-cluster pattern without weakening the SDK default.
+
+### ⚠️ Known Limitations
+- `pkg/retry.DoHTTPRequest` and `pkg/performance.BatchProcessor` retain strict outbound-URL validation regardless of `WithAllowInsecureHTTP`. Direct users of those public packages who reach an in-cluster `http://` target should call `security.ValidateOutboundRequestWithInsecureHTTP` from their own pre-flight or keep using HTTPS / loopback. A follow-up will thread the flag through these public retry / batch surfaces.
+
 import "github.com/LerianStudio/midaz-sdk-golang/v2"
 
 [Compare changes](https://github.com/LerianStudio/midaz-sdk-golang/compare/v2.1.0-beta.5...v2.1.0-beta.6)

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ templates are [`.env.example`](.env.example) (alias of
 | `MIDAZ_CLIENT_ID` | string | OAuth client ID |
 | `MIDAZ_CLIENT_SECRET` | string | OAuth client secret |
 | `MIDAZ_ACCESS_MANAGER_ALLOW_INSECURE_HTTP` | bool | Permit plain HTTP to the Access Manager. Local development only |
+| `MIDAZ_ALLOW_INSECURE_HTTP` | bool | Permit plain HTTP to the Ledger / CRM service URLs for non-loopback hosts. Intended for Kubernetes cluster-internal services (`*.svc.cluster.local`) reached over the cluster mesh and dev/test deployments behind a controlled network boundary. Leave false for public-internet deployments; rejected at validation time when `MIDAZ_ENVIRONMENT=production` |
 
 The `User-Agent` header is fixed by the SDK to `midaz-go-sdk/<version>`;
 override programmatically with `midaz.WithUserAgent` if needed. See

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ The full list (v3):
 |---|---|
 | `WithAccessManager` | Plugin-based authentication (OAuth M2M) |
 | `WithAllowInsecureAccessManagerHTTP` | Permit non-loopback `http://` Access Manager URLs for trusted in-cluster networks |
+| `WithAllowInsecureHTTP` | Permit non-loopback `http://` Ledger / CRM URLs for trusted in-cluster networks (e.g. `*.svc.cluster.local`); apply BEFORE the URL setters |
 | `WithAnonymous` | Disable authentication (testing/local) |
 | `WithBaseURL` | Override service base URL |
 | `WithConfig` | Use a pre-built `*config.Config` (advanced) |
@@ -268,6 +269,7 @@ environment.
 | `MIDAZ_CLIENT_ID` | string | — | OAuth M2M client ID (required when `PLUGIN_AUTH_ENABLED=true`) |
 | `MIDAZ_CLIENT_SECRET` | string | — | OAuth M2M client secret (required when `PLUGIN_AUTH_ENABLED=true`) |
 | `MIDAZ_ACCESS_MANAGER_ALLOW_INSECURE_HTTP` | bool | `false` | Permit non-loopback `http://` Access Manager URLs for trusted in-cluster networks. Not allowed with `MIDAZ_ENVIRONMENT=production`. |
+| `MIDAZ_ALLOW_INSECURE_HTTP` | bool | `false` | Permit non-loopback `http://` Ledger / CRM service URLs (`MIDAZ_LEDGER_URL` / `MIDAZ_CRM_URL` / `MIDAZ_BASE_URL`). Intended for Kubernetes cluster-internal services (e.g. `http://midaz-ledger.<ns>.svc.cluster.local:3000`) reached over the cluster mesh and dev/test deployments behind a controlled network boundary. Loaded before the URL env vars so ordering is automatic. Not allowed with `MIDAZ_ENVIRONMENT=production`. Independent of `MIDAZ_ACCESS_MANAGER_ALLOW_INSECURE_HTTP` (auth-plane). |
 
 > Boolean parsing uses Go's [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool)
 > and accepts only its canonical forms: `1`, `t`, `T`, `TRUE`, `true`, `True`,

--- a/entities/entity.go
+++ b/entities/entity.go
@@ -45,6 +45,27 @@ type Config interface {
 	GetPluginAuth() auth.AccessManager
 }
 
+// insecureHTTPConfig is an OPTIONAL extension of [Config] that exposes
+// the data-plane insecure-HTTP opt-in. The entities layer uses a type
+// assertion against this interface so adding the method to [Config] does
+// not silently break callers that supply their own Config implementation
+// (e.g. test fixtures). When the assertion fails, the SDK defaults to
+// strict mode (no insecure HTTP), which matches the v3 default behavior.
+type insecureHTTPConfig interface {
+	GetAllowInsecureHTTP() bool
+}
+
+// configAllowsInsecureHTTP reads the optional insecure-HTTP flag from a
+// Config implementation. Returns false for nil or for implementations
+// that do not satisfy [insecureHTTPConfig], preserving the strict default.
+func configAllowsInsecureHTTP(config Config) bool {
+	if ext, ok := config.(insecureHTTPConfig); ok {
+		return ext.GetAllowInsecureHTTP()
+	}
+
+	return false
+}
+
 // Entity provides a centralized access point to all entity types in the Midaz SDK.
 // It acts as a factory for creating specific entity interfaces for different resource types
 // and operations.
@@ -127,9 +148,11 @@ func NewEntityWithConfigContext(ctx context.Context, config Config) (*Entity, er
 	}
 
 	// Create a new entity with the provided configuration
+	allowInsecureHTTP := configAllowsInsecureHTTP(config)
 	httpClient := NewHTTPClient(config.GetHTTPClient(), authToken, config.GetObservabilityProvider())
+	httpClient.SetAllowInsecureHTTP(allowInsecureHTTP)
 
-	normalizedBaseURLs, err := normalizeBaseURLs(config.GetBaseURLs())
+	normalizedBaseURLs, err := normalizeBaseURLs(config.GetBaseURLs(), allowInsecureHTTP)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +387,7 @@ func (e *Entity) SetObservability(provider observability.Provider) error {
 	return nil
 }
 
-func normalizeBaseURLs(baseURLs map[string]string) (map[string]string, error) {
+func normalizeBaseURLs(baseURLs map[string]string, allowInsecureHTTP bool) (map[string]string, error) {
 	normalized := maps.Clone(baseURLs)
 	if normalized == nil {
 		return nil, errors.New("service URLs map cannot be nil")
@@ -384,7 +407,7 @@ func normalizeBaseURLs(baseURLs map[string]string) (map[string]string, error) {
 	}
 
 	for service, serviceURL := range normalized {
-		normalizedURL, err := normalizeServiceURL(serviceURL)
+		normalizedURL, err := normalizeServiceURL(serviceURL, allowInsecureHTTP)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s URL: %w", service, err)
 		}
@@ -395,7 +418,7 @@ func normalizeBaseURLs(baseURLs map[string]string) (map[string]string, error) {
 	return normalized, nil
 }
 
-func normalizeServiceURL(rawURL string) (string, error) {
+func normalizeServiceURL(rawURL string, allowInsecureHTTP bool) (string, error) {
 	parsedURL, err := url.Parse(strings.TrimRight(strings.TrimSpace(rawURL), "/"))
 	if err != nil {
 		return "", err
@@ -413,7 +436,7 @@ func normalizeServiceURL(rawURL string) (string, error) {
 		return "", errors.New("URL must not include query parameters or fragments")
 	}
 
-	if err := security.ValidateOutboundRequest(&http.Request{URL: parsedURL}); err != nil {
+	if err := security.ValidateOutboundRequestWithInsecureHTTP(&http.Request{URL: parsedURL}, allowInsecureHTTP); err != nil {
 		return "", err
 	}
 

--- a/entities/entity_http_client_safety_regression_test.go
+++ b/entities/entity_http_client_safety_regression_test.go
@@ -77,17 +77,17 @@ func TestEntityURLs_NormalizeV1AndRejectUnsafeDirectURLs(t *testing.T) {
 		"onboarding":  "http://localhost:3002///",
 		"transaction": "http://localhost:3002/api",
 		"crm":         "http://localhost:4003",
-	})
+	}, false)
 	require.NoError(t, err)
 	require.Equal(t, "http://localhost:3002/v1", normalized["onboarding"])
 	require.Equal(t, "http://localhost:3002/api/v1", normalized["transaction"])
 	require.Equal(t, "http://localhost:4003/v1", normalized["crm"])
 
-	_, err = normalizeServiceURL("https://user:pass@example.com")
+	_, err = normalizeServiceURL("https://user:pass@example.com", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "user information")
 
-	_, err = normalizeServiceURL("http://api.example.com")
+	_, err = normalizeServiceURL("http://api.example.com", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "insecure HTTP")
 }

--- a/entities/entity_test.go
+++ b/entities/entity_test.go
@@ -26,7 +26,7 @@ func TestMainFunction(_ *testing.T) {
 func newTestEntity(t *testing.T, client *http.Client, authToken string, baseURLs map[string]string, provider observability.Provider) *Entity {
 	t.Helper()
 
-	normalizedBaseURLs, err := normalizeBaseURLs(baseURLs)
+	normalizedBaseURLs, err := normalizeBaseURLs(baseURLs, false)
 	require.NoError(t, err)
 
 	entity := &Entity{
@@ -45,7 +45,7 @@ func TestNormalizeBaseURLs_DefaultsMissingCRMURLToOnboarding(t *testing.T) {
 	normalized, err := normalizeBaseURLs(map[string]string{
 		"onboarding":  "https://api.example.com/onboarding",
 		"transaction": "https://api.example.com/transaction",
-	})
+	}, false)
 
 	require.NoError(t, err)
 	require.Equal(t, "https://api.example.com/onboarding/v1", normalized["crm"])
@@ -56,7 +56,7 @@ func TestNormalizeBaseURLs_RequiresOnboardingKey(t *testing.T) {
 
 	baseURLs, err := normalizeBaseURLs(map[string]string{
 		"transaction": "https://api.example.com/transaction",
-	})
+	}, false)
 
 	require.Error(t, err)
 	require.Nil(t, baseURLs)

--- a/entities/http.go
+++ b/entities/http.go
@@ -96,6 +96,13 @@ type HTTPClient struct {
 	debug             atomic.Bool
 	enableIdempotency atomic.Bool
 	exposeErrorBody   atomic.Bool
+	// allowInsecureHTTP gates the runtime [security.ValidateOutboundRequest]
+	// check against plain http:// non-loopback targets. Default false
+	// (strict). Set via [SetAllowInsecureHTTP], typically threaded from
+	// [pkg/config.Config.AllowInsecureHTTP] at entity construction.
+	// Atomic so the request path reads it without contending with the
+	// HTTPClient mutex.
+	allowInsecureHTTP atomic.Bool
 	retryOptions      *retry.Options        // Retry options for the client
 	jsonPool          *performance.JSONPool // Pool for JSON encoding/decoding
 	metrics           *observability.MetricsCollector
@@ -334,6 +341,36 @@ func (c *HTTPClient) SetExposeErrorBody(enabled bool) {
 	}
 
 	c.exposeErrorBody.Store(enabled)
+}
+
+// SetAllowInsecureHTTP gates the runtime outbound-URL guard against plain
+// http:// non-loopback targets. Default false (strict). Wired from
+// [pkg/config.Config.AllowInsecureHTTP] by [NewEntityWithConfigContext];
+// callers building entities by hand can flip the flag here.
+//
+// SECURITY: leave this off in production over the public internet. The
+// flag exists for in-cluster Kubernetes Service DNS and dev/test
+// deployments behind a controlled network boundary.
+//
+// Lock-free: backed by an atomic.Bool so the request path reads it
+// without contending with the HTTPClient mutex.
+func (c *HTTPClient) SetAllowInsecureHTTP(allow bool) {
+	if c == nil {
+		return
+	}
+
+	c.allowInsecureHTTP.Store(allow)
+}
+
+// AllowInsecureHTTP reports whether the data-plane insecure-HTTP opt-in
+// is active. Exposed for diagnostic readers and for the retry layer
+// snapshot helpers.
+func (c *HTTPClient) AllowInsecureHTTP() bool {
+	if c == nil {
+		return false
+	}
+
+	return c.allowInsecureHTTP.Load()
 }
 
 // SetCustomRetryPolicy sets the predicate used to decide whether retries should continue.
@@ -628,7 +665,7 @@ func (c *HTTPClient) doRawRequest(ctx context.Context, method, requestURL string
 	ctx, endSpan := c.setupObservabilityContext(ctx, method, requestURL)
 	defer endSpan()
 
-	req, headers, err := buildRawHTTPRequest(ctx, method, requestURL, headers, body)
+	req, headers, err := buildRawHTTPRequest(ctx, method, requestURL, headers, body, c.allowInsecureHTTP.Load())
 	if err != nil {
 		c.logHTTPPhaseFailure(ctx, method, requestURL, nil, err)
 		c.recordSDKFailure(ctx, method, requestURL, 0, err)
@@ -709,7 +746,7 @@ func prepareRawRequestBody(headers map[string]string, body []byte) (io.Reader, m
 	return bytes.NewReader(body), headers, nil
 }
 
-func buildRawHTTPRequest(ctx context.Context, method, requestURL string, headers map[string]string, body []byte) (*http.Request, map[string]string, error) {
+func buildRawHTTPRequest(ctx context.Context, method, requestURL string, headers map[string]string, body []byte, allowInsecureHTTP bool) (*http.Request, map[string]string, error) {
 	reader, headers, err := prepareRawRequestBody(headers, body)
 	if err != nil {
 		return nil, nil, err
@@ -721,7 +758,7 @@ func buildRawHTTPRequest(ctx context.Context, method, requestURL string, headers
 	}
 
 	validationReq := &http.Request{URL: parsedURL}
-	if err := security.ValidateOutboundRequest(validationReq); err != nil {
+	if err := security.ValidateOutboundRequestWithInsecureHTTP(validationReq, allowInsecureHTTP); err != nil {
 		return nil, nil, wrapHTTPPhaseError(httpPhaseRequestValidate, false, err)
 	}
 
@@ -750,7 +787,7 @@ func (c *HTTPClient) doCountRequest(ctx context.Context, method, requestURL stri
 		return 0, buildErr
 	}
 
-	if err := security.ValidateOutboundRequest(req); err != nil {
+	if err := security.ValidateOutboundRequestWithInsecureHTTP(req, c.allowInsecureHTTP.Load()); err != nil {
 		validateErr := wrapHTTPPhaseError(httpPhaseRequestValidate, false, err)
 		c.logHTTPPhaseFailure(ctx, method, requestURL, nil, validateErr)
 		c.recordSDKFailure(ctx, method, requestURL, 0, validateErr)
@@ -1003,7 +1040,7 @@ func (c *HTTPClient) buildHTTPRequest(ctx context.Context, method, requestURL st
 		return nil, nil, wrapHTTPPhaseError(httpPhaseRequestBuild, false, fmt.Errorf("failed to parse request URL: %w", err))
 	}
 
-	if err := security.ValidateOutboundRequest(&http.Request{URL: parsedURL}); err != nil {
+	if err := security.ValidateOutboundRequestWithInsecureHTTP(&http.Request{URL: parsedURL}, c.allowInsecureHTTP.Load()); err != nil {
 		return nil, nil, wrapHTTPPhaseError(httpPhaseRequestValidate, false, fmt.Errorf("invalid request URL: %w", err))
 	}
 

--- a/entities/http_retry_response.go
+++ b/entities/http_retry_response.go
@@ -164,7 +164,7 @@ func (c *HTTPClient) performSingleAttempt(req *http.Request, method, requestURL 
 		return wrapHTTPPhaseError(httpPhaseRequestBuild, false, err)
 	}
 
-	if err := security.ValidateOutboundRequest(req); err != nil {
+	if err := security.ValidateOutboundRequestWithInsecureHTTP(req, c.allowInsecureHTTP.Load()); err != nil {
 		return wrapHTTPPhaseError(httpPhaseRequestValidate, false, fmt.Errorf("invalid request URL: %w", err))
 	}
 
@@ -319,7 +319,45 @@ func (c *HTTPClient) snapshotHTTPClient() *http.Client {
 		return defaultHTTPClient()
 	}
 
+	// When the data-plane insecure-HTTP opt-in is active, the redirect
+	// policy installed at construction (strict ValidateRedirect) would
+	// reject the very kind of http://*.svc.cluster.local target the
+	// caller asked us to accept. Wrap the client with the permissive
+	// ValidateRedirectWithInsecureHTTP variant on a shallow copy so
+	// the caller-supplied transport, jar, and timeout are preserved.
+	if c.allowInsecureHTTP.Load() {
+		return dataPlaneInsecureHTTPClient(c.client)
+	}
+
 	return c.client
+}
+
+// dataPlaneInsecureHTTPClient returns a shallow client copy whose
+// CheckRedirect delegates to [security.ValidateRedirectWithInsecureHTTP]
+// before any caller-supplied policy. Mirrors the pattern used by
+// [pkg/auth.accessManagerHTTPClient] for the auth plane. The wrapper is
+// produced per request snapshot, but the underlying Transport / Jar /
+// Timeout are shared via field assignment so the per-request cost is a
+// single struct copy plus one closure allocation.
+func dataPlaneInsecureHTTPClient(client *http.Client) *http.Client {
+	if client == nil {
+		return nil
+	}
+
+	clientCopy := *client
+	callerRedirect := client.CheckRedirect
+	clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if err := security.ValidateRedirectWithInsecureHTTP(req, via, true); err != nil {
+			return err
+		}
+		if callerRedirect != nil {
+			return callerRedirect(req, via)
+		}
+
+		return nil
+	}
+
+	return &clientCopy
 }
 
 func resetRequestBody(req *http.Request) error {

--- a/midaz_options.go
+++ b/midaz_options.go
@@ -684,6 +684,62 @@ func WithAllowInsecureAccessManagerHTTP(allow bool) Option {
 	}
 }
 
+// WithAllowInsecureHTTP opts the configured Ledger and CRM service URLs
+// out of the SDK's "http:// only for localhost" gate. DEFAULT IS FALSE
+// (strict). Set this for the canonical Kubernetes cluster-internal
+// pattern where the SDK reaches midaz-ledger / midaz-crm via Service DNS
+// (e.g. http://midaz-ledger.midaz-mt.svc.cluster.local:3000) over a
+// service-mesh-protected network. Also valid for dev/test deployments
+// behind a controlled network boundary.
+//
+// Two-layer surface: this is the user-facing wrapper. It delegates to
+// [github.com/LerianStudio/midaz-sdk-golang/v3/pkg/config.WithAllowInsecureHTTP],
+// which most callers should not invoke directly.
+//
+// SECURITY: this disables a deliberate transport-security gate. Production
+// deployments over the public internet must leave this off. The flag
+// lifts only the http-non-localhost rule — the scheme allowlist
+// (http/https), userinfo rejection, and missing-host rejection remain
+// active at both config-time (parseURL) and request-time
+// ([pkg/security.ValidateOutboundRequestWithInsecureHTTP]).
+//
+// ORDERING NOTE: this option mutates a flag read by [WithLedgerURL],
+// [WithCRMURL], and [WithBaseURL] when those options run. Apply
+// WithAllowInsecureHTTP BEFORE the URL setters in your option chain:
+//
+//	client, err := midaz.New(
+//	    midaz.WithAllowInsecureHTTP(true),
+//	    midaz.WithLedgerURL("http://midaz-ledger.midaz-mt.svc.cluster.local:3000"),
+//	    midaz.WithAccessManager(am),
+//	)
+//
+// Env-loaded callers (MIDAZ_LEDGER_URL / MIDAZ_CRM_URL / MIDAZ_BASE_URL via
+// FromEnvironment) get the right ordering automatically — FromEnvironment
+// loads MIDAZ_ALLOW_INSECURE_HTTP before processing URLs.
+//
+// Equivalent env var: MIDAZ_ALLOW_INSECURE_HTTP=true (consumed via
+// [github.com/LerianStudio/midaz-sdk-golang/v3/pkg/config.FromEnvironment]).
+//
+// This flag is independent of [WithAllowInsecureAccessManagerHTTP], which
+// gates the Access Manager (auth) URL. Set both when both the Access
+// Manager and the Ledger live behind the cluster mesh.
+//
+// Parameters:
+//   - allow: Whether to permit plain http:// for non-loopback Ledger/CRM hosts.
+//
+// Returns:
+//   - Option: A function that wires the flag onto the underlying Config.
+//
+// See also:
+//   - [WithLedgerURL], [WithCRMURL], [WithBaseURL] — URL setters this flag relaxes.
+//   - [WithAllowInsecureAccessManagerHTTP] — the auth-plane equivalent.
+func WithAllowInsecureHTTP(allow bool) Option {
+	return func(c *Client) error {
+		c.markConfigMutated()
+		return config.WithAllowInsecureHTTP(allow)(c.config)
+	}
+}
+
 // WithLogger sets the canonical *slog.Logger for the client. Once configured,
 // the SDK emits structured log lines for retry attempts, slow calls, and
 // internal warnings through this logger.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,6 +146,24 @@ type Config struct {
 	// midaz-onboarding/midaz-transaction stack, or for tests. v3 rejects
 	// construction with no auth source AND no Anonymous=true via validateConfig.
 	Anonymous bool
+
+	// AllowInsecureHTTP opts the configured Ledger and CRM service URLs out
+	// of the SDK's "http:// only for localhost" gate. Default is false
+	// (strict). Set this BEFORE applying [WithLedgerURL], [WithCRMURL], or
+	// [WithBaseURL] — those option setters validate their input via
+	// [parseURL], which honors the flag value at the time it runs.
+	//
+	// Intended for Kubernetes cluster-internal services reached over the
+	// cluster mesh (e.g. http://midaz-ledger.midaz-mt.svc.cluster.local:3000)
+	// where TLS is terminated by the service mesh, and for development or
+	// test deployments behind a controlled network boundary. Production
+	// deployments over the public internet must leave this off.
+	//
+	// This flag is independent of [auth.AccessManager.AllowInsecureHTTP],
+	// which gates the Access Manager (auth) URL. The two are decoupled so a
+	// client may run HTTPS against the Access Manager while reaching the
+	// Ledger over an in-cluster HTTP service, or vice versa.
+	AllowInsecureHTTP bool
 }
 
 // Option is a function that configures a Config.
@@ -208,7 +226,7 @@ func WithLedgerURL(ledgerURL string) Option {
 			return errors.New("config cannot be nil")
 		}
 
-		if err := parseURL(ledgerURL); err != nil {
+		if err := parseURLWithInsecureHTTP(ledgerURL, c.AllowInsecureHTTP); err != nil {
 			return fmt.Errorf("invalid ledger URL: %w", err)
 		}
 
@@ -237,7 +255,7 @@ func WithCRMURL(crmURL string) Option {
 			return errors.New("config cannot be nil")
 		}
 
-		if err := parseURL(crmURL); err != nil {
+		if err := parseURLWithInsecureHTTP(crmURL, c.AllowInsecureHTTP); err != nil {
 			return fmt.Errorf("invalid crm URL: %w", err)
 		}
 
@@ -275,7 +293,7 @@ func WithBaseURL(baseURL string) Option {
 		}
 
 		// Validate the base URL
-		if err := parseURL(baseURL); err != nil {
+		if err := parseURLWithInsecureHTTP(baseURL, c.AllowInsecureHTTP); err != nil {
 			return fmt.Errorf("invalid base URL: %w", err)
 		}
 
@@ -626,6 +644,65 @@ func WithAllowInsecureAccessManagerHTTP(allow bool) Option {
 	}
 }
 
+// WithAllowInsecureHTTP opts the configured Ledger and CRM service URLs
+// out of the SDK's "http:// only for localhost" gate. DEFAULT IS FALSE
+// (strict).
+//
+// The canonical use case is a Kubernetes cluster-internal service reached
+// via cluster DNS (e.g. http://midaz-ledger.midaz-mt.svc.cluster.local:3000)
+// where TLS is terminated by the service mesh, so the link from this SDK
+// to the upstream is plaintext but inside a trusted network boundary.
+// A secondary use case is dev/test deployments behind a controlled LAN
+// where issuing a TLS certificate would be operationally heavy.
+//
+// SECURITY: this disables a deliberate transport-security gate. Production
+// deployments over the public internet must leave this off. The flag
+// lifts only the http-non-localhost guard — the scheme allowlist
+// (http/https), userinfo rejection, and missing-host rejection remain
+// active.
+//
+// ORDERING NOTE: this option mutates a flag read by [WithLedgerURL],
+// [WithCRMURL], and [WithBaseURL] at the moment those options run.
+// Apply WithAllowInsecureHTTP BEFORE the URL setters in your option
+// chain:
+//
+//	cfg, err := config.NewConfig(
+//	    config.WithAllowInsecureHTTP(true),
+//	    config.WithLedgerURL("http://midaz-ledger.midaz-mt.svc.cluster.local:3000"),
+//	    config.WithAccessManager(am),
+//	)
+//
+// When the URLs come from [FromEnvironment], the helper loads
+// MIDAZ_ALLOW_INSECURE_HTTP before processing MIDAZ_LEDGER_URL /
+// MIDAZ_CRM_URL / MIDAZ_BASE_URL so the ordering is automatic.
+//
+// This flag is independent of [WithAllowInsecureAccessManagerHTTP], which
+// gates the Access Manager (auth) endpoint. Set both when both the
+// Access Manager and the Ledger live behind the cluster mesh.
+//
+// Two-layer surface: this is the internal/test-layer Option that operates
+// on [Config]. The user-facing wrapper at
+// [github.com/LerianStudio/midaz-sdk-golang/v3.WithAllowInsecureHTTP]
+// is what most callers should use; it composes with
+// [github.com/LerianStudio/midaz-sdk-golang/v3.New] directly.
+//
+// Parameters:
+//   - allow: Whether to permit plain http:// for non-loopback Ledger/CRM hosts.
+//
+// Returns:
+//   - Option: A function that wires the flag onto a Config.
+func WithAllowInsecureHTTP(allow bool) Option {
+	return func(c *Config) error {
+		if c == nil {
+			return errors.New("config cannot be nil")
+		}
+
+		c.AllowInsecureHTTP = allow
+
+		return nil
+	}
+}
+
 // FromEnvironment loads configuration from environment variables.
 // This allows for configuration without code changes.
 //
@@ -648,6 +725,14 @@ func WithAllowInsecureAccessManagerHTTP(allow bool) Option {
 //     Manager URLs for non-loopback hosts (parsed via [strconv.ParseBool]).
 //     Production deployments must leave this unset or false; the flag
 //     exists for the in-cluster Kubernetes Service pattern.
+//   - MIDAZ_ALLOW_INSECURE_HTTP: Permit plain http:// Ledger/CRM service
+//     URLs for non-loopback hosts (parsed via [strconv.ParseBool]). Loaded
+//     before the URL env vars so MIDAZ_LEDGER_URL / MIDAZ_CRM_URL /
+//     MIDAZ_BASE_URL pointing at cluster-internal services are accepted.
+//     Production deployments over the public internet must leave this
+//     unset or false; the flag exists for the in-cluster Kubernetes
+//     Service pattern and for dev/test deployments behind a controlled
+//     network boundary.
 //
 // Boolean variables accept the canonical [strconv.ParseBool] forms only:
 // "1", "t", "T", "TRUE", "true", "True", "0", "f", "F", "FALSE", "false",
@@ -669,6 +754,13 @@ func FromEnvironment() Option {
 		}
 
 		if err := configureAccessManager(c); err != nil {
+			return err
+		}
+
+		// configureInsecureHTTP MUST run before configureURLs so the
+		// in-cluster cluster.local Ledger/CRM URLs that drove the flag's
+		// existence in the first place are accepted by parseURL.
+		if err := configureInsecureHTTP(c); err != nil {
 			return err
 		}
 
@@ -752,6 +844,25 @@ func configureAccessManager(c *Config) error {
 	if enabled {
 		c.Anonymous = false
 	}
+
+	return nil
+}
+
+// configureInsecureHTTP loads MIDAZ_ALLOW_INSECURE_HTTP and applies it to
+// the Config before any URL setter runs. Unset env var leaves the
+// programmatically-configured value (typically false) untouched.
+func configureInsecureHTTP(c *Config) error {
+	raw := os.Getenv("MIDAZ_ALLOW_INSECURE_HTTP")
+	if raw == "" {
+		return nil
+	}
+
+	parsed, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid MIDAZ_ALLOW_INSECURE_HTTP value %q: %w", raw, err)
+	}
+
+	c.AllowInsecureHTTP = parsed
 
 	return nil
 }
@@ -1051,6 +1162,9 @@ func validateConfig(config *Config) error {
 // validateServiceURLs enforces that the Ledger service URL is configured.
 // The onboarding and transaction internal routes both resolve to LedgerURL,
 // so both map entries must be populated for the entity layer to function.
+// It also refuses the AllowInsecureHTTP opt-in in the production
+// environment, mirroring the Access Manager equivalent — the flag is for
+// in-cluster or controlled-network deployments, never the public internet.
 func validateServiceURLs(config *Config) error {
 	if onboardingURL, ok := config.ServiceURLs[ServiceOnboarding]; !ok || strings.TrimSpace(onboardingURL) == "" {
 		return errors.New("ledger URL is required")
@@ -1058,6 +1172,10 @@ func validateServiceURLs(config *Config) error {
 
 	if transactionURL, ok := config.ServiceURLs[ServiceTransaction]; !ok || strings.TrimSpace(transactionURL) == "" {
 		return errors.New("ledger URL is required")
+	}
+
+	if config.Environment == EnvironmentProduction && config.AllowInsecureHTTP {
+		return errors.New("insecure HTTP is not allowed in production")
 	}
 
 	return nil
@@ -1175,6 +1293,18 @@ func (c *Config) GetObservabilityProvider() observability.Provider {
 	return c.ObservabilityProvider
 }
 
+// GetAllowInsecureHTTP returns the data-plane (Ledger / CRM) insecure HTTP
+// opt-in flag. The entities layer reads this to gate the runtime
+// [security.ValidateOutboundRequest] check the same way the config-time
+// [parseURL] gate is relaxed.
+func (c *Config) GetAllowInsecureHTTP() bool {
+	if c == nil {
+		return false
+	}
+
+	return c.AllowInsecureHTTP
+}
+
 // Clone returns an independent copy of the configuration.
 //
 // The clone is safe to mutate without affecting the receiver. In particular,
@@ -1210,9 +1340,21 @@ func (c *Config) Clone() *Config {
 	return &cloned
 }
 
-// parseURL validates that a URL is properly formatted.
-// It also warns (via stderr) if using HTTP instead of HTTPS for non-localhost URLs.
+// parseURL validates that a URL is properly formatted using the SDK's
+// default strict mode (HTTP permitted only for localhost targets). The
+// scheme and userinfo checks are always enforced. To allow plain HTTP for
+// a non-localhost target (typically an in-cluster Kubernetes Service),
+// use [parseURLWithInsecureHTTP] with allowInsecureHTTP=true.
 func parseURL(rawURL string) error {
+	return parseURLWithInsecureHTTP(rawURL, false)
+}
+
+// parseURLWithInsecureHTTP validates that a URL is properly formatted.
+//
+// Scheme allowlist (http/https), missing-scheme/host rejection, and the
+// userinfo block are always enforced. The "http:// only for localhost"
+// gate is the single rule honored by allowInsecureHTTP=true.
+func parseURLWithInsecureHTTP(rawURL string, allowInsecureHTTP bool) error {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return err
@@ -1231,7 +1373,7 @@ func parseURL(rawURL string) error {
 		return errors.New("URL must not include user information")
 	}
 
-	if parsedURL.Scheme == "http" && !isLocalhost(parsedURL.Host) {
+	if parsedURL.Scheme == "http" && !allowInsecureHTTP && !isLocalhost(parsedURL.Host) {
 		return fmt.Errorf("insecure HTTP is only allowed for localhost targets: %s", parsedURL.Host)
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1131,6 +1131,243 @@ func TestParseURL_Invalid(t *testing.T) {
 	}
 }
 
+// TestParseURLWithInsecureHTTP exercises the per-call insecure-HTTP
+// opt-in. The strict default path is covered by TestParseURL_Valid /
+// TestParseURL_Invalid; this matrix asserts:
+//
+//   - allow=true relaxes ONLY the http-non-localhost guard.
+//   - scheme allowlist, userinfo rejection, and missing-scheme/host
+//     rejection are NOT relaxed by the flag.
+//   - allow=false explicitly still rejects.
+//   - HTTPS URLs are unaffected.
+func TestParseURLWithInsecureHTTP(t *testing.T) {
+	tests := []struct {
+		name              string
+		url               string
+		allowInsecureHTTP bool
+		errContain        string
+	}{
+		{
+			name:              "AllowHTTPClusterLocalServiceDNS",
+			url:               "http://midaz-ledger.midaz-mt.svc.cluster.local:3000",
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name:              "AllowHTTPPrivateRFC1918",
+			url:               "http://10.0.0.5:3000",
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name:              "AllowHTTPLocalhostRegression",
+			url:               "http://localhost:3000",
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name:              "AllowHTTPPublicHostInsideClusterMesh",
+			url:               "http://api.internal.example.com",
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name:              "RejectFTPSchemeEvenWithAllow",
+			url:               "ftp://midaz-ledger.midaz-mt.svc.cluster.local:3000",
+			allowInsecureHTTP: true,
+			errContain:        "URL scheme must be http or https",
+		},
+		{
+			name:              "RejectUserinfoEvenWithAllow",
+			url:               "http://attacker@midaz-ledger.midaz-mt.svc.cluster.local:3000",
+			allowInsecureHTTP: true,
+			errContain:        "URL must not include user information",
+		},
+		{
+			name:              "RejectMissingHostEvenWithAllow",
+			url:               "http://",
+			allowInsecureHTTP: true,
+			errContain:        "URL must include scheme and host",
+		},
+		{
+			name:              "AllowFalseStillRejectsHTTPNonLocalhost",
+			url:               "http://midaz-ledger.midaz-mt.svc.cluster.local:3000",
+			allowInsecureHTTP: false,
+			errContain:        "insecure HTTP is only allowed for localhost targets",
+		},
+		{
+			name:              "AllowHTTPSPublicWithoutFlag",
+			url:               "https://api.example.com",
+			allowInsecureHTTP: false,
+			errContain:        "",
+		},
+		{
+			name:              "AllowHTTPSPublicWithFlag",
+			url:               "https://api.example.com",
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseURLWithInsecureHTTP(tc.url, tc.allowInsecureHTTP)
+
+			if tc.errContain == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errContain)
+		})
+	}
+}
+
+// TestWithAllowInsecureHTTP_LedgerURL asserts the user-facing wiring at
+// the config layer: applying WithAllowInsecureHTTP(true) BEFORE
+// WithLedgerURL permits an http://*.svc.cluster.local target that
+// would otherwise be rejected by parseURL at option-application time.
+// This reproduces the plugin-br-bank-transfer MT-staging failure that
+// drove the hotfix.
+func TestWithAllowInsecureHTTP_LedgerURL(t *testing.T) {
+	const clusterURL = "http://midaz-ledger.midaz-mt.svc.cluster.local:3000"
+
+	t.Run("OptInAcceptsClusterLocalHTTP", func(t *testing.T) {
+		cfg, err := NewConfig(
+			disableAuthCheck(t),
+			WithEnvironment(EnvironmentDevelopment),
+			WithAllowInsecureHTTP(true),
+			WithLedgerURL(clusterURL),
+		)
+		require.NoError(t, err)
+		assert.True(t, cfg.AllowInsecureHTTP)
+		assert.True(t, cfg.GetAllowInsecureHTTP())
+		assert.Equal(t, clusterURL, cfg.ServiceURLs[ServiceOnboarding])
+		assert.Equal(t, clusterURL, cfg.ServiceURLs[ServiceTransaction])
+	})
+
+	t.Run("DefaultRejectsClusterLocalHTTP", func(t *testing.T) {
+		_, err := NewConfig(
+			disableAuthCheck(t),
+			WithEnvironment(EnvironmentDevelopment),
+			WithLedgerURL(clusterURL),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insecure HTTP is only allowed for localhost targets")
+	})
+
+	t.Run("ExplicitFalseRejectsClusterLocalHTTP", func(t *testing.T) {
+		_, err := NewConfig(
+			disableAuthCheck(t),
+			WithEnvironment(EnvironmentDevelopment),
+			WithAllowInsecureHTTP(false),
+			WithLedgerURL(clusterURL),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insecure HTTP is only allowed for localhost targets")
+	})
+
+	t.Run("OptInAfterURLDoesNotRetroactivelyAllow", func(t *testing.T) {
+		// Documents the ordering rule from WithAllowInsecureHTTP's
+		// godoc. The URL setter validates against c.AllowInsecureHTTP
+		// at the moment it runs, so flipping the flag afterwards
+		// cannot rescue a URL that was already rejected.
+		_, err := NewConfig(
+			disableAuthCheck(t),
+			WithEnvironment(EnvironmentDevelopment),
+			WithLedgerURL(clusterURL),
+			WithAllowInsecureHTTP(true),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insecure HTTP is only allowed for localhost targets")
+	})
+}
+
+// TestWithAllowInsecureHTTP_CRMURL mirrors the LedgerURL coverage on
+// the CRM URL path so both setters are pinned.
+func TestWithAllowInsecureHTTP_CRMURL(t *testing.T) {
+	const crmURL = "http://midaz-crm.midaz-mt.svc.cluster.local:4003"
+
+	cfg, err := NewConfig(
+		disableAuthCheck(t),
+		WithEnvironment(EnvironmentDevelopment),
+		WithAllowInsecureHTTP(true),
+		WithLedgerURL("http://midaz-ledger.midaz-mt.svc.cluster.local:3000"),
+		WithCRMURL(crmURL),
+	)
+	require.NoError(t, err)
+	assert.True(t, cfg.AllowInsecureHTTP)
+	assert.Equal(t, crmURL, cfg.ServiceURLs[ServiceCRM])
+}
+
+// TestWithAllowInsecureHTTP_BaseURL covers WithBaseURL, which fans out
+// to all ServiceURLs via buildLedgerServiceURL / buildCRMServiceURL —
+// each of those internally parses the same base URL.
+func TestWithAllowInsecureHTTP_BaseURL(t *testing.T) {
+	const baseURL = "http://midaz-api.midaz-mt.svc.cluster.local:3000"
+
+	cfg, err := NewConfig(
+		disableAuthCheck(t),
+		WithEnvironment(EnvironmentDevelopment),
+		WithAllowInsecureHTTP(true),
+		WithBaseURL(baseURL),
+	)
+	require.NoError(t, err)
+	assert.True(t, cfg.AllowInsecureHTTP)
+	assert.NotEmpty(t, cfg.ServiceURLs[ServiceOnboarding])
+	assert.NotEmpty(t, cfg.ServiceURLs[ServiceCRM])
+}
+
+// TestValidateConfig_RejectsInsecureHTTPInProduction mirrors the
+// existing Access Manager production gate. The data-plane flag is also
+// forbidden in production so the in-cluster carve-out cannot be flipped
+// on by accident for a public deployment.
+func TestValidateConfig_RejectsInsecureHTTPInProduction(t *testing.T) {
+	_, err := NewConfig(
+		disableAuthCheck(t),
+		WithEnvironment(EnvironmentProduction),
+		WithAllowInsecureHTTP(true),
+		// Use HTTPS here so the URL setter itself accepts the value;
+		// the validation gate fires later in validateConfig.
+		WithLedgerURL("https://api.midaz.io"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insecure HTTP is not allowed in production")
+}
+
+// TestFromEnvironment_AllowInsecureHTTP pins the env-loading path: the
+// MIDAZ_ALLOW_INSECURE_HTTP var must be read BEFORE the URL env vars so
+// in-cluster http:// targets are accepted automatically.
+func TestFromEnvironment_AllowInsecureHTTP(t *testing.T) {
+	t.Run("EnabledAcceptsClusterLocalLedger", func(t *testing.T) {
+		t.Setenv("MIDAZ_ALLOW_INSECURE_HTTP", "true")
+		t.Setenv("MIDAZ_LEDGER_URL", "http://midaz-ledger.midaz-mt.svc.cluster.local:3000")
+
+		cfg, err := NewConfig(disableAuthCheck(t), FromEnvironment())
+		require.NoError(t, err)
+		assert.True(t, cfg.AllowInsecureHTTP)
+		assert.Equal(t, "http://midaz-ledger.midaz-mt.svc.cluster.local:3000", cfg.ServiceURLs[ServiceOnboarding])
+	})
+
+	t.Run("UnsetKeepsDefaultStrict", func(t *testing.T) {
+		t.Setenv("MIDAZ_LEDGER_URL", "http://midaz-ledger.midaz-mt.svc.cluster.local:3000")
+
+		_, err := NewConfig(disableAuthCheck(t), FromEnvironment())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "insecure HTTP is only allowed for localhost targets")
+	})
+
+	t.Run("InvalidBoolValueIsRejected", func(t *testing.T) {
+		t.Setenv("MIDAZ_ALLOW_INSECURE_HTTP", "yes")
+
+		_, err := NewConfig(disableAuthCheck(t), FromEnvironment())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid MIDAZ_ALLOW_INSECURE_HTTP")
+	})
+}
+
 func TestParseEnvInt_Valid(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/security/http_request.go
+++ b/pkg/security/http_request.go
@@ -28,6 +28,28 @@ func ValidateOutboundRequest(req *http.Request) error {
 	return validateOutboundRequest(req, false)
 }
 
+// ValidateOutboundRequestWithInsecureHTTP validates the minimal security
+// requirements for outbound HTTP requests while optionally permitting
+// plain http:// for non-loopback hosts. The scheme allowlist
+// (http/https), userinfo rejection, missing-host rejection, and
+// nil-request guard are always enforced; allowInsecureHTTP gates only
+// the "http:// only for localhost" rule.
+//
+// SECURITY: this lifts a deliberate transport-security gate. Callers
+// must reach the target over an inherently secure channel that http://
+// cannot represent — typically a Kubernetes cluster-internal service
+// reached via the service mesh, or a dev/test deployment behind a
+// controlled network boundary. Never enable for traffic crossing the
+// public internet.
+//
+// Wired into the SDK by the Config-layer [pkg/config.WithAllowInsecureHTTP]
+// (data plane) and [pkg/config.WithAllowInsecureAccessManagerHTTP] (auth
+// plane); callers building their own HTTP path on top of pkg/security can
+// use this directly.
+func ValidateOutboundRequestWithInsecureHTTP(req *http.Request, allowInsecureHTTP bool) error {
+	return validateOutboundRequest(req, allowInsecureHTTP)
+}
+
 func validateOutboundRequest(req *http.Request, allowInsecureHTTP bool) error {
 	if req == nil {
 		return errors.New("http request cannot be nil")

--- a/pkg/security/http_request_test.go
+++ b/pkg/security/http_request_test.go
@@ -155,6 +155,127 @@ func TestValidateOutboundRequest(t *testing.T) {
 	}
 }
 
+// TestValidateOutboundRequestWithInsecureHTTP exercises the runtime
+// outbound-URL guard with the opt-in flag toggled. The strict default
+// path is covered by TestValidateOutboundRequest; this table focuses on:
+//
+//   - allow=true relaxes ONLY the http-non-localhost guard.
+//   - allow=true does NOT relax scheme allowlist, userinfo rejection,
+//     missing-host rejection.
+//   - allow=false explicitly (not just default) still rejects.
+//   - HTTPS targets remain unaffected by the flag.
+func TestValidateOutboundRequestWithInsecureHTTP(t *testing.T) {
+	tests := []struct {
+		name              string
+		req               *http.Request
+		allowInsecureHTTP bool
+		errContain        string
+	}{
+		{
+			name: "AllowHTTPClusterLocalServiceDNS",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "midaz-ledger.midaz-mt.svc.cluster.local:3000"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name: "AllowHTTPPrivateRFC1918",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "10.0.0.5:3000"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name: "AllowHTTPLocalhostRegression",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "localhost:8080"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name: "AllowHTTPPublicHostInsideClusterMesh",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "midaz-ledger.example.com:3000"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+		{
+			name: "RejectFTPSchemeEvenWithAllow",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "ftp", Host: "midaz-ledger.midaz-mt.svc.cluster.local:3000"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "unsupported URL scheme",
+		},
+		{
+			name: "RejectUserinfoEvenWithAllow",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", User: url.User("attacker"), Host: "midaz-ledger.midaz-mt.svc.cluster.local:3000"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "URL must not include user information",
+		},
+		{
+			name: "RejectMissingHostEvenWithAllow",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "http request URL must include host",
+		},
+		{
+			name: "RejectNilRequestEvenWithAllow",
+			req:  nil,
+			// allow=true is irrelevant when the request itself is nil.
+			allowInsecureHTTP: true,
+			errContain:        "http request cannot be nil",
+		},
+		{
+			name: "AllowFalseStillRejectsHTTPNonLocalhost",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "http", Host: "midaz-ledger.midaz-mt.svc.cluster.local:3000"},
+			},
+			allowInsecureHTTP: false,
+			errContain:        "insecure HTTP is only allowed for localhost targets",
+		},
+		{
+			name: "AllowHTTPSPublicWithoutFlag",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "https", Host: "api.example.com"},
+			},
+			allowInsecureHTTP: false,
+			errContain:        "",
+		},
+		{
+			name: "AllowHTTPSPublicWithFlag",
+			req: &http.Request{
+				URL: &url.URL{Scheme: "https", Host: "api.example.com"},
+			},
+			allowInsecureHTTP: true,
+			errContain:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOutboundRequestWithInsecureHTTP(tt.req, tt.allowInsecureHTTP)
+
+			if tt.errContain == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errContain)
+		})
+	}
+}
+
 func TestValidateRedirect(t *testing.T) {
 	// Table-driven consolidation of the redirect-policy cases. Each row
 	// describes the previous request's shape (method, URL, headers,


### PR DESCRIPTION
## Bug

The SDK rejects ANY non-localhost `http://` URL unconditionally at config build time:

```go
// pkg/config/config.go::parseURL
if parsedURL.Scheme == "http" && !isLocalhost(parsedURL.Host) {
    return fmt.Errorf("insecure HTTP is only allowed for localhost targets: %s", parsedURL.Host)
}
```

Real-world failure (downstream, `plugin-br-bank-transfer` in Kubernetes multi-tenant staging):

```
build midaz sdk config: invalid transaction URL: insecure HTTP is only allowed for localhost targets:
  midaz-ledger.midaz-mt.svc.cluster.local:3000
```

Kubernetes cluster-internal services (`*.svc.cluster.local`) are a legitimate plain-HTTP target — TLS is not typical inside the cluster mesh (that is the service mesh's job). The plugin already has `ALLOW_PRIVATE_UPSTREAMS=true` to permit private/loopback at its SSRF layer, but the SDK's URL parser overrides it.

## Goal

Add an **explicit opt-in** that lets downstream callers permit non-localhost `http://` (typically for cluster-internal `*.svc.cluster.local` endpoints OR for dev environments hitting private LANs). Default behaviour stays strict — no breaking change.

## API shape

```go
// pkg/config layer
func WithAllowInsecureHTTP(allow bool) Option

// midaz layer (user-facing wrapper)
func WithAllowInsecureHTTP(allow bool) Option

// Config-struct accessor
func (c *Config) GetAllowInsecureHTTP() bool

// pkg/security runtime guard
func ValidateOutboundRequestWithInsecureHTTP(req *http.Request, allowInsecureHTTP bool) error

// entities runtime knob (lock-free atomic; reads on the per-request hot path)
func (c *HTTPClient) SetAllowInsecureHTTP(allow bool)
func (c *HTTPClient) AllowInsecureHTTP() bool

// env var (loaded BEFORE URL env vars by FromEnvironment so the ordering
// is automatic when MIDAZ_LEDGER_URL / MIDAZ_CRM_URL / MIDAZ_BASE_URL
// points at *.svc.cluster.local)
MIDAZ_ALLOW_INSECURE_HTTP=true
```

Independent of `WithAllowInsecureAccessManagerHTTP` (auth plane) — both can be set when both Access Manager and Ledger live behind the cluster mesh.

## Default-strict guarantee

The DEFAULT remains `false`. Pre-existing strict behaviour is preserved verbatim:

- The 4 pre-existing `"insecure HTTP is only allowed for localhost targets"` test cases in `pkg/security/http_request_test.go` (`InsecureRemoteHTTP`, `InsecureLocalhostSuffixSpoof`, `RejectHTTPMetadataAddress`, `RejectHTTPPrivateAddress`) STILL PASS unchanged.
- Existing callers who never call `WithAllowInsecureHTTP` see no behaviour change.
- An explicit `WithAllowInsecureHTTP(false)` is also tested to confirm the flag is the gate, not a side effect.

## Threading (full sweep)

The flag is read at every layer that previously hard-coded the localhost-only-for-HTTP check:

| Layer | File | Hook |
|---|---|---|
| Config build-time URL validation | `pkg/config/config.go::parseURLWithInsecureHTTP` | `WithLedgerURL`, `WithCRMURL`, `WithBaseURL` all pass `c.AllowInsecureHTTP` |
| Env loader | `pkg/config/config.go::configureInsecureHTTP` | runs BEFORE `configureURLs` so URLs from env are validated against the right policy |
| Production refusal | `pkg/config/config.go::validateServiceURLs` | rejects `WithAllowInsecureHTTP(true)` in `EnvironmentProduction`, mirroring the Access Manager equivalent |
| Entities construction | `entities/entity.go::NewEntityWithConfigContext` | reads via `configAllowsInsecureHTTP` interface assertion (optional; defaults to strict if Config impl lacks the method — preserves test fixture compatibility) |
| Base URL normalization | `entities/entity.go::normalizeBaseURLs` / `normalizeServiceURL` | uses `ValidateOutboundRequestWithInsecureHTTP` |
| Per-request validation | `entities/http.go::buildRawHTTPRequest`, `doRequest`, and the retry response path in `entities/http_retry_response.go::DoRetryRequest` | reads `c.allowInsecureHTTP.Load()` (atomic.Bool) |
| Redirect policy | `entities/http_retry_response.go::dataPlaneInsecureHTTPClient` | shallow-copies the client and swaps `CheckRedirect` to `ValidateRedirectWithInsecureHTTP` when the flag is on, so an `http://` cluster-local 301 cannot be rejected mid-request |

## Guards still enforced (always-on; flag does NOT lift)

- Scheme allowlist: `http` or `https` only
- Userinfo rejection
- Missing-scheme / missing-host rejection
- Nil-request guard
- Production-environment validation refuses the flag at `Validate()` time

## Security trade-off

This disables a deliberate transport-security gate. The flag is for in-cluster Kubernetes service DNS (`*.svc.cluster.local`) reached over the service mesh, OR dev/test deployments behind a controlled network boundary. Production deployments over the public internet must leave this off — and `Validate()` will refuse the flag with `MIDAZ_ENVIRONMENT=production` to make that hard to misconfigure.

## Test matrix

`pkg/security/http_request_test.go::TestValidateOutboundRequestWithInsecureHTTP` (11 cases):

| Case | `allowInsecureHTTP` | Expected |
|---|---|---|
| HTTP `*.svc.cluster.local:3000` | `true` | success |
| HTTP `10.0.0.5:3000` (RFC1918) | `true` | success |
| HTTP `localhost:8080` (regression) | `true` | success |
| HTTP `midaz-ledger.example.com:3000` (public host) | `true` | success |
| `ftp://...` (scheme allowlist) | `true` | error `unsupported URL scheme` |
| HTTP with `User=...` userinfo | `true` | error `URL must not include user information` |
| HTTP with missing host | `true` | error `http request URL must include host` |
| nil request | `true` | error `http request cannot be nil` |
| HTTP `*.svc.cluster.local:3000` | `false` | error `insecure HTTP is only allowed for localhost targets` |
| HTTPS `api.example.com` | `false` | success |
| HTTPS `api.example.com` | `true` | success |

Plus the existing `TestValidateOutboundRequest` table (18 cases) UNCHANGED, including the 4 strict-default `"insecure HTTP is only allowed for localhost targets"` rows.

`pkg/config/config_test.go` adds:

- `TestWithAllowInsecureHTTP_LedgerURL` — 4 subtests: OptIn accepts `*.svc.cluster.local`, default rejects, explicit `false` rejects, opt-in-after-URL does NOT retroactively allow (documents the ordering trap from the godoc).
- `TestWithAllowInsecureHTTP_CRMURL` — same shape on the CRM setter.
- `TestWithAllowInsecureHTTP_BaseURL` — same shape on the unified base URL.
- `TestValidateConfig_RejectsInsecureHTTPInProduction` — production refusal.
- `TestFromEnvironment_AllowInsecureHTTP` — 3 subtests: env-enabled accepts cluster-local Ledger; unset keeps default-strict; invalid boolean value (`yes`) is rejected.

Verification:

```text
go build ./...                                          → clean
go vet ./...                                            → clean
golangci-lint run ./...                                 → clean
go test -count=1 ./...                                  → 5356 passed in 48 packages
```

## Files changed

| Type | Path |
|---|---|
| Code (config layer) | `pkg/config/config.go` |
| Code (security layer) | `pkg/security/http_request.go` |
| Code (entities runtime) | `entities/entity.go`, `entities/http.go`, `entities/http_retry_response.go` |
| Code (user-facing wrapper) | `midaz_options.go` |
| Tests | `pkg/config/config_test.go`, `pkg/security/http_request_test.go`, `entities/entity_test.go`, `entities/entity_http_client_safety_regression_test.go` |
| Docs | `README.md`, `docs/configuration.md`, `.env.example` |
| Changelog | `CHANGELOG.md` (Unreleased — Added / Fixed / Known Limitations) |

## Known limitation (documented in CHANGELOG)

`pkg/retry.DoHTTPRequest` and `pkg/performance.BatchProcessor` retain strict outbound-URL validation regardless of `WithAllowInsecureHTTP`. Direct users of those public packages who reach an in-cluster `http://` target should call `security.ValidateOutboundRequestWithInsecureHTTP` from their own pre-flight or keep using HTTPS / loopback. A follow-up will thread the flag through these public retry / batch surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
