### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,6 @@ jobs:
       pull-requests: write # open the changelog PR
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.43.1
     with:
-      runner_type: ubuntu-latest
+      runner_type: blacksmith-4vcpu-ubuntu-2404
       stable_releases_only: true
     secrets: inherit


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration.

The `develop` branch already carries the Blacksmith migration for all workflows except one shared-workflow input in `release.yml`, so this PR (rebased onto `develop` and retargeted per the branch policy enforced by check-branch) contains only that remaining change:

```yaml
uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.27.5
with:
  runner_type: blacksmith-4vcpu-ubuntu-2404
```

Self-hosted labels are untouched, and no other workflow logic changed.