### PR TITLE
feat: add metadata filter to TransactionsListOpts

### DIFF
--- a/docs/mapping/external_apis.md
+++ b/docs/mapping/external_apis.md
@@ -304,6 +304,8 @@ Use `github.com/LerianStudio/midaz-sdk-golang/v3/entities`. Consumers should pre
 
 `CreateTransactionWithDSLFile` sends `POST /transactions/dsl` as multipart form data with field name `transaction`, filename `transaction.dsl`, and UTF-8 DSL content. The SDK rejects empty, invalid UTF-8, and over-limit DSL payloads before network I/O.
 
+`ListTransactions` (and the `*All` / `*Pages` iterators) can filter by a single metadata field via `TransactionsListOpts.Filters.MetadataKey` + `MetadataValue`, rendered on the wire as `metadata.<key>=<value>`. This is the supported way to correlate a ledger transaction back to a caller's business id (e.g. a `transferId` stamped into transaction metadata at create time) — useful for lost-response recovery where the Midaz transaction id was never received. Only one metadata predicate is honored per request (not AND-combinable). Metadata keys are not indexed by default; for a hot correlation key, create the index via `MetadataIndexesService.CreateMetadataIndex(ctx, "transaction", input)` to avoid a backend collection scan at scale.
+
 ### Count method behavior
 
 The supported count methods are `GetOrganizationsMetricsCount`, `GetLedgersMetricsCount`, `GetAssetsMetricsCount`, `GetPortfoliosMetricsCount`, `GetSegmentsMetricsCount`, `GetAccountsMetricsCount`, and `GetTransactionsMetricsCount`.

--- a/docs/plans/transaction-metadata-list-filter.md
+++ b/docs/plans/transaction-metadata-list-filter.md
@@ -1,0 +1,95 @@
+# Plan: expose transaction metadata filtering on `ListTransactions`
+
+**Status:** Draft for review
+**Repo:** `github.com/LerianStudio/midaz-sdk-golang/v3` (branch develop)
+**Scope:** `models/transactions_list_opts.go`, `entities/transactions.go` (wiring only), validation, tests, docs. **No new SDK method; no server change.**
+
+---
+
+## 1. Problem
+
+A client cannot look up or list ledger transactions by a business correlation id (e.g. a caller's `transferId`). This blocks the lost-response recovery path: when a `CreateTransaction` HTTP response is lost (timeout / 5xx), the client has no Midaz `transaction.ID` and today has **no way to ask the ledger "did this credit land?"** by anything it actually knows.
+
+Concretely, the SDK's transaction query surface:
+- `GetTransaction` is by Midaz `transaction.ID` only (`entities/transactions.go:670-705`) — useless when the id was never received.
+- `ListTransactions` filters expose only `AssetCode/Status/Reference/DestinationAccount/SourceAccount/Route` + cursor/date (`models/transactions_list_opts.go:31-50`, `ToQueryParams:61-89`). **No metadata filter.**
+- The only correlation the client can stamp on create that survives to the ledger is `Metadata["transferId"]` (metadata IS serialized on create; `models/transaction.go:905-907`).
+
+So the client can WRITE the business id (into metadata) but cannot QUERY by it.
+
+## 2. Root cause — and the dead ends to avoid
+
+The SDK does not expose the server's metadata query parameter. Three tempting "fixes" are dead ends, verified against the server source (`../midaz`, `components/ledger`, develop):
+
+- **`ExternalID` is inert.** `CreateTransactionInput.ExternalID` is `json:"-"` (`models/transaction.go:300`); the wire-body builder `ToLibTransaction` (`models/transaction.go:857-910`) has never emitted it. It was severed SDK-side in `8fc6e8a` (a broad model sweep), not in reaction to a server change. The server has **no `external_id` column on transactions** (operation/FromTo-level only) and cannot filter by it. Do **not** resurrect ExternalID as the lever.
+- **`reference` / `code` don't pair.** The list filter `reference` and the create field `code` are different server concepts; the server transaction table has neither a `reference` nor a queryable `code` column — `code` survives only inside the `body` JSON blob, which the list endpoint cannot filter. Do **not** route correlation through them.
+- **Idempotency key is not a read handle.** `X-Idempotency` is Redis-backed with a default 5-min TTL; a duplicate create within the window returns the original (replay), but there is **no get-by-idempotency-key endpoint**. Useful as a *secondary* recovery inside the TTL, never a durable lookup.
+
+## 3. Verified server capability (the real lever)
+
+`GET .../transactions?metadata.transferId=<uuid>` is a **working server capability** today (`../midaz/components/ledger`):
+- Query parse: `pkg/net/http/httputils.go:153-155` captures any `metadata.*` key into a Mongo filter.
+- Dispatch: `transaction_query_handlers.go:75-93` routes to `GetAllMetadataTransactions` when a metadata filter is present.
+- Execution: `get_all_metadata_transactions.go:37-62` queries the Mongo metadata collection (`metadata.mongodb.go:332-336`, exact-match on the dotted key), collects `entity_id`s, then joins Postgres `WHERE id = ANY(uuids)`. Cursor-paginated.
+- Metadata is also returned on list responses (`get_all_transactions.go:100-102`), enabling client-side confirmation.
+
+**Two constraints the server imposes — must shape the SDK API:**
+1. **Single metadata predicate.** The parser assigns a single `bson.M{key: value}`; multiple `metadata.*` params do not AND together (last-wins). The SDK must expose a **single key/value pair**, not a multi-key map that would imply unsupported AND semantics. (Confirm exact multi-key behavior during impl; default to single-pair.)
+2. **Unindexed by default.** Only `entity_id` is auto-indexed on the transaction metadata collection (`config.mongo.transaction.go:128-144`); arbitrary metadata keys are collection scans until an operator creates the index via the admin `CreateIndex` API. This is a performance note for the SDK docs + a cross-repo ops follow-up, not an SDK blocker.
+
+## 4. The fix
+
+Expose a single metadata key/value filter on the transactions list, emitted as `metadata.<key>=<value>`.
+
+### 4.1 `models/transactions_list_opts.go`
+Add to `TransactionsFilters`:
+```go
+// MetadataKey / MetadataValue filter transactions by a single metadata field,
+// rendered as the query param `metadata.<MetadataKey>=<MetadataValue>`.
+// The server honors ONE metadata predicate per request (not AND-combinable),
+// so this is a single pair by design. Both must be set together.
+MetadataKey   string
+MetadataValue string
+```
+In `ToQueryParams` (after the existing filters):
+```go
+if o.Filters.MetadataKey != "" && o.Filters.MetadataValue != "" {
+    params["metadata."+o.Filters.MetadataKey] = o.Filters.MetadataValue
+}
+```
+**API-shape decision:** explicit `MetadataKey`/`MetadataValue` pair over a `map[string]string`, because the server is single-predicate last-wins — a map would silently mislead callers into expecting multi-key AND. (Alternative considered and rejected: `map[string]string` capped at one entry with validation — more surface, same capability, worse ergonomics.)
+
+### 4.2 `Validate()` (`transactions_list_opts.go`)
+Reject the half-set case (one of key/value empty) and validate the key against the server's metadata key rules (reuse `pkg/validation/core` metadata-key validation if present). Keep `ValidateCursorListOpts` as-is.
+
+### 4.3 Wiring
+No signature change: `ListTransactions` / `ListTransactionsAll` / `ListTransactionsPages` already take `TransactionsListOpts` and call `ToQueryParams` (`entities/transactions.go:64-84`). The new param flows through automatically.
+
+### 4.4 (Optional) convenience helper
+Consider a `WithMetadataFilter(key, value string)` fluent option for parity with the existing `With*` builders. Not required — the struct fields are enough. Decide during review.
+
+## 5. Tests
+- **Unit** (`models/transactions_list_opts_test.go`): `ToQueryParams` emits `metadata.transferId=<uuid>` when the pair is set; emits nothing when either side is empty; `Validate` rejects half-set pairs.
+- **Contract regression** (`entities/transaction_contract_regression_test.go` style): assert the rendered request query string contains `metadata.transferId=` for a representative filter — locks the wire shape against future drift.
+- **Iterator coverage:** a `ListTransactionsAll` test confirming the metadata param is carried across cursor pages.
+
+## 6. Docs
+- Update `docs/mapping/external_apis.md` / `internal_apis.md` to document the metadata list filter.
+- Godoc on the new fields: the single-predicate constraint AND the **unindexed-by-default performance caveat** — recommend operators create the `metadata.<key>` index via the Midaz admin `CreateIndex` API for hot correlation keys (e.g. `metadata.transferId`) to avoid Mongo collection scans at scale.
+- CHANGELOG entry.
+
+## 7. Non-goals
+- Do NOT resurrect `ExternalID` (inert; no server support for transactions).
+- Do NOT add `reference`/`code` correlation (no queryable server column).
+- Do NOT add a get/list-by-idempotency-key (no server endpoint).
+- No multi-key metadata AND (server doesn't support it).
+
+## 8. Cross-repo follow-ups (out of SDK scope, flag to owners)
+- **Server (`midaz`):** consider auto-indexing common transaction metadata keys, or document the `CreateIndex` requirement for correlation keys, so `metadata.transferId` lookups don't scan at scale.
+- **Consumer (`plugin-br-bank-transfer`):** the §8 reconciliation resolver in `docs/plans/ted-in-intent-first-persistence.md` consumes this filter — once shipped, the resolver lists `metadata.transferId=<id>` (scoped by date window) instead of relying on idempotency replay. Bump the SDK dep there.
+
+## 9. Sequencing
+1. Add fields + `ToQueryParams` emission + `Validate` (4.1–4.2) with unit tests (RED→GREEN).
+2. Contract-regression + iterator tests (5).
+3. Docs + CHANGELOG (6).
+4. Tag/release; notify the plugin to bump and wire the §8 resolver.

--- a/models/transactions_list_opts.go
+++ b/models/transactions_list_opts.go
@@ -3,6 +3,12 @@
 
 package models
 
+import (
+	"fmt"
+
+	"github.com/LerianStudio/midaz-sdk-golang/v3/pkg/validation/core"
+)
+
 // TransactionsListOpts is the typed options struct for ListTransactions and
 // the ListTransactionsAll / ListTransactionsPages iterators.
 //
@@ -47,11 +53,49 @@ type TransactionsFilters struct {
 	// Route narrows by transaction route name (e.g. "cashin", "cashout").
 	// Honored on both List and the metrics-count endpoint.
 	Route string
+
+	// MetadataKey and MetadataValue filter transactions by a single metadata
+	// field, rendered on the wire as `metadata.<MetadataKey>=<MetadataValue>`.
+	// The ledger honors ONE metadata predicate per request (it does not
+	// AND-combine multiple metadata keys), so this is a single pair by design.
+	// Both must be set together; MetadataKey must obey the storage-layer key
+	// rules (non-empty, <=100 chars, no '.' and no leading '$').
+	//
+	// PERFORMANCE: transaction metadata keys are NOT indexed by default on the
+	// ledger (only entity_id is). For a hot correlation key such as
+	// "transferId", have an operator create the index via the Midaz admin
+	// CreateIndex API to avoid a Mongo collection scan at scale.
+	MetadataKey   string
+	MetadataValue string
 }
 
 // Validate enforces SDK-side preconditions on TransactionsListOpts.
 func (o TransactionsListOpts) Validate() error {
-	return ValidateCursorListOpts("TransactionsListOpts.Validate", o.CursorListOpts)
+	if err := ValidateCursorListOpts("TransactionsListOpts.Validate", o.CursorListOpts); err != nil {
+		return err
+	}
+
+	return validateMetadataFilter(o.Filters.MetadataKey, o.Filters.MetadataValue)
+}
+
+// validateMetadataFilter enforces that the metadata list-filter is either
+// fully unset or a complete key/value pair, and that the key obeys the
+// storage-layer metadata rules (reused from core.ValidateMetadata: non-empty,
+// <=100 chars, no '.' and no leading '$', value within type/length bounds).
+func validateMetadataFilter(key, value string) error {
+	if key == "" && value == "" {
+		return nil
+	}
+
+	if key == "" || value == "" {
+		return fmt.Errorf("TransactionsListOpts.Validate: metadata filter requires both MetadataKey and MetadataValue")
+	}
+
+	if err := core.ValidateMetadata(map[string]any{key: value}); err != nil {
+		return fmt.Errorf("TransactionsListOpts.Validate: invalid metadata filter: %w", err)
+	}
+
+	return nil
 }
 
 // ToQueryParams renders an TransactionsListOpts into the wire query map.
@@ -83,6 +127,10 @@ func (o TransactionsListOpts) ToQueryParams() map[string]string {
 
 	if o.Filters.Route != "" {
 		params["route"] = o.Filters.Route
+	}
+
+	if o.Filters.MetadataKey != "" && o.Filters.MetadataValue != "" {
+		params["metadata."+o.Filters.MetadataKey] = o.Filters.MetadataValue
 	}
 
 	return params

--- a/models/typed_list_opts_test.go
+++ b/models/typed_list_opts_test.go
@@ -675,6 +675,8 @@ func TestTypedListOpts_ToQueryParams_FilterEncoding(t *testing.T) {
 				DestinationAccount: "dst",
 				SourceAccount:      "src",
 				Route:              "cashout",
+				MetadataKey:        "transferId",
+				MetadataValue:      "f403e2d7-1b09-52d7-b58e-5d955442f812",
 			},
 		}
 		require.NoError(t, opts.Validate())
@@ -685,6 +687,7 @@ func TestTypedListOpts_ToQueryParams_FilterEncoding(t *testing.T) {
 		assert.Equal(t, "dst", params["destination_account"])
 		assert.Equal(t, "src", params["source_account"])
 		assert.Equal(t, "cashout", params["route"])
+		assert.Equal(t, "f403e2d7-1b09-52d7-b58e-5d955442f812", params["metadata.transferId"])
 	})
 
 	t.Run("TransactionRoutesListOpts filters", func(t *testing.T) {
@@ -737,4 +740,42 @@ func TestUpdateInputMarshalJSON_NilPointersReturnNull(t *testing.T) {
 
 	// UpdateAccountInput nil pointer is already covered by
 	// TestUpdateAccountInputMarshalJSONNilPointer in account_test.go.
+}
+
+// TestTransactionsListOpts_MetadataFilter pins the metadata list-filter
+// contract: the SDK exposes a SINGLE metadata key/value pair (the server
+// honors one metadata.* predicate, not AND-combinable), rendered as the
+// query param metadata.<key>=<value>. Both sides must be set together, and
+// the key must obey the storage-layer key rules (no '.', no '$' prefix).
+func TestTransactionsListOpts_MetadataFilter(t *testing.T) {
+	t.Run("both set emits metadata.<key>", func(t *testing.T) {
+		opts := TransactionsListOpts{Filters: TransactionsFilters{MetadataKey: "transferId", MetadataValue: "abc-123"}}
+		require.NoError(t, opts.Validate())
+		assert.Equal(t, "abc-123", opts.ToQueryParams()["metadata.transferId"])
+	})
+
+	t.Run("half-set is omitted and rejected", func(t *testing.T) {
+		keyOnly := TransactionsListOpts{Filters: TransactionsFilters{MetadataKey: "transferId"}}
+		_, hasKey := keyOnly.ToQueryParams()["metadata.transferId"]
+		assert.False(t, hasKey, "key without value must not emit a param")
+		assert.Error(t, keyOnly.Validate(), "key without value must fail validation")
+
+		valOnly := TransactionsListOpts{Filters: TransactionsFilters{MetadataValue: "abc-123"}}
+		assert.NotContains(t, valOnly.ToQueryParams(), "metadata.", "value without key must not emit a param")
+		assert.Error(t, valOnly.Validate(), "value without key must fail validation")
+	})
+
+	t.Run("reserved key chars rejected", func(t *testing.T) {
+		dotted := TransactionsListOpts{Filters: TransactionsFilters{MetadataKey: "a.b", MetadataValue: "x"}}
+		assert.Error(t, dotted.Validate(), "metadata key with '.' must be rejected (storage-layer reserved)")
+
+		dollar := TransactionsListOpts{Filters: TransactionsFilters{MetadataKey: "$set", MetadataValue: "x"}}
+		assert.Error(t, dollar.Validate(), "metadata key starting with '$' must be rejected")
+	})
+
+	t.Run("unset is valid and emits nothing", func(t *testing.T) {
+		opts := TransactionsListOpts{}
+		require.NoError(t, opts.Validate())
+		assert.NotContains(t, opts.ToQueryParams(), "metadata.transferId")
+	})
 }


### PR DESCRIPTION
## Purpose

Add a metadata-based filter to `TransactionsListOpts` so callers can list transactions by a single `metadata.<key>=<value>` predicate (e.g. correlation keys like `transferId`).

## Scope

- `models/transactions_list_opts.go` — new `MetadataKey` / `MetadataValue` fields, validation, and wire rendering.
- `models/typed_list_opts_test.go` — tests for validation and query-param rendering.
- `docs/mapping/external_apis.md`, `docs/plans/transaction-metadata-list-filter.md` — docs.

## Key changes

- **New fields** `MetadataKey` / `MetadataValue` on `TransactionsFilters`. Both must be set together — the ledger honors **one** metadata predicate per request (no AND-combine), so this is a single pair by design.
- **Validation** via `validateMetadataFilter`: either fully unset or a complete pair; the key is checked against the storage-layer rules reused from `core.ValidateMetadata` (non-empty, ≤100 chars, no `.`, no leading `$`).
- **Wire rendering** in `ToQueryParams` as `metadata.<key>=<value>`.
- **Performance note** documented in the field comment: transaction metadata keys are not indexed by default on the ledger; hot keys should be indexed via the admin `CreateIndex` API to avoid collection scans.

## How to test

```bash
go test ./models -run TestTransactionsListOpts
make test
```
