### PR TITLE
chore(ci): align changelog generation with shared OpenRouter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,8 @@ jobs:
     needs: post-release-steps
     if: github.ref_name == 'main'
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
+      contents: write # commit the generated CHANGELOG.md
+      pull-requests: write # open the changelog PR
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.27.5
     with:
       runner_type: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,30 +86,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ needs.publish-release.outputs.gpg_fingerprint }}
 
-  #Generate changelog using the lerian-studio/github-actions-gptchangelog custom module
+  # AI-powered changelog via the shared OpenRouter workflow (aligned with console-sdk).
+  # Uses the org OPENROUTER_API_KEY through `secrets: inherit`; model openai/gpt-4o.
+  # Only runs on stable releases from main (stable_releases_only).
   generate-changelog:
     name: 📝 Generate AI-powered Changelog
-    runs-on: ubuntu-22.04
     needs: post-release-steps
+    if: github.ref_name == 'main'
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      - name: Generate app installation token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          private-key: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
-
-      - uses: LerianStudio/github-actions-gptchangelog@6e52a6108b5436d10b947345c325b12bcb66c444 # main
-        with:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          LERIAN_CI_CD_USER_GPG_KEY: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
-          LERIAN_CI_CD_USER_GPG_KEY_PASSWORD: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}
-          LERIAN_CI_CD_USER_NAME: ${{ secrets.LERIAN_CI_CD_USER_NAME }}
-          LERIAN_CI_CD_USER_EMAIL: ${{ secrets.LERIAN_CI_CD_USER_EMAIL }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_APP_ID }}
-          LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY: ${{ secrets.LERIAN_STUDIO_MIDAZ_PUSH_BOT_PRIVATE_KEY }}
+      id-token: write
+    uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.27.5
+    with:
+      runner_type: ubuntu-latest
+      stable_releases_only: true
+    secrets: inherit


### PR DESCRIPTION
## Purpose
The release `generate-changelog` job has failed on **every v4 release** — it used the `github-actions-gptchangelog` action, which is hard-wired to OpenAI and dies on the missing `OPENAI_API_KEY` secret. The tag/release published anyway (other jobs), but the run always went red and no CHANGELOG was generated.

## Change
Swap that job for the org's shared reusable workflow `LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.27.5`, which calls **OpenRouter** using the org-level `OPENROUTER_API_KEY` (no `OPENAI_API_KEY` needed) via `secrets: inherit`.

Config mirrors **console-sdk** (closest SDK precedent):
- `runner_type: ubuntu-latest` (repo has no blacksmith runners)
- `stable_releases_only: true` + `if: github.ref_name == 'main'` (skips beta/develop)
- model `openai/gpt-4o` (reusable default, OpenRouter format)

## How to test
After merge, the next stable release (`v4.1.0`, via the develop→main PR #210) runs this job; it should generate the CHANGELOG green instead of failing on the missing OpenAI key. `workflow_dispatch` on the release also exercises it.

https://claude.ai/code/session_01QnNKbiyKKQtry2ohwJ3oFR