### PR TITLE
fix(ci): fail fast in midaz drift check instead of false "no drift"

### DIFF
--- a/scripts/check-midaz-drift.sh
+++ b/scripts/check-midaz-drift.sh
@@ -30,11 +30,17 @@ git -C "$midaz_repo" cat-file -e "${pinned}^{commit}" 2>/dev/null \
   || { echo "error: pinned commit $pinned not in local midaz (shallow clone?). Run: git -C '$midaz_repo' fetch --unshallow" >&2; exit 2; }
 
 head="$(git -C "$midaz_repo" rev-parse "origin/$branch")"
+git -C "$midaz_repo" merge-base --is-ancestor "$pinned" "$head" \
+  || { echo "error: pinned commit $pinned is not an ancestor of origin/$branch (history rewrite?); a diff would be misleading" >&2; exit 2; }
 ahead="$(git -C "$midaz_repo" rev-list --count "${pinned}..${head}")"
 echo "midaz origin/$branch is at ${head:0:9} (${ahead} commit(s) ahead of pin)"
 
-# git diff exits non-zero under set -e when there ARE changes; capture without tripping it.
-stat="$(git -C "$midaz_repo" diff --stat "${pinned}..${head}" -- "${specs[@]}" || true)"
+# git diff --stat exits 0 with or without changes; a non-zero exit is a real
+# error (bad rev, missing object) that must NOT be swallowed into a false "no drift".
+if ! stat="$(git -C "$midaz_repo" diff --stat "${pinned}..${head}" -- "${specs[@]}")"; then
+  echo "error: git diff failed while comparing tracked paths" >&2
+  exit 2
+fi
 if [[ -z "$stat" ]]; then
   echo "✅ no contract drift: tracked specs unchanged since pin"
   exit 0


### PR DESCRIPTION
## Purpose
CodeRabbit (Major, Functional Correctness) on #210 caught a false-negative path in `scripts/check-midaz-drift.sh`: `git diff ... || true` swallowed real failures into the green "no contract drift" branch. In a drift alerting tool that's the worst failure mode — it says "all clear" precisely when it couldn't compare.

## Fix
- Guard: `git merge-base --is-ancestor "$pinned" "$head"` — if the pin is no longer an ancestor of `origin/$branch` (history rewrite in midaz), exit `2` instead of producing a misleading diff.
- Replace `stat=$(git diff … || true)` with `if ! stat=$(git diff …); then exit 2` — a non-zero `git diff` (bad rev / missing object) is a real error, not "no drift". `git diff --stat` still exits 0 with or without changes, so genuine drift detection is unchanged.

Exit contract stays: `0` no drift, `1` drift, `2` environment/comparison error.

## How to test
```
bash scripts/check-midaz-drift.sh main      # exit 0
bash scripts/check-midaz-drift.sh develop   # exit 0
```

https://claude.ai/code/session_01QnNKbiyKKQtry2ohwJ3oFR