### PR TITLE
ci: migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/check-branch.yml
+++ b/.github/workflows/check-branch.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check-branch:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Check if PR is from develop or hotfix
         if: github.event.pull_request.head.ref != 'develop' && startsWith(github.event.pull_request.head.ref, 'hotfix/') == false

--- a/.github/workflows/go-combined-analysis.yml
+++ b/.github/workflows/go-combined-analysis.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   GolangCI-Lint:
     name: Run GolangCI-Lint to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6.0.2
@@ -43,7 +43,7 @@ jobs:
 
   GoSec:
     name: Run GoSec to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -57,7 +57,7 @@ jobs:
 
   GoSec-Audit:
     name: Run Scheduled GoSec Audit to SDK
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v6.0.2
@@ -72,7 +72,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -97,7 +97,7 @@ jobs:
 
   verify:
     name: Verify SDK
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -113,7 +113,7 @@ jobs:
 
   docs:
     name: Generate Docs
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/feature/')
     steps:
       - name: Checkout code

--- a/.github/workflows/midaz-drift.yml
+++ b/.github/workflows/midaz-drift.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   drift:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       issues: write # open/update the drift report issue

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   preflight:
     name: ✅ Release Preflight
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:
@@ -60,7 +60,7 @@ jobs:
   # Execute post steps after the release is published
   post-release-steps:
     name: 📦 Post Release Tasks
-    runs-on: ubuntu-22.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: publish-release
     permissions:
       id-token: write


### PR DESCRIPTION
The org is standardizing CI on Blacksmith runners, a drop-in replacement for GitHub-hosted runners that is roughly 2x faster at about half the per-minute price. This swaps every GitHub-hosted ubuntu label (`ubuntu-latest`, `ubuntu-24.04`, `ubuntu-22.04`) in `.github/workflows/` to the same `blacksmith-4vcpu-ubuntu-2404` label the rest of the org uses; no other workflow changes.

```yaml
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```