### PR TITLE
fix(ci): skip the release pipeline entirely on .github/docs/lint-config-only pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
       - '*.md'
       - '**/*.txt'
       - '*.txt'
+      - '.github/**'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.golangci.yml'
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
## Description

Follow-up to #237 (already merged). Adds `.github/**`, `docs/**`, `LICENSE*`, `.golangci.yml` to `release.yml`'s `paths-ignore`, matching `go-release.yml`'s `ignore_globs` default and this org's documented standardize-repo convention. Without this, a push touching only these paths still starts the release pipeline (it's just gated from actually cutting a release by commit type via semantic-release's conventionalcommits preset) — this avoids running the pipeline at all in that case.

## Type of Change

- [x] `ci`: CI pipeline or workflow changes

## Testing

- [ ] Confirm a push touching only `.github/**` no longer triggers `release.yml`