### PR TITLE
build(deps): bump lib-observability to v3.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/LerianStudio/midaz-sdk-golang/v5
 go 1.26.3
 
 require (
-	github.com/LerianStudio/lib-observability/v3 v3.1.0
+	github.com/LerianStudio/lib-observability/v3 v3.2.0
 	github.com/brianvoe/gofakeit/v7 v7.16.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LerianStudio/lib-observability/v3 v3.1.0 h1:NP29WDBeCPkz0AxzWO+yULR7OaGQc0lIDt2HqYhmwqg=
-github.com/LerianStudio/lib-observability/v3 v3.1.0/go.mod h1:3wiIk6QdAIgH8/ecYcs/HnmalktLMP0QbQzfvGzOaGI=
+github.com/LerianStudio/lib-observability/v3 v3.2.0 h1:p4QXA6fv5tOkJ+As8UhN3fkyAKBWdVde814vc48Y900=
+github.com/LerianStudio/lib-observability/v3 v3.2.0/go.mod h1:3wiIk6QdAIgH8/ecYcs/HnmalktLMP0QbQzfvGzOaGI=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=


### PR DESCRIPTION
## Description

Unblocks the Lerian Library Version Check on the v5.0.0 promote (#244): develop pinned lib-observability/v3 v3.1.0, latest is v3.2.0. The v3.2.0 delta is per-tenant HTTP middleware metrics — server-side surface the SDK does not use; the one shared-file change (tracing/otel.go) is additive (NewTelemetryWithOptions) and NewTelemetry, which the SDK calls, is untouched. Diff: go.mod + go.sum, 3 lines.

Gates: build, vet, make test-fast, make verify-sdk (API compat, config parity, codegen drift, examples), lint 0 issues.

Requested by: @fredcamaral

🤖 Generated with [Claude Code](https://claude.com/claude-code)