### PR TITLE
ci: bump checkout, setup-go and import-gpg to v7 and pin midaz-drift by sha

### DIFF
--- a/.github/workflows/midaz-drift.yml
+++ b/.github/workflows/midaz-drift.yml
@@ -29,13 +29,13 @@ jobs:
         branch: [main, develop]
     steps:
       - name: Checkout SDK (${{ matrix.branch }})
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ matrix.branch }}
           persist-credentials: false
 
       - name: Checkout midaz upstream (${{ matrix.branch }})
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: LerianStudio/midaz
           ref: ${{ matrix.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.pipeline.outputs.new_release_git_tag }}
           fetch-depth: 0
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY }}
           passphrase: ${{ secrets.LERIAN_CI_CD_USER_GPG_KEY_PASSWORD }}

--- a/.github/workflows/sdk-checks.yml
+++ b/.github/workflows/sdk-checks.yml
@@ -19,12 +19,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -43,11 +43,11 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false


### PR DESCRIPTION
## Purpose
Close the two CI follow-ups left from the dependency sweep (#242): upstream action pins one major behind, and midaz-drift.yml pinning by tag while sibling workflows pin by SHA.

## Changes
- actions/checkout v6.1.0 → v7.0.1 (release.yml, sdk-checks.yml, midaz-drift.yml)
- actions/setup-go v6.5.0 → v7.0.0 (sdk-checks.yml)
- crazy-max/ghaction-import-gpg v6.3.0 → v7.0.0 (release.yml)
- midaz-drift.yml now pins actions/checkout by SHA with a version comment, matching the sibling workflows
- actions/upload-artifact and goreleaser/goreleaser-action already at latest; untouched
- LerianStudio shared workflows stay tag-pinned per org convention

## Risk
- checkout v7 breaking change (safer pull_request_target defaults) was backported to v6.1.0, which we already run; no workflow here uses pull_request_target
- setup-go v7 and import-gpg v7 are ESM/node24 migrations with unchanged inputs
- release.yml and sdk-checks.yml paths do not run on PRs; first live proof is the next develop push (release) and the next scheduled run (sdk-checks, midaz-drift)

## How to test
actionlint + YAML parse clean (only the pre-existing Blacksmith runner-label false positive). Next scheduled midaz-drift run and next release run exercise the new pins.