### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,6 @@ jobs:
       pull-requests: write # open the changelog PR
     uses: LerianStudio/github-actions-shared-workflows/.github/workflows/gptchangelog.yml@v1.43.1
     with:
-      runner_type: ubuntu-latest
+      runner_type: blacksmith-4vcpu-ubuntu-2404
       stable_releases_only: true
     secrets: inherit


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
