### PR TITLE
feat: audit SDK against midaz v3 + add contract drift tracking

### DIFF
--- a/.github/workflows/midaz-drift.yml
+++ b/.github/workflows/midaz-drift.yml
@@ -1,0 +1,75 @@
+name: midaz-drift
+
+# Nightly check: does the SDK's pinned midaz baseline still match midaz HEAD?
+# "Drift" = changes in the tracked contract paths (OpenAPI specs + Go vocabulary
+# files), not raw commit count. Engine is scripts/check-midaz-drift.sh; this
+# workflow only schedules it and reports. See midaz-baseline.json.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # 00:00 America/Sao_Paulo (UTC-3)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, develop]
+    steps:
+      - name: Checkout SDK (${{ matrix.branch }})
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Checkout midaz upstream (${{ matrix.branch }})
+        uses: actions/checkout@v6.0.2
+        with:
+          repository: LerianStudio/midaz
+          ref: ${{ matrix.branch }}
+          path: .midaz-upstream
+          fetch-depth: 0 # full history: pinned commit may be far behind HEAD
+
+      - name: Check contract drift
+        id: check
+        run: |
+          set +e
+          MIDAZ_REPO="$GITHUB_WORKSPACE/.midaz-upstream" \
+            bash scripts/check-midaz-drift.sh "${{ matrix.branch }}" 2>&1 | tee drift-report.txt
+          echo "code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish report to job summary
+        if: always()
+        run: |
+          {
+            echo "## midaz drift — ${{ matrix.branch }}"
+            echo '```'
+            cat drift-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update drift issue
+        if: steps.check.outputs.code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="⚠️ midaz contract drift on ${{ matrix.branch }}"
+          body="$(cat drift-report.txt)"
+          existing="$(gh issue list --state open --json number,title \
+            | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' | head -1)"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+
+      - name: Fail job on drift or environment error
+        if: steps.check.outputs.code != '0'
+        run: |
+          echo "drift check exit code: ${{ steps.check.outputs.code }} (1=drift, 2=env error)"
+          exit 1

--- a/.github/workflows/midaz-drift.yml
+++ b/.github/workflows/midaz-drift.yml
@@ -12,11 +12,17 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   drift:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # open/update the drift report issue
+    concurrency:
+      # serialize per branch: a manual dispatch must not race a scheduled run
+      group: midaz-drift-${{ matrix.branch }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +32,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ matrix.branch }}
+          persist-credentials: false
 
       - name: Checkout midaz upstream (${{ matrix.branch }})
         uses: actions/checkout@v6.0.2
@@ -34,6 +41,7 @@ jobs:
           ref: ${{ matrix.branch }}
           path: .midaz-upstream
           fetch-depth: 0 # full history: pinned commit may be far behind HEAD
+          persist-credentials: false
 
       - name: Check contract drift
         id: check
@@ -60,7 +68,7 @@ jobs:
         run: |
           title="⚠️ midaz contract drift on ${{ matrix.branch }}"
           body="$(cat drift-report.txt)"
-          existing="$(gh issue list --state open --json number,title \
+          existing="$(gh issue list --state open --search "in:title $title" --limit 100 --json number,title \
             | jq -r --arg t "$title" '.[] | select(.title==$t) | .number' | head -1)"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/midaz-baseline.json
+++ b/midaz-baseline.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Commit do midaz contra o qual esta SDK foi validada. Drift relevante = mudanca nos tracked_paths entre o commit pinado e o HEAD do midaz na branch correspondente. tracked_paths inclui os specs OpenAPI E os arquivos Go que carregam vocabulario nao expresso no spec (enums de status sao strings livres no OpenAPI, validadas em codigo Go). Verifique com scripts/check-midaz-drift.sh. Atualize o commit ao revalidar a SDK contra um midaz mais novo.",
+  "repo": "github.com/LerianStudio/midaz",
+  "tracked_paths": [
+    "components/ledger/api/openapi.yaml",
+    "components/crm/api/openapi.yaml",
+    "pkg/constant/transaction.go",
+    "pkg/mmodel/status.go"
+  ],
+  "branches": {
+    "main": {
+      "commit": "168e8d565e22d6cd380de7b3b2a405b7c94c7eff",
+      "pinned_at": "2026-06-24"
+    },
+    "develop": {
+      "commit": "bb4ef4092f934da31f3ef006bb2e42d18e8f537d",
+      "pinned_at": "2026-06-24"
+    }
+  }
+}

--- a/models/balance.go
+++ b/models/balance.go
@@ -23,6 +23,7 @@ type Balance struct {
 	OnHold         decimal.Decimal `json:"onHold" example:"500" minimum:"0"`
 	Version        int64           `json:"version" example:"1" minimum:"1"`
 	AccountType    string          `json:"accountType" example:"creditCard" maxLength:"50"`
+	Direction      string          `json:"direction,omitempty" example:"credit"`
 	AllowSending   bool            `json:"allowSending" example:"true"`
 	AllowReceiving bool            `json:"allowReceiving" example:"true"`
 	CreatedAt      time.Time       `json:"createdAt" example:"2021-01-01T00:00:00Z" format:"date-time"`
@@ -44,6 +45,7 @@ type BalanceHistory struct {
 	OnHold         decimal.Decimal `json:"onHold" example:"500" minimum:"0"`
 	Version        int64           `json:"version" example:"1" minimum:"1"`
 	AccountType    string          `json:"accountType" example:"creditCard" maxLength:"50"`
+	Direction      string          `json:"direction,omitempty" example:"credit"`
 	AllowSending   bool            `json:"allowSending" example:"true"`
 	AllowReceiving bool            `json:"allowReceiving" example:"true"`
 	CreatedAt      time.Time       `json:"createdAt" example:"2021-01-01T00:00:00Z" format:"date-time"`

--- a/models/operation_route.go
+++ b/models/operation_route.go
@@ -33,11 +33,12 @@ type AccountingEntry struct {
 
 // AccountingEntries groups accounting entries by transaction action type.
 type AccountingEntries struct {
-	Direct *AccountingEntry `json:"direct,omitempty"`
-	Hold   *AccountingEntry `json:"hold,omitempty"`
-	Commit *AccountingEntry `json:"commit,omitempty"`
-	Cancel *AccountingEntry `json:"cancel,omitempty"`
-	Revert *AccountingEntry `json:"revert,omitempty"`
+	Direct    *AccountingEntry `json:"direct,omitempty"`
+	Hold      *AccountingEntry `json:"hold,omitempty"`
+	Commit    *AccountingEntry `json:"commit,omitempty"`
+	Cancel    *AccountingEntry `json:"cancel,omitempty"`
+	Revert    *AccountingEntry `json:"revert,omitempty"`
+	Overdraft *AccountingEntry `json:"overdraft,omitempty"`
 }
 
 // OperationRoute is the SDK-native operation route response type (Track 7E — audit 7.1).

--- a/scripts/check-midaz-drift.sh
+++ b/scripts/check-midaz-drift.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Detect contract drift between the pinned midaz commit and the current midaz HEAD.
+# "Drift" = changes in the tracked OpenAPI specs only, not raw commit count.
+#
+#   exit 0  -> no contract drift (specs unchanged since the pin)
+#   exit 1  -> drift detected (specs changed; diff printed)
+#   exit 2  -> usage / environment error
+#
+# Usage:
+#   scripts/check-midaz-drift.sh [branch]      # branch defaults to the SDK's current branch
+#   MIDAZ_REPO=/path/to/midaz scripts/check-midaz-drift.sh develop
+set -euo pipefail
+
+sdk_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+baseline="$sdk_root/midaz-baseline.json"
+midaz_repo="${MIDAZ_REPO:-$sdk_root/../midaz}"
+branch="${1:-$(git -C "$sdk_root" rev-parse --abbrev-ref HEAD)}"
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 2; }
+[[ -f "$baseline" ]] || { echo "error: baseline not found: $baseline" >&2; exit 2; }
+[[ -d "$midaz_repo/.git" ]] || { echo "error: midaz repo not found at '$midaz_repo' (set MIDAZ_REPO)" >&2; exit 2; }
+
+pinned="$(jq -r --arg b "$branch" '.branches[$b].commit // empty' "$baseline")"
+[[ -n "$pinned" ]] || { echo "error: no pin for branch '$branch' in $baseline" >&2; exit 2; }
+mapfile -t specs < <(jq -r '.tracked_paths[]' "$baseline")
+
+echo "midaz drift check: branch=$branch pinned=${pinned:0:9}"
+git -C "$midaz_repo" fetch --quiet origin "$branch" || { echo "error: git fetch origin $branch failed" >&2; exit 2; }
+git -C "$midaz_repo" cat-file -e "${pinned}^{commit}" 2>/dev/null \
+  || { echo "error: pinned commit $pinned not in local midaz (shallow clone?). Run: git -C '$midaz_repo' fetch --unshallow" >&2; exit 2; }
+
+head="$(git -C "$midaz_repo" rev-parse "origin/$branch")"
+ahead="$(git -C "$midaz_repo" rev-list --count "${pinned}..${head}")"
+echo "midaz origin/$branch is at ${head:0:9} (${ahead} commit(s) ahead of pin)"
+
+# git diff exits non-zero under set -e when there ARE changes; capture without tripping it.
+stat="$(git -C "$midaz_repo" diff --stat "${pinned}..${head}" -- "${specs[@]}" || true)"
+if [[ -z "$stat" ]]; then
+  echo "✅ no contract drift: tracked specs unchanged since pin"
+  exit 0
+fi
+
+echo "⚠️  CONTRACT DRIFT detected in tracked specs:"
+echo "$stat"
+echo
+echo "Full diff:"
+echo "  git -C '$midaz_repo' diff ${pinned:0:9}..origin/$branch -- ${specs[*]}"
+exit 1


### PR DESCRIPTION
## Purpose

The `v4.1.0-beta.1` cleanup raised a broader question: is the SDK still in line with the midaz server it targets? This PR (1) answers it — a full endpoint + payload audit against **midaz v3 @ `origin/main` (`168e8d56`)** — and (2) wires a standing drift check so the answer stays current instead of being a point-in-time guess.

## Audit result

- **Endpoints: 97/97 covered** (86 ledger + 11 CRM). No broken calls, no coverage gaps (machine-verified `comm`-diff of normalized path shapes).
- **Payloads/enums: in line.** Transaction status vocabulary matches exactly (`CREATED, APPROVED, PENDING, CANCELED, NOTED`). Two response-fidelity gaps found and fixed below.

## Key changes

**`fix(models)` — `f5f179a`**
- `AccountingEntries.overdraft`: midaz exposes 6 accounting-entry keys; the SDK struct had 5, so an operation-route response carrying `overdraft` was silently dropped on decode. Added (also enables the typed write path).
- `Balance.direction`: midaz returns `direction` on balance reads; the SDK exposed it only on the create input, not the response types. Added to `Balance` and `BalanceHistory`.

**`feat(ci)` — `7723020`**
- `midaz-baseline.json`: pins the midaz commit the SDK is validated against, per branch (SDK `main` ↔ midaz `main`, SDK `develop` ↔ midaz `develop`).
- `scripts/check-midaz-drift.sh`: diffs **only the tracked contract paths**, not raw commit count — ledger + CRM OpenAPI specs **plus** `pkg/constant/transaction.go` and `pkg/mmodel/status.go`, because transaction-status enums are free strings in the OpenAPI and enforced in Go (the spec alone is blind to them). `exit 0/1/2`.
- `.github/workflows/midaz-drift.yml`: nightly run (00:00 BRT) for `main` and `develop`, publishes a report to the job summary, opens/updates an issue on drift, fails the job.

## How to test

```
bash scripts/check-midaz-drift.sh main      # exit 0, no drift
bash scripts/check-midaz-drift.sh develop   # exit 0, no drift
```

After merge, trigger the workflow manually (**Actions → midaz-drift → Run workflow**) to validate the cross-repo midaz checkout and issue creation — scheduled runs only fire from the default branch.

## Notes

- SDK doc-comments citing `github.com/LerianStudio/midaz/v3/pkg/constant` are **correct and intentionally untouched**: the server module is `v3`, the SDK is `v4` — independent major cycles.

https://claude.ai/code/session_01QnNKbiyKKQtry2ohwJ3oFR
